### PR TITLE
feat: token pipeline with oklch colors and theme validation

### DIFF
--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -17,9 +17,13 @@
     "./dist/tailwind/*": "./dist/tailwind/*",
     "./dist/json/*": "./dist/json/*"
   },
-  "files": ["dist", "src", "themes"],
+  "files": [
+    "dist",
+    "src",
+    "themes"
+  ],
   "scripts": {
-    "build": "style-dictionary build --config sd.config.ts && tsc",
+    "build": "tsx sd.config.ts && tsc",
     "test": "vitest run",
     "test:unit": "vitest run",
     "lint": "eslint src/",
@@ -30,6 +34,7 @@
   },
   "devDependencies": {
     "style-dictionary": "^4",
+    "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^3"
   }

--- a/packages/tokens/sd.config.ts
+++ b/packages/tokens/sd.config.ts
@@ -1,0 +1,173 @@
+import StyleDictionary from "style-dictionary";
+import type { TransformedToken } from "style-dictionary/types";
+import { readdir } from "node:fs/promises";
+import { basename, extname } from "node:path";
+
+/**
+ * Flatten a token name into a CSS variable name.
+ * E.g. "color-background" → "--color-background"
+ */
+function tokenToCssVar(token: TransformedToken): string {
+	return `--${token.name}`;
+}
+
+// ---------------------------------------------------------------------------
+// Custom format: Tailwind v4 @theme inline block
+// Maps every token to a CSS variable reference so Tailwind generates utilities.
+// ---------------------------------------------------------------------------
+StyleDictionary.registerFormat({
+	name: "tailwind/theme-inline",
+	format: ({ dictionary }) => {
+		const lines = dictionary.allTokens.map(
+			(token) => `  ${tokenToCssVar(token)}: var(${tokenToCssVar(token)});`,
+		);
+		return `@theme inline {\n${lines.join("\n")}\n}\n`;
+	},
+});
+
+// ---------------------------------------------------------------------------
+// Custom format: TypeScript token map
+// Produces a typed Record<string, TokenDefinition> and the TokenDefinition type.
+// ---------------------------------------------------------------------------
+StyleDictionary.registerFormat({
+	name: "typescript/token-map",
+	format: ({ dictionary }) => {
+		const categoryMap: Record<string, string> = {
+			color: "color",
+			spacing: "spacing",
+			typography: "typography",
+			radius: "radii",
+			shadow: "shadows",
+			opacity: "opacity",
+		};
+
+		const entries = dictionary.allTokens.map((token) => {
+			const category =
+				categoryMap[token.path[0] ?? ""] ?? token.path[0] ?? "unknown";
+			return `  "${token.path.join(".")}": {
+    name: "${token.path.join(".")}",
+    category: "${category}" as const,
+    type: "${token.$type ?? token.type ?? "unknown"}",
+    cssVariable: "${tokenToCssVar(token)}",
+  }`;
+		});
+
+		return `export type TokenCategory = "color" | "spacing" | "typography" | "radii" | "shadows" | "opacity";
+
+export type TokenDefinition = {
+  name: string;
+  category: TokenCategory;
+  type: string;
+  cssVariable: string;
+};
+
+export const tokenMap: Record<string, TokenDefinition> = {
+${entries.join(",\n")},
+} as const;
+`;
+	},
+});
+
+// ---------------------------------------------------------------------------
+// Custom format: raw JSON token map
+// ---------------------------------------------------------------------------
+StyleDictionary.registerFormat({
+	name: "json/flat-map",
+	format: ({ dictionary }) => {
+		const result: Record<
+			string,
+			{ name: string; value: unknown; type: string; cssVariable: string }
+		> = {};
+		for (const token of dictionary.allTokens) {
+			result[token.path.join(".")] = {
+				name: token.path.join("."),
+				value: token.value,
+				type: (token.$type as string) ?? (token.type as string) ?? "unknown",
+				cssVariable: tokenToCssVar(token),
+			};
+		}
+		return JSON.stringify(result, null, 2) + "\n";
+	},
+});
+
+// ---------------------------------------------------------------------------
+// Build
+// ---------------------------------------------------------------------------
+async function build() {
+	// Discover theme files
+	const themeDir = "themes";
+	const themeFiles = await readdir(themeDir);
+	const themes = themeFiles
+		.filter((f) => extname(f) === ".json")
+		.map((f) => basename(f, ".json"));
+
+	// 1. Per-theme CSS builds
+	for (const theme of themes) {
+		const sd = new StyleDictionary({
+			source: ["src/tokens/**/*.json", `themes/${theme}.json`],
+			log: { warnings: "disabled" },
+			platforms: {
+				css: {
+					transformGroup: "css",
+					buildPath: "dist/css/",
+					files: [
+						{
+							destination: `tokens-${theme}.css`,
+							format: "css/variables",
+							options: {
+								selector: `[data-theme="${theme}"]`,
+								outputReferences: false,
+							},
+						},
+					],
+				},
+			},
+		});
+		await sd.buildAllPlatforms();
+	}
+
+	// 2. Shared assets from base tokens (Tailwind preset, TS types, JSON)
+	//    Use "css" transformGroup for all so token names stay kebab-case.
+	const sdBase = new StyleDictionary({
+		source: ["src/tokens/**/*.json"],
+		platforms: {
+			tailwind: {
+				transformGroup: "css",
+				buildPath: "dist/tailwind/",
+				files: [
+					{
+						destination: "preset.css",
+						format: "tailwind/theme-inline",
+					},
+				],
+			},
+			ts: {
+				transformGroup: "css",
+				buildPath: "dist/ts/",
+				files: [
+					{
+						destination: "tokens.ts",
+						format: "typescript/token-map",
+					},
+				],
+			},
+			json: {
+				transformGroup: "css",
+				buildPath: "dist/json/",
+				files: [
+					{
+						destination: "tokens.json",
+						format: "json/flat-map",
+					},
+				],
+			},
+		},
+	});
+	await sdBase.buildAllPlatforms();
+
+	console.log(
+		`✓ Built ${themes.length} theme CSS files + Tailwind preset + TypeScript types + JSON`,
+	);
+}
+
+build();

--- a/packages/tokens/src/color.ts
+++ b/packages/tokens/src/color.ts
@@ -1,0 +1,200 @@
+/**
+ * Color parsing and conversion utilities.
+ * Supports hex (#rgb, #rrggbb) and oklch(L C H) formats.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type RGB = [number, number, number]; // 0–255
+type LinearRGB = [number, number, number]; // 0–1 linear
+type OklabColor = [number, number, number]; // L, a, b
+type OklchColor = [number, number, number]; // L, C, H (H in degrees)
+
+// ---------------------------------------------------------------------------
+// Hex parsing
+// ---------------------------------------------------------------------------
+
+function hexToRgb(hex: string): RGB | null {
+	const clean = hex.replace(/^#/, "");
+	let r: number, g: number, b: number;
+
+	if (clean.length === 3) {
+		r = parseInt(clean[0]! + clean[0]!, 16);
+		g = parseInt(clean[1]! + clean[1]!, 16);
+		b = parseInt(clean[2]! + clean[2]!, 16);
+	} else if (clean.length === 6) {
+		r = parseInt(clean.slice(0, 2), 16);
+		g = parseInt(clean.slice(2, 4), 16);
+		b = parseInt(clean.slice(4, 6), 16);
+	} else {
+		return null;
+	}
+
+	if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+	return [r, g, b];
+}
+
+// ---------------------------------------------------------------------------
+// oklch parsing
+// ---------------------------------------------------------------------------
+
+const OKLCH_RE =
+	/^oklch\(\s*([\d.]+)(%?)\s+([\d.]+)\s+([\d.]+(?:deg)?)\s*(?:\/\s*[\d.]+%?\s*)?\)$/i;
+
+function parseOklch(str: string): OklchColor | null {
+	const m = OKLCH_RE.exec(str.trim());
+	if (!m) return null;
+
+	let L = parseFloat(m[1]!);
+	if (m[2] === "%") L /= 100;
+	const C = parseFloat(m[3]!);
+	const H = parseFloat(m[4]!);
+
+	if (Number.isNaN(L) || Number.isNaN(C) || Number.isNaN(H)) return null;
+	return [L, C, H];
+}
+
+// ---------------------------------------------------------------------------
+// Conversions: sRGB ↔ linear RGB ↔ OKLab ↔ OKLCh
+// ---------------------------------------------------------------------------
+
+function srgbToLinear(c: number): number {
+	const s = c / 255;
+	return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+function linearToSrgb(c: number): number {
+	const clamped = Math.max(0, Math.min(1, c));
+	return clamped <= 0.0031308
+		? Math.round(clamped * 12.92 * 255)
+		: Math.round((1.055 * Math.pow(clamped, 1 / 2.4) - 0.055) * 255);
+}
+
+function rgbToLinear(rgb: RGB): LinearRGB {
+	return [srgbToLinear(rgb[0]), srgbToLinear(rgb[1]), srgbToLinear(rgb[2])];
+}
+
+function linearRgbToOklab(rgb: LinearRGB): OklabColor {
+	const [r, g, b] = rgb;
+	const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+	const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+	const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+
+	return [
+		0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+		1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+		0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+	];
+}
+
+function oklabToLinearRgb(lab: OklabColor): LinearRGB {
+	const [L, a, b] = lab;
+	const l = L + 0.3963377774 * a + 0.2158037573 * b;
+	const m = L - 0.1055613458 * a - 0.0638541728 * b;
+	const s = L - 0.0894841775 * a - 1.291485548 * b;
+
+	const l3 = l * l * l;
+	const m3 = m * m * m;
+	const s3 = s * s * s;
+
+	return [
+		4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3,
+		-1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3,
+		-0.0041960863 * l3 - 0.7034186147 * m3 + 1.707614701 * s3,
+	];
+}
+
+function oklabToOklch(lab: OklabColor): OklchColor {
+	const [L, a, b] = lab;
+	const C = Math.sqrt(a * a + b * b);
+	let H = (Math.atan2(b, a) * 180) / Math.PI;
+	if (H < 0) H += 360;
+	return [L, C, H];
+}
+
+function oklchToOklab(lch: OklchColor): OklabColor {
+	const [L, C, H] = lch;
+	const hRad = (H * Math.PI) / 180;
+	return [L, C * Math.cos(hRad), C * Math.sin(hRad)];
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse any supported color string into linear RGB for luminance calculation.
+ * Returns null if the format is unrecognized.
+ */
+export function parseColor(value: string): LinearRGB | null {
+	// Try hex
+	const rgb = hexToRgb(value);
+	if (rgb) return rgbToLinear(rgb);
+
+	// Try oklch
+	const oklch = parseOklch(value);
+	if (oklch) {
+		const lab = oklchToOklab(oklch);
+		return oklabToLinearRgb(lab);
+	}
+
+	return null;
+}
+
+/**
+ * Compute WCAG 2.x relative luminance from linear RGB.
+ */
+export function relativeLuminance(rgb: LinearRGB): number {
+	return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
+}
+
+/**
+ * Compute WCAG 2.x contrast ratio between two colors.
+ */
+export function contrastRatio(a: LinearRGB, b: LinearRGB): number {
+	const la = relativeLuminance(a);
+	const lb = relativeLuminance(b);
+	const lighter = Math.max(la, lb);
+	const darker = Math.min(la, lb);
+	return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * Convert a hex color string to oklch() CSS function.
+ * Returns the original string if it's already oklch or unparseable.
+ */
+export function hexToOklch(value: string): string {
+	if (!value.startsWith("#")) return value;
+
+	const rgb = hexToRgb(value);
+	if (!rgb) return value;
+
+	const linear = rgbToLinear(rgb);
+	const lab = linearRgbToOklab(linear);
+	const [L, C, H] = oklabToOklch(lab);
+
+	// Round to reasonable precision
+	const lStr = L.toFixed(4);
+	const cStr = C.toFixed(4);
+	const hStr = H.toFixed(2);
+
+	return `oklch(${lStr} ${cStr} ${hStr})`;
+}
+
+/**
+ * Convert an oklch color to hex (for round-trip testing).
+ */
+export function oklchToHex(value: string): string | null {
+	const oklch = parseOklch(value);
+	if (!oklch) return null;
+
+	const lab = oklchToOklab(oklch);
+	const linear = oklabToLinearRgb(lab);
+	const r = linearToSrgb(linear[0]);
+	const g = linearToSrgb(linear[1]);
+	const b = linearToSrgb(linear[2]);
+
+	return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+}

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -1,0 +1,8 @@
+export { themeSchema, contrastPairs } from "./schema.js";
+export type { Theme, ContrastPair } from "./schema.js";
+
+export { validateTheme } from "./validate.js";
+export type { ValidationResult, ValidationIssue } from "./validate.js";
+
+export { tokenMap } from "./token-map.js";
+export type { TokenDefinition, TokenCategory } from "./token-map.js";

--- a/packages/tokens/src/runtime.ts
+++ b/packages/tokens/src/runtime.ts
@@ -1,0 +1,62 @@
+import { validateTheme } from "./validate.js";
+import type { Theme } from "./schema.js";
+import { hexToOklch } from "./color.js";
+
+export class ThemeValidationError extends Error {
+	constructor(
+		message: string,
+		public readonly issues: Array<{
+			path: string;
+			code: string;
+			message: string;
+		}>,
+	) {
+		super(message);
+		this.name = "ThemeValidationError";
+	}
+}
+
+/**
+ * Validates a theme and injects a `<style>` block scoped to
+ * `[data-theme="<name>"]` into the document head.
+ *
+ * Throws `ThemeValidationError` if the theme fails validation.
+ */
+export function registerTheme(themeJson: Theme): void {
+	const result = validateTheme(themeJson);
+
+	if (!result.ok) {
+		throw new ThemeValidationError(
+			`Theme "${(themeJson as { name?: string }).name ?? "unknown"}" failed validation`,
+			result.issues,
+		);
+	}
+
+	const { theme } = result;
+	const selector = `[data-theme="${theme.name}"]`;
+
+	const vars: string[] = [];
+	const tokens = theme.tokens as Record<string, Record<string, string>>;
+
+	for (const [category, group] of Object.entries(tokens)) {
+		for (const [key, value] of Object.entries(group)) {
+			// Normalize hex → oklch for color tokens; pass others through
+			const cssValue = category === "color" ? hexToOklch(value) : value;
+			vars.push(`  --${category}-${key}: ${cssValue};`);
+		}
+	}
+
+	const css = `${selector} {\n${vars.join("\n")}\n}`;
+
+	// Remove any existing style block for this theme
+	const existingId = `ds-theme-${theme.name}`;
+	const existing = document.getElementById(existingId);
+	if (existing) {
+		existing.remove();
+	}
+
+	const style = document.createElement("style");
+	style.id = existingId;
+	style.textContent = css;
+	document.head.appendChild(style);
+}

--- a/packages/tokens/src/schema.ts
+++ b/packages/tokens/src/schema.ts
@@ -1,0 +1,127 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Token schema — mirrors the 6 token categories from the DTCG source files.
+// Every theme must provide a value for every token defined here.
+// ---------------------------------------------------------------------------
+
+const colorTokens = z.object({
+	background: z.string(),
+	foreground: z.string(),
+	primary: z.string(),
+	"primary-foreground": z.string(),
+	muted: z.string(),
+	"muted-foreground": z.string(),
+	border: z.string(),
+	ring: z.string(),
+	destructive: z.string(),
+	"destructive-foreground": z.string(),
+});
+
+const spacingTokens = z.object({
+	px: z.string(),
+	"1": z.string(),
+	"2": z.string(),
+	"3": z.string(),
+	"4": z.string(),
+	"5": z.string(),
+	"6": z.string(),
+	"7": z.string(),
+	"8": z.string(),
+	"9": z.string(),
+	"10": z.string(),
+	"11": z.string(),
+	"12": z.string(),
+	"13": z.string(),
+	"14": z.string(),
+	"15": z.string(),
+	"16": z.string(),
+});
+
+const typographyTokens = z.object({
+	"font-sans": z.string(),
+	"font-mono": z.string(),
+	"size-sm": z.string(),
+	"size-base": z.string(),
+	"size-lg": z.string(),
+	"size-xl": z.string(),
+	"weight-normal": z.string(),
+	"weight-medium": z.string(),
+	"weight-semibold": z.string(),
+	"weight-bold": z.string(),
+	"leading-normal": z.string(),
+	"leading-tight": z.string(),
+	"leading-relaxed": z.string(),
+});
+
+const radiiTokens = z.object({
+	sm: z.string(),
+	md: z.string(),
+	lg: z.string(),
+	full: z.string(),
+});
+
+const shadowTokens = z.object({
+	sm: z.string(),
+	md: z.string(),
+	lg: z.string(),
+});
+
+const opacityTokens = z.object({
+	disabled: z.string(),
+	hover: z.string(),
+});
+
+// ---------------------------------------------------------------------------
+// Theme schema — the user-facing format consumed by validateTheme / registerTheme.
+// ---------------------------------------------------------------------------
+
+export const themeSchema = z
+	.object({
+		name: z.string().min(1),
+		displayName: z.string().min(1),
+		tokens: z.object({
+			color: colorTokens,
+			spacing: spacingTokens,
+			typography: typographyTokens,
+			radius: radiiTokens,
+			shadow: shadowTokens,
+			opacity: opacityTokens,
+		}),
+	})
+	.passthrough();
+
+export type Theme = z.infer<typeof themeSchema>;
+
+// ---------------------------------------------------------------------------
+// Contrast pairs — declared foreground/background pairs for WCAG AA checking.
+// ---------------------------------------------------------------------------
+
+export type ContrastPair = {
+	foreground: string;
+	background: string;
+	threshold: number;
+};
+
+export const contrastPairs: ContrastPair[] = [
+	{
+		foreground: "color.foreground",
+		background: "color.background",
+		threshold: 4.5,
+	},
+	{
+		foreground: "color.primary-foreground",
+		background: "color.primary",
+		threshold: 4.5,
+	},
+	{
+		foreground: "color.muted-foreground",
+		background: "color.muted",
+		threshold: 4.5,
+	},
+	{
+		foreground: "color.destructive-foreground",
+		background: "color.destructive",
+		threshold: 4.5,
+	},
+];

--- a/packages/tokens/src/token-map.ts
+++ b/packages/tokens/src/token-map.ts
@@ -1,0 +1,81 @@
+export type TokenCategory =
+	| "color"
+	| "spacing"
+	| "typography"
+	| "radii"
+	| "shadows"
+	| "opacity";
+
+export type TokenDefinition = {
+	name: string;
+	category: TokenCategory;
+	type: string;
+	cssVariable: string;
+};
+
+/**
+ * Typed map of all tokens in the schema.
+ * Keys are dot-paths (e.g. "color.primary"), values describe the token.
+ */
+export const tokenMap: Record<string, TokenDefinition> = {
+	// Color tokens
+	"color.background": { name: "color.background", category: "color", type: "color", cssVariable: "--color-background" },
+	"color.foreground": { name: "color.foreground", category: "color", type: "color", cssVariable: "--color-foreground" },
+	"color.primary": { name: "color.primary", category: "color", type: "color", cssVariable: "--color-primary" },
+	"color.primary-foreground": { name: "color.primary-foreground", category: "color", type: "color", cssVariable: "--color-primary-foreground" },
+	"color.muted": { name: "color.muted", category: "color", type: "color", cssVariable: "--color-muted" },
+	"color.muted-foreground": { name: "color.muted-foreground", category: "color", type: "color", cssVariable: "--color-muted-foreground" },
+	"color.border": { name: "color.border", category: "color", type: "color", cssVariable: "--color-border" },
+	"color.ring": { name: "color.ring", category: "color", type: "color", cssVariable: "--color-ring" },
+	"color.destructive": { name: "color.destructive", category: "color", type: "color", cssVariable: "--color-destructive" },
+	"color.destructive-foreground": { name: "color.destructive-foreground", category: "color", type: "color", cssVariable: "--color-destructive-foreground" },
+
+	// Spacing tokens
+	"spacing.px": { name: "spacing.px", category: "spacing", type: "dimension", cssVariable: "--spacing-px" },
+	"spacing.1": { name: "spacing.1", category: "spacing", type: "dimension", cssVariable: "--spacing-1" },
+	"spacing.2": { name: "spacing.2", category: "spacing", type: "dimension", cssVariable: "--spacing-2" },
+	"spacing.3": { name: "spacing.3", category: "spacing", type: "dimension", cssVariable: "--spacing-3" },
+	"spacing.4": { name: "spacing.4", category: "spacing", type: "dimension", cssVariable: "--spacing-4" },
+	"spacing.5": { name: "spacing.5", category: "spacing", type: "dimension", cssVariable: "--spacing-5" },
+	"spacing.6": { name: "spacing.6", category: "spacing", type: "dimension", cssVariable: "--spacing-6" },
+	"spacing.7": { name: "spacing.7", category: "spacing", type: "dimension", cssVariable: "--spacing-7" },
+	"spacing.8": { name: "spacing.8", category: "spacing", type: "dimension", cssVariable: "--spacing-8" },
+	"spacing.9": { name: "spacing.9", category: "spacing", type: "dimension", cssVariable: "--spacing-9" },
+	"spacing.10": { name: "spacing.10", category: "spacing", type: "dimension", cssVariable: "--spacing-10" },
+	"spacing.11": { name: "spacing.11", category: "spacing", type: "dimension", cssVariable: "--spacing-11" },
+	"spacing.12": { name: "spacing.12", category: "spacing", type: "dimension", cssVariable: "--spacing-12" },
+	"spacing.13": { name: "spacing.13", category: "spacing", type: "dimension", cssVariable: "--spacing-13" },
+	"spacing.14": { name: "spacing.14", category: "spacing", type: "dimension", cssVariable: "--spacing-14" },
+	"spacing.15": { name: "spacing.15", category: "spacing", type: "dimension", cssVariable: "--spacing-15" },
+	"spacing.16": { name: "spacing.16", category: "spacing", type: "dimension", cssVariable: "--spacing-16" },
+
+	// Typography tokens
+	"typography.font-sans": { name: "typography.font-sans", category: "typography", type: "fontFamily", cssVariable: "--typography-font-sans" },
+	"typography.font-mono": { name: "typography.font-mono", category: "typography", type: "fontFamily", cssVariable: "--typography-font-mono" },
+	"typography.size-sm": { name: "typography.size-sm", category: "typography", type: "dimension", cssVariable: "--typography-size-sm" },
+	"typography.size-base": { name: "typography.size-base", category: "typography", type: "dimension", cssVariable: "--typography-size-base" },
+	"typography.size-lg": { name: "typography.size-lg", category: "typography", type: "dimension", cssVariable: "--typography-size-lg" },
+	"typography.size-xl": { name: "typography.size-xl", category: "typography", type: "dimension", cssVariable: "--typography-size-xl" },
+	"typography.weight-normal": { name: "typography.weight-normal", category: "typography", type: "fontWeight", cssVariable: "--typography-weight-normal" },
+	"typography.weight-medium": { name: "typography.weight-medium", category: "typography", type: "fontWeight", cssVariable: "--typography-weight-medium" },
+	"typography.weight-semibold": { name: "typography.weight-semibold", category: "typography", type: "fontWeight", cssVariable: "--typography-weight-semibold" },
+	"typography.weight-bold": { name: "typography.weight-bold", category: "typography", type: "fontWeight", cssVariable: "--typography-weight-bold" },
+	"typography.leading-normal": { name: "typography.leading-normal", category: "typography", type: "number", cssVariable: "--typography-leading-normal" },
+	"typography.leading-tight": { name: "typography.leading-tight", category: "typography", type: "number", cssVariable: "--typography-leading-tight" },
+	"typography.leading-relaxed": { name: "typography.leading-relaxed", category: "typography", type: "number", cssVariable: "--typography-leading-relaxed" },
+
+	// Radii tokens
+	"radius.sm": { name: "radius.sm", category: "radii", type: "dimension", cssVariable: "--radius-sm" },
+	"radius.md": { name: "radius.md", category: "radii", type: "dimension", cssVariable: "--radius-md" },
+	"radius.lg": { name: "radius.lg", category: "radii", type: "dimension", cssVariable: "--radius-lg" },
+	"radius.full": { name: "radius.full", category: "radii", type: "dimension", cssVariable: "--radius-full" },
+
+	// Shadow tokens
+	"shadow.sm": { name: "shadow.sm", category: "shadows", type: "shadow", cssVariable: "--shadow-sm" },
+	"shadow.md": { name: "shadow.md", category: "shadows", type: "shadow", cssVariable: "--shadow-md" },
+	"shadow.lg": { name: "shadow.lg", category: "shadows", type: "shadow", cssVariable: "--shadow-lg" },
+
+	// Opacity tokens
+	"opacity.disabled": { name: "opacity.disabled", category: "opacity", type: "number", cssVariable: "--opacity-disabled" },
+	"opacity.hover": { name: "opacity.hover", category: "opacity", type: "number", cssVariable: "--opacity-hover" },
+} as const;

--- a/packages/tokens/src/tokens/color.json
+++ b/packages/tokens/src/tokens/color.json
@@ -1,0 +1,44 @@
+{
+  "color": {
+    "background": {
+      "$value": "oklch(1.0000 0.0000 89.88)",
+      "$type": "color"
+    },
+    "foreground": {
+      "$value": "oklch(0.1408 0.0044 285.82)",
+      "$type": "color"
+    },
+    "primary": {
+      "$value": "oklch(0.2103 0.0059 285.89)",
+      "$type": "color"
+    },
+    "primary-foreground": {
+      "$value": "oklch(0.9851 0.0000 89.88)",
+      "$type": "color"
+    },
+    "muted": {
+      "$value": "oklch(0.9674 0.0013 286.38)",
+      "$type": "color"
+    },
+    "muted-foreground": {
+      "$value": "oklch(0.5517 0.0138 285.94)",
+      "$type": "color"
+    },
+    "border": {
+      "$value": "oklch(0.9197 0.0040 286.32)",
+      "$type": "color"
+    },
+    "ring": {
+      "$value": "oklch(0.2103 0.0059 285.89)",
+      "$type": "color"
+    },
+    "destructive": {
+      "$value": "oklch(0.6368 0.2078 25.33)",
+      "$type": "color"
+    },
+    "destructive-foreground": {
+      "$value": "oklch(0.9851 0.0000 89.88)",
+      "$type": "color"
+    }
+  }
+}

--- a/packages/tokens/src/tokens/opacity.json
+++ b/packages/tokens/src/tokens/opacity.json
@@ -1,0 +1,12 @@
+{
+  "opacity": {
+    "disabled": {
+      "$value": "0.5",
+      "$type": "number"
+    },
+    "hover": {
+      "$value": "0.8",
+      "$type": "number"
+    }
+  }
+}

--- a/packages/tokens/src/tokens/radii.json
+++ b/packages/tokens/src/tokens/radii.json
@@ -1,0 +1,20 @@
+{
+  "radius": {
+    "sm": {
+      "$value": "0.25rem",
+      "$type": "dimension"
+    },
+    "md": {
+      "$value": "0.375rem",
+      "$type": "dimension"
+    },
+    "lg": {
+      "$value": "0.5rem",
+      "$type": "dimension"
+    },
+    "full": {
+      "$value": "9999px",
+      "$type": "dimension"
+    }
+  }
+}

--- a/packages/tokens/src/tokens/shadows.json
+++ b/packages/tokens/src/tokens/shadows.json
@@ -1,0 +1,16 @@
+{
+  "shadow": {
+    "sm": {
+      "$value": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+      "$type": "shadow"
+    },
+    "md": {
+      "$value": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+      "$type": "shadow"
+    },
+    "lg": {
+      "$value": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",
+      "$type": "shadow"
+    }
+  }
+}

--- a/packages/tokens/src/tokens/spacing.json
+++ b/packages/tokens/src/tokens/spacing.json
@@ -1,0 +1,72 @@
+{
+  "spacing": {
+    "px": {
+      "$value": "1px",
+      "$type": "dimension"
+    },
+    "1": {
+      "$value": "0.25rem",
+      "$type": "dimension"
+    },
+    "2": {
+      "$value": "0.5rem",
+      "$type": "dimension"
+    },
+    "3": {
+      "$value": "0.75rem",
+      "$type": "dimension"
+    },
+    "4": {
+      "$value": "1rem",
+      "$type": "dimension"
+    },
+    "5": {
+      "$value": "1.25rem",
+      "$type": "dimension"
+    },
+    "6": {
+      "$value": "1.5rem",
+      "$type": "dimension"
+    },
+    "7": {
+      "$value": "1.75rem",
+      "$type": "dimension"
+    },
+    "8": {
+      "$value": "2rem",
+      "$type": "dimension"
+    },
+    "9": {
+      "$value": "2.25rem",
+      "$type": "dimension"
+    },
+    "10": {
+      "$value": "2.5rem",
+      "$type": "dimension"
+    },
+    "11": {
+      "$value": "2.75rem",
+      "$type": "dimension"
+    },
+    "12": {
+      "$value": "3rem",
+      "$type": "dimension"
+    },
+    "13": {
+      "$value": "3.25rem",
+      "$type": "dimension"
+    },
+    "14": {
+      "$value": "3.5rem",
+      "$type": "dimension"
+    },
+    "15": {
+      "$value": "3.75rem",
+      "$type": "dimension"
+    },
+    "16": {
+      "$value": "4rem",
+      "$type": "dimension"
+    }
+  }
+}

--- a/packages/tokens/src/tokens/typography.json
+++ b/packages/tokens/src/tokens/typography.json
@@ -1,0 +1,56 @@
+{
+  "typography": {
+    "font-sans": {
+      "$value": "ui-sans-serif, system-ui, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\"",
+      "$type": "fontFamily"
+    },
+    "font-mono": {
+      "$value": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace",
+      "$type": "fontFamily"
+    },
+    "size-sm": {
+      "$value": "0.875rem",
+      "$type": "dimension"
+    },
+    "size-base": {
+      "$value": "1rem",
+      "$type": "dimension"
+    },
+    "size-lg": {
+      "$value": "1.125rem",
+      "$type": "dimension"
+    },
+    "size-xl": {
+      "$value": "1.25rem",
+      "$type": "dimension"
+    },
+    "weight-normal": {
+      "$value": "400",
+      "$type": "fontWeight"
+    },
+    "weight-medium": {
+      "$value": "500",
+      "$type": "fontWeight"
+    },
+    "weight-semibold": {
+      "$value": "600",
+      "$type": "fontWeight"
+    },
+    "weight-bold": {
+      "$value": "700",
+      "$type": "fontWeight"
+    },
+    "leading-normal": {
+      "$value": "1.5",
+      "$type": "number"
+    },
+    "leading-tight": {
+      "$value": "1.25",
+      "$type": "number"
+    },
+    "leading-relaxed": {
+      "$value": "1.625",
+      "$type": "number"
+    }
+  }
+}

--- a/packages/tokens/src/validate.ts
+++ b/packages/tokens/src/validate.ts
@@ -1,0 +1,106 @@
+import { type ZodIssue } from "zod";
+import { themeSchema, contrastPairs, type Theme } from "./schema.js";
+import { parseColor, contrastRatio } from "./color.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type ValidationIssue = {
+	path: string;
+	code:
+		| "MISSING_TOKEN"
+		| "INVALID_TYPE"
+		| "UNKNOWN_TOKEN"
+		| "CONTRAST_FAILURE";
+	message: string;
+	expected?: string;
+	actual?: string;
+	ratio?: number;
+	threshold?: number;
+};
+
+export type ValidationResult =
+	| { ok: true; theme: Theme }
+	| { ok: false; issues: ValidationIssue[] };
+
+// ---------------------------------------------------------------------------
+// Resolve a dot-path like "color.primary" to the token value in the theme
+// ---------------------------------------------------------------------------
+
+function resolveTokenValue(theme: Theme, dotPath: string): string | undefined {
+	const [category, ...rest] = dotPath.split(".");
+	const key = rest.join(".");
+	const group = (theme.tokens as Record<string, Record<string, string>>)[
+		category ?? ""
+	];
+	return group?.[key];
+}
+
+// ---------------------------------------------------------------------------
+// validateTheme
+// ---------------------------------------------------------------------------
+
+export function validateTheme(themeJson: unknown): ValidationResult {
+	// 1. Schema validation via Zod
+	const result = themeSchema.safeParse(themeJson);
+
+	if (!result.success) {
+		const issues: ValidationIssue[] = result.error.issues.map(
+			(issue: ZodIssue) => {
+				const path = issue.path.join(".");
+				if (issue.code === "invalid_type" && issue.received === "undefined") {
+					return {
+						path,
+						code: "MISSING_TOKEN" as const,
+						message: `Missing required token: ${path}`,
+						expected: issue.expected,
+					};
+				}
+				return {
+					path,
+					code: "INVALID_TYPE" as const,
+					message: issue.message,
+					expected:
+						"expected" in issue ? String(issue.expected) : undefined,
+					actual: "received" in issue ? String(issue.received) : undefined,
+				};
+			},
+		);
+		return { ok: false, issues };
+	}
+
+	const theme = result.data;
+
+	// 2. Contrast checking for all declared pairs (supports hex and oklch)
+	const contrastIssues: ValidationIssue[] = [];
+
+	for (const pair of contrastPairs) {
+		const fgValue = resolveTokenValue(theme, pair.foreground);
+		const bgValue = resolveTokenValue(theme, pair.background);
+
+		if (!fgValue || !bgValue) continue;
+
+		const fgLinear = parseColor(fgValue);
+		const bgLinear = parseColor(bgValue);
+
+		if (!fgLinear || !bgLinear) continue;
+
+		const ratio = contrastRatio(fgLinear, bgLinear);
+		if (ratio < pair.threshold) {
+			contrastIssues.push({
+				path: `${pair.foreground} / ${pair.background}`,
+				code: "CONTRAST_FAILURE",
+				message: `Contrast ratio ${ratio.toFixed(2)}:1 is below the required ${pair.threshold}:1 threshold`,
+				ratio: Math.round(ratio * 100) / 100,
+				threshold: pair.threshold,
+			});
+		}
+	}
+
+	if (contrastIssues.length > 0) {
+		return { ok: false, issues: contrastIssues };
+	}
+
+	return { ok: true, theme };
+}

--- a/packages/tokens/themes/brand.json
+++ b/packages/tokens/themes/brand.json
@@ -1,0 +1,44 @@
+{
+  "color": {
+    "background": {
+      "$value": "oklch(0.9768 0.0142 308.30)",
+      "$type": "color"
+    },
+    "foreground": {
+      "$value": "oklch(0.2352 0.0362 290.58)",
+      "$type": "color"
+    },
+    "primary": {
+      "$value": "oklch(0.5413 0.2466 293.01)",
+      "$type": "color"
+    },
+    "primary-foreground": {
+      "$value": "oklch(1.0000 0.0000 89.88)",
+      "$type": "color"
+    },
+    "muted": {
+      "$value": "oklch(0.9464 0.0327 307.17)",
+      "$type": "color"
+    },
+    "muted-foreground": {
+      "$value": "oklch(0.5115 0.0914 295.69)",
+      "$type": "color"
+    },
+    "border": {
+      "$value": "oklch(0.8943 0.0549 293.28)",
+      "$type": "color"
+    },
+    "ring": {
+      "$value": "oklch(0.5413 0.2466 293.01)",
+      "$type": "color"
+    },
+    "destructive": {
+      "$value": "oklch(0.5858 0.2220 17.58)",
+      "$type": "color"
+    },
+    "destructive-foreground": {
+      "$value": "oklch(1.0000 0.0000 89.88)",
+      "$type": "color"
+    }
+  }
+}

--- a/packages/tokens/themes/dark.json
+++ b/packages/tokens/themes/dark.json
@@ -1,0 +1,44 @@
+{
+  "color": {
+    "background": {
+      "$value": "oklch(0.1408 0.0044 285.82)",
+      "$type": "color"
+    },
+    "foreground": {
+      "$value": "oklch(0.9851 0.0000 89.88)",
+      "$type": "color"
+    },
+    "primary": {
+      "$value": "oklch(0.9851 0.0000 89.88)",
+      "$type": "color"
+    },
+    "primary-foreground": {
+      "$value": "oklch(0.2103 0.0059 285.89)",
+      "$type": "color"
+    },
+    "muted": {
+      "$value": "oklch(0.2739 0.0055 286.03)",
+      "$type": "color"
+    },
+    "muted-foreground": {
+      "$value": "oklch(0.7118 0.0129 286.07)",
+      "$type": "color"
+    },
+    "border": {
+      "$value": "oklch(0.2739 0.0055 286.03)",
+      "$type": "color"
+    },
+    "ring": {
+      "$value": "oklch(0.8711 0.0055 286.29)",
+      "$type": "color"
+    },
+    "destructive": {
+      "$value": "oklch(0.5771 0.2152 27.33)",
+      "$type": "color"
+    },
+    "destructive-foreground": {
+      "$value": "oklch(0.9851 0.0000 89.88)",
+      "$type": "color"
+    }
+  }
+}

--- a/packages/tokens/themes/light.json
+++ b/packages/tokens/themes/light.json
@@ -1,0 +1,44 @@
+{
+  "color": {
+    "background": {
+      "$value": "oklch(1.0000 0.0000 89.88)",
+      "$type": "color"
+    },
+    "foreground": {
+      "$value": "oklch(0.1408 0.0044 285.82)",
+      "$type": "color"
+    },
+    "primary": {
+      "$value": "oklch(0.2103 0.0059 285.89)",
+      "$type": "color"
+    },
+    "primary-foreground": {
+      "$value": "oklch(0.9851 0.0000 89.88)",
+      "$type": "color"
+    },
+    "muted": {
+      "$value": "oklch(0.9674 0.0013 286.38)",
+      "$type": "color"
+    },
+    "muted-foreground": {
+      "$value": "oklch(0.5517 0.0138 285.94)",
+      "$type": "color"
+    },
+    "border": {
+      "$value": "oklch(0.9197 0.0040 286.32)",
+      "$type": "color"
+    },
+    "ring": {
+      "$value": "oklch(0.2103 0.0059 285.89)",
+      "$type": "color"
+    },
+    "destructive": {
+      "$value": "oklch(0.6368 0.2078 25.33)",
+      "$type": "color"
+    },
+    "destructive-foreground": {
+      "$value": "oklch(0.9851 0.0000 89.88)",
+      "$type": "color"
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^8.1.1
-        version: 8.1.1(@typescript-eslint/rule-tester@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.58.1(typescript@5.9.3))(@typescript-eslint/utils@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.32)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3))
+        version: 8.1.1(@typescript-eslint/rule-tester@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.58.1(typescript@5.9.3))(@typescript-eslint/utils@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.32)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.6.1)
@@ -44,16 +44,16 @@ importers:
         version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@storybook/addon-mcp':
         specifier: ^0.5.0
-        version: 0.5.0(@storybook/addon-vitest@10.3.5(@vitest/runner@3.2.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3)))(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+        version: 0.5.0(@storybook/addon-vitest@10.3.5(@vitest/runner@3.2.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
       '@storybook/addon-vitest':
         specifier: ^10.3
-        version: 10.3.5(@vitest/runner@3.2.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3))
+        version: 10.3.5(@vitest/runner@3.2.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/react-vite':
         specifier: ^10.3
-        version: 10.3.5(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+        version: 10.3.5(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.2.2(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+        version: 4.2.2(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       react:
         specifier: ^19
         version: 19.2.5
@@ -71,10 +71,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6
-        version: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+        version: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^3
-        version: 3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/react:
     dependencies:
@@ -114,13 +114,13 @@ importers:
         version: 4.2.2
       tsup:
         specifier: ^8
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5
         version: 5.9.3
       vitest:
         specifier: ^3
-        version: 3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/tokens:
     dependencies:
@@ -131,12 +131,15 @@ importers:
       style-dictionary:
         specifier: ^4
         version: 4.4.0(tslib@2.8.1)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5
         version: 5.9.3
       vitest:
         specifier: ^3
-        version: 3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -3751,6 +3754,11 @@ packages:
       typescript:
         optional: true
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo@2.9.6:
     resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
     hasBin: true
@@ -4042,7 +4050,7 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@antfu/eslint-config@8.1.1(@typescript-eslint/rule-tester@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.58.1(typescript@5.9.3))(@typescript-eslint/utils@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.32)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+  '@antfu/eslint-config@8.1.1(@typescript-eslint/rule-tester@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.58.1(typescript@5.9.3))(@typescript-eslint/utils@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.32)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 1.2.0
@@ -4052,7 +4060,7 @@ snapshots:
       '@stylistic/eslint-plugin': 5.10.0(eslint@9.39.4(jiti@2.6.1))
       '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@vitest/eslint-plugin': 1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@vitest/eslint-plugin': 1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       ansis: 4.2.0
       cac: 7.0.0
       eslint: 9.39.4(jiti@2.6.1)
@@ -4593,11 +4601,11 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -4847,7 +4855,7 @@ snapshots:
       axe-core: 4.11.2
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  '@storybook/addon-mcp@0.5.0(@storybook/addon-vitest@10.3.5(@vitest/runner@3.2.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3)))(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)':
+  '@storybook/addon-mcp@0.5.0(@storybook/addon-vitest@10.3.5(@vitest/runner@3.2.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)':
     dependencies:
       '@storybook/mcp': 0.6.2(typescript@5.9.3)
       '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.3(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
@@ -4857,42 +4865,42 @@ snapshots:
       tmcp: 1.19.3(typescript@5.9.3)
       valibot: 1.2.0(typescript@5.9.3)
     optionalDependencies:
-      '@storybook/addon-vitest': 10.3.5(@vitest/runner@3.2.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@storybook/addon-vitest': 10.3.5(@vitest/runner@3.2.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@tmcp/auth'
       - typescript
 
-  '@storybook/addon-vitest@10.3.5(@vitest/runner@3.2.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+  '@storybook/addon-vitest@10.3.5(@vitest/runner@3.2.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     optionalDependencies:
       '@vitest/runner': 3.2.4
-      vitest: 3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vitest: 3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+  '@storybook/builder-vite@10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ts-dedent: 2.2.0
-      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+  '@storybook/csf-plugin@10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.7
       rollup: 4.60.1
-      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@storybook/global@5.0.0': {}
 
@@ -4917,11 +4925,11 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  '@storybook/react-vite@10.3.5(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+  '@storybook/react-vite@10.3.5(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      '@storybook/builder-vite': 10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@storybook/builder-vite': 10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/react': 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -4931,7 +4939,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tsconfig-paths: 4.2.0
-      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -5024,12 +5032,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.2(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -5262,7 +5270,7 @@ snapshots:
     dependencies:
       valibot: 1.2.0(typescript@5.9.3)
 
-  '@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+  '@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -5270,7 +5278,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vitest: 3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -5282,13 +5290,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -7379,12 +7387,13 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.9)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
       postcss: 8.5.9
+      tsx: 4.21.0
       yaml: 2.8.3
 
   postcss-selector-parser@7.1.1:
@@ -7922,7 +7931,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.9)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -7933,7 +7942,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.9)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
@@ -7949,6 +7958,13 @@ snapshots:
       - supports-color
       - tsx
       - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
 
   turbo@2.9.6:
     optionalDependencies:
@@ -8079,13 +8095,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  vite-node@3.2.4(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
+  vite-node@3.2.4(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8100,7 +8116,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
+  vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -8112,13 +8128,14 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
+      tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -8136,8 +8153,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
-      vite-node: 3.2.4(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13

--- a/specs/001-token-design-system/tasks.md
+++ b/specs/001-token-design-system/tasks.md
@@ -50,23 +50,23 @@ This is a pnpm monorepo:
 
 **CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T014 [P] Author color tokens in W3C DTCG format in `packages/tokens/src/tokens/color.json` — background, foreground, primary, primary-foreground, muted, muted-foreground, border, ring, destructive, destructive-foreground (light theme values as `$value`)
-- [ ] T015 [P] Author spacing tokens in `packages/tokens/src/tokens/spacing.json` — spacing scale (1–16, px)
-- [ ] T016 [P] Author typography tokens in `packages/tokens/src/tokens/typography.json` — font-sans, font-mono, size-sm/base/lg/xl, weight-normal/medium/semibold/bold, leading-normal/tight/relaxed
-- [ ] T017 [P] Author radii tokens in `packages/tokens/src/tokens/radii.json` — sm, md, lg, full
-- [ ] T018 [P] Author shadow tokens in `packages/tokens/src/tokens/shadows.json` — sm, md, lg
-- [ ] T019 [P] Author opacity tokens in `packages/tokens/src/tokens/opacity.json` — disabled, hover
-- [ ] T020 Configure Style Dictionary v4 in `packages/tokens/sd.config.ts` — define 4 output platforms: CSS variables (scoped under `[data-theme]`), Tailwind v4 preset (CSS `@theme inline` block), TypeScript types, raw JSON
-- [ ] T021 [P] Author light theme in `packages/tokens/themes/light.json` with all required token values
-- [ ] T022 [P] Author dark theme in `packages/tokens/themes/dark.json` with all required token values
-- [ ] T023 [P] Author brand theme in `packages/tokens/themes/brand.json` with all required token values (visually distinct from light/dark)
-- [ ] T024 Implement Zod schema for theme validation in `packages/tokens/src/schema.ts` — schema mirrors token structure, enforces all tokens present with correct types
-- [ ] T025 Implement contrast pair declarations in `packages/tokens/src/schema.ts` — define foreground/background pairs (foreground↔background, primary-foreground↔primary, muted-foreground↔muted, destructive-foreground↔destructive) with WCAG AA thresholds
-- [ ] T026 Implement `validateTheme()` in `packages/tokens/src/validate.ts` — schema conformance via Zod + WCAG AA contrast checking for all declared pairs, returns `{ ok, theme }` or `{ ok, issues }`
-- [ ] T027 Implement `registerTheme()` in `packages/tokens/src/runtime.ts` — validates theme, injects `<style>` block scoped to `[data-theme="<name>"]`
-- [ ] T028 Create barrel export in `packages/tokens/src/index.ts` — export `validateTheme`, `themeSchema`, `tokenMap`, `registerTheme`, `contrastPairs`
-- [ ] T029 Run Style Dictionary build and verify 4 artifacts output to `packages/tokens/dist/` — CSS vars (3 theme files), Tailwind preset CSS, TypeScript types, raw JSON
-- [ ] T030 Verify Tailwind preset (`packages/tokens/dist/tailwind/preset.css`) contains `@theme inline` entries for all 6 token namespaces (`--color-*`, `--spacing-*`, `--font-*`, `--radius-*`, `--shadow-*`, `--opacity-*`)
+- [x] T014 [P] Author color tokens in W3C DTCG format in `packages/tokens/src/tokens/color.json` — background, foreground, primary, primary-foreground, muted, muted-foreground, border, ring, destructive, destructive-foreground (light theme values as `$value`)
+- [x] T015 [P] Author spacing tokens in `packages/tokens/src/tokens/spacing.json` — spacing scale (1–16, px)
+- [x] T016 [P] Author typography tokens in `packages/tokens/src/tokens/typography.json` — font-sans, font-mono, size-sm/base/lg/xl, weight-normal/medium/semibold/bold, leading-normal/tight/relaxed
+- [x] T017 [P] Author radii tokens in `packages/tokens/src/tokens/radii.json` — sm, md, lg, full
+- [x] T018 [P] Author shadow tokens in `packages/tokens/src/tokens/shadows.json` — sm, md, lg
+- [x] T019 [P] Author opacity tokens in `packages/tokens/src/tokens/opacity.json` — disabled, hover
+- [x] T020 Configure Style Dictionary v4 in `packages/tokens/sd.config.ts` — define 4 output platforms: CSS variables (scoped under `[data-theme]`), Tailwind v4 preset (CSS `@theme inline` block), TypeScript types, raw JSON
+- [x] T021 [P] Author light theme in `packages/tokens/themes/light.json` with all required token values
+- [x] T022 [P] Author dark theme in `packages/tokens/themes/dark.json` with all required token values
+- [x] T023 [P] Author brand theme in `packages/tokens/themes/brand.json` with all required token values (visually distinct from light/dark)
+- [x] T024 Implement Zod schema for theme validation in `packages/tokens/src/schema.ts` — schema mirrors token structure, enforces all tokens present with correct types
+- [x] T025 Implement contrast pair declarations in `packages/tokens/src/schema.ts` — define foreground/background pairs (foreground↔background, primary-foreground↔primary, muted-foreground↔muted, destructive-foreground↔destructive) with WCAG AA thresholds
+- [x] T026 Implement `validateTheme()` in `packages/tokens/src/validate.ts` — schema conformance via Zod + WCAG AA contrast checking for all declared pairs, returns `{ ok, theme }` or `{ ok, issues }`
+- [x] T027 Implement `registerTheme()` in `packages/tokens/src/runtime.ts` — validates theme, injects `<style>` block scoped to `[data-theme="<name>"]`
+- [x] T028 Create barrel export in `packages/tokens/src/index.ts` — export `validateTheme`, `themeSchema`, `tokenMap`, `registerTheme`, `contrastPairs`
+- [x] T029 Run Style Dictionary build and verify 4 artifacts output to `packages/tokens/dist/` — CSS vars (3 theme files), Tailwind preset CSS, TypeScript types, raw JSON
+- [x] T030 Verify Tailwind preset (`packages/tokens/dist/tailwind/preset.css`) contains `@theme inline` entries for all 6 token namespaces (`--color-*`, `--spacing-*`, `--font-*`, `--radius-*`, `--shadow-*`, `--opacity-*`)
 
 **Checkpoint**: `pnpm --filter @unbranded-ds/tokens build` succeeds. Four artifacts in `dist/`. `validateTheme()` accepts the 3 built-in themes and rejects a deliberately broken fixture.
 


### PR DESCRIPTION
## Summary

- build foundational token pipeline (Phase 2, T014–T030) that components will depend on
- 6 DTCG token source files (color, spacing, typography, radii, shadows, opacity) w/ oklch color vals
- style dictionary v4 compiles to: per-theme CSS vars, tw 4 `@theme inline` preset, TS token map, raw JSON
- 3 built-in themes (light, dark, brand) scoped under `[data-theme]`
- zod schema enforces theme completeness; `validateTheme()` checks WCAG AA contrast for fg/bg pairs
- `registerTheme()` injects runtime CSS, auto-converting hex → oklch
- theme authors can write colors in hex or oklch; both are accepted

Closes #14, #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30

## Test plan

- [ ] `pnpm --filter @unbranded-ds/tokens build` produces all 4 artifacts in `dist/`
- [ ] CSS files use `[data-theme="<name>"]` selectors with oklch values
- [ ] tw preset contains `@theme inline` entries for all 6 token namespaces
- [ ] `tsc --noEmit` passes with zero errors
- [ ] `validateTheme()` accepts built-in themes and rejects broken fixtures (Phase 5 will add formal test fixtures)