### PR TITLE
feat(react): add Tooltip, SkipLink, Slider, SegmentedControl

### DIFF
--- a/.changeset/add-segmentedcontrol.md
+++ b/.changeset/add-segmentedcontrol.md
@@ -1,0 +1,7 @@
+---
+'@unbranded-ds/react': minor
+---
+
+Add `<SegmentedControl>` — a mutually-exclusive selection control built on Base UI's RadioGroup primitives, styled as a connected pill. Keyboard navigation follows the WAI-ARIA radiogroup pattern: horizontal orientation uses Left and Right arrows, vertical uses Up and Down, with cross-axis keys ignored.
+
+The wrapper exposes `Root` and `Item` slots that match Base UI's slot names exactly. CVA variants cover `size` (`sm`, `md`, `lg`), `orientation`, and `disabled`. Controlled (`value` + `onValueChange`) and uncontrolled (`defaultValue`) usage both work. Rendering with zero children emits a structured warning under the `[unbranded-ds]` console namespace; rendering with one or two items is fine.

--- a/.changeset/add-skiplink.md
+++ b/.changeset/add-skiplink.md
@@ -1,0 +1,7 @@
+---
+'@unbranded-ds/react': minor
+---
+
+Add `<SkipLink>` — a keyboard-accessibility staple. Renders a visually-hidden anchor that reveals on focus and jumps to a target element. Default `targetId` is `'main'`. Multiple instances supported.
+
+Drop a `<SkipLink />` as the first focusable element in your layout, then add `id="main"` to the matching content region. On first Tab the link reveals at the top-left of the viewport; pressing Enter triggers native browser anchor behavior to scroll and focus the target. For multi-landmark layouts, render several `<SkipLink>` instances with distinct `targetId`s — for example one each pointing at `main`, `nav`, and `footer` — and the consumer chooses how to stack them visually.

--- a/.changeset/add-slider.md
+++ b/.changeset/add-slider.md
@@ -1,0 +1,5 @@
+---
+'@unbranded-ds/react': minor
+---
+
+Add `<Slider>` — a draggable numeric input wrapping Base UI's Slider primitives. Supports single-value (`[50]`) and range (`[20, 80]`) from day one. Pointer drag, keyboard, and touch all resolve to the same `onValueChange` pathway, with `aria-valuenow` exposed on every thumb. Invalid props (value out of range, `step <= 0`, `min >= max`) clamp to safe defaults and emit a structured `console.warn('[unbranded-ds]', { component: 'Slider', issue, ... })` instead of throwing, so a misconfigured slider never breaks the page that hosts it.

--- a/.changeset/add-tooltip.md
+++ b/.changeset/add-tooltip.md
@@ -1,0 +1,7 @@
+---
+'@unbranded-ds/react': minor
+---
+
+Add `<Tooltip>` — a token-styled, ARIA-compliant tooltip wrapping Base UI's Tooltip primitives. Exposes `Tooltip.Provider`, `Tooltip.Trigger`, and `Tooltip.Content` with sensible defaults: 700ms hover delay, `side="top"`, `align="center"`, and a Portal that mounts to `document.body` so content escapes ancestors with `overflow: hidden`.
+
+Wrap any element with `<Tooltip.Trigger asChild>` to preserve the original DOM shape, which is what the citation pattern (`<sup><a>[1]</a></sup>`) requires. The open and close transitions go instant when the user has `prefers-reduced-motion: reduce` set, via Tailwind's `motion-reduce:` variant, so the component stays compliant with WCAG SC 2.3.3 without consumer work.

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,29 +1,34 @@
 <!--
 SYNC IMPACT REPORT
 ==================
-Version change:  1.0.0 → 1.0.1  [PATCH — clarification to existing tooling and compliance machinery]
-Bump rationale:  Adopts `@changesets/cli` as the canonical versioning + changelog tool
-                 (Section VIII tool-list addition) and extends Section X Compliance Review
-                 with a per-PR changeset-presence rule. Both changes refine existing
-                 machinery rather than introducing new principles, so PATCH is the correct
-                 level per Section X's versioning policy.
+Version change:  1.0.1 → 1.0.2  [PATCH — codifies an existing implicit constraint]
+Bump rationale:  Adds SSR safety to Section IX Definition of Done as an explicit
+                 mergeable-blocking gate. The constraint is already true of the
+                 existing component set (the nine 0.2.0 components are SSR-safe);
+                 this amendment makes it explicit and binding for future components.
+                 Surfaced during spec 004 (primitive set expansion) clarification —
+                 no new principle, refines an existing section, so PATCH per
+                 Section X policy.
 
 Modified principles:
-  - Section VIII (Tooling baseline): added `@changesets/cli` to the locked tool list.
-  - Section X (Governance) Compliance Review: extended with a one-sentence rule requiring
-    a `.changeset/*.md` file on every PR touching packages/react/ or packages/tokens/.
+  - Section IX (Definition of done for any component): added a new bullet (#6)
+    requiring components to render server-side without accessing `window`,
+    `document`, or other browser-only globals at render time. Subsequent bullets
+    renumbered.
 
-Added sections:       N/A (both edits extend existing sections).
+Added sections:       N/A.
 Removed sections:     N/A.
 
 Templates audited:
-  ✅ .specify/templates/plan-template.md   — Constitution Check gate references Section X
-                                             compliance review; no template change needed
-                                             since the extension is within the same gate.
+  ✅ .specify/templates/plan-template.md   — Constitution Check gate already covers
+                                             Section IX wholesale; no template change
+                                             required.
   ✅ .specify/templates/spec-template.md   — No change required.
   ✅ .specify/templates/tasks-template.md  — No change required.
 
 Prior amendments:
+  - 1.0.1 (2026-05-16): Adopted `@changesets/cli` in Section VIII and extended
+    Section X Compliance Review with the per-PR changeset-presence rule. Per spec 003.
   - 1.0.0 (2026-04-10): Initial ratification from template. Section X renamed from
     "Amendment" → "Governance" and expanded with versioning policy and compliance review.
 
@@ -162,9 +167,10 @@ A component PR is mergeable only when all of the following are true:
 3. Stories cover Default plus all meaningful variants and states.
 4. At least one `play` function exists and passes.
 5. Axe reports zero `serious` or `critical` violations across all stories for the component.
-6. Autodocs render with descriptions for every prop.
-7. The component is exported from `packages/react/src/index.ts`.
-8. CI is green end to end, including the post-publish MCP smoke test.
+6. The component renders server-side without accessing `window`, `document`, or other browser-only globals at render time. Browser-API access is deferred to `useEffect` or equivalent post-mount hooks. This preserves SSR compatibility for Next.js, Remix, and other server-rendering consumers.
+7. Autodocs render with descriptions for every prop.
+8. The component is exported from `packages/react/src/index.ts`.
+9. CI is green end to end, including the post-publish MCP smoke test.
 
 ---
 
@@ -196,4 +202,4 @@ trigger a constitution amendment before merge.
 
 ---
 
-**Version**: 1.0.1 | **Ratified**: TODO(RATIFICATION_DATE): set to original adoption date | **Last Amended**: 2026-05-16
+**Version**: 1.0.2 | **Ratified**: TODO(RATIFICATION_DATE): set to original adoption date | **Last Amended**: 2026-05-16

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,9 @@
 Auto-generated from all feature plans. Last updated: 2026-05-16
 
 ## Active Technologies
+- TypeScript 5.x, strict mode, no `any` (Constitution Section VIII) (004-primitive-set-expansion)
+- N/A (component library; no persisted data) (004-primitive-set-expansion)
+
 - TypeScript 5.x (existing); no language additions (003-versioning-workflow)
 - filesystem only. `.changeset/*.md` files under `.changeset/`; `package.json` `version` field per package; `CHANGELOG.md` per package. No database, no external state. (003-versioning-workflow)
 
@@ -27,11 +30,12 @@ npm test && npm run lint
 TypeScript 5.x, strict mode, no `any` (EVER): Follow standard conventions
 
 ## Recent Changes
+- 004-primitive-set-expansion: Added TypeScript 5.x, strict mode, no `any` (Constitution Section VIII)
+
 - 003-versioning-workflow: Added TypeScript 5.x (existing); no language additions
 
 - 002-consumer-dx-preset: Added TypeScript 5.x, strict mode, no `any` (per constitution Section VIII)
 
-- 001-token-design-system: Added TypeScript 5.x, strict mode, no `any` (EVER) + pnpm (workspaces), Turborepo, Style Dictionary v4 (DTCG), Tailwind CSS v4 (`@theme` directive), `@base-ui-components/react`, shadcn/ui (Base UI variant, `base-vega` style), `class-variance-authority`, `clsx` + `tailwind-merge`, `tsup` (ESM only), Storybook 10.3 (`@storybook/react-vite`), `@storybook/addon-mcp`, `@storybook/addon-vitest`, `@storybook/addon-a11y`, Chromatic
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/packages/react/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/react/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,0 +1,338 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { SegmentedControl } from './SegmentedControl';
+
+const meta = {
+	title: 'Components/SegmentedControl',
+	component: SegmentedControl.Root,
+	tags: ['autodocs'],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'A mutually-exclusive selection control rendered as a connected pill. Built on Base UI\'s RadioGroup, so assistive technology announces it as a radiogroup with one radio per option. Keyboard navigation follows the WAI-ARIA radiogroup pattern: a horizontal control responds to Left and Right arrows, a vertical control responds to Up and Down, and cross-axis keys are no-ops. Home and End jump to the first and last items in both orientations.',
+			},
+		},
+	},
+	argTypes: {
+		value: {
+			control: 'text',
+			description:
+				'The controlled selected value. When set, the consumer owns selection state and must update `value` from `onValueChange` for the selection to change. Pair with `onValueChange`.',
+		},
+		defaultValue: {
+			control: 'text',
+			description:
+				'The initial selected value for uncontrolled usage. Pass either `defaultValue` or `value`, not both.',
+		},
+		onValueChange: {
+			action: 'value-changed',
+			description:
+				'Fires with the newly selected string when the user picks an item via click or keyboard. The callback receives only the new value.',
+		},
+		size: {
+			control: 'inline-radio',
+			options: ['sm', 'md', 'lg'],
+			description:
+				'CVA size axis. Controls item height, horizontal padding, and font size. Defaults to `md`.',
+			table: { defaultValue: { summary: 'md' } },
+		},
+		orientation: {
+			control: 'inline-radio',
+			options: ['horizontal', 'vertical'],
+			description:
+				'CVA orientation axis. Horizontal lays items in a row; vertical lays them in a column. Determines which arrow keys move focus and selection — Left and Right for horizontal, Up and Down for vertical. Defaults to `horizontal`.',
+			table: { defaultValue: { summary: 'horizontal' } },
+		},
+		disabled: {
+			control: 'boolean',
+			description:
+				'When true, the entire control is non-interactive. The Root sets `aria-disabled="true"` and pointer events are suppressed. Defaults to `false`.',
+			table: { defaultValue: { summary: 'false' } },
+		},
+		className: {
+			control: 'text',
+			description:
+				'Extra Tailwind utilities merged onto the Root via `cn()`. Override layout details without redeclaring the CVA baseline.',
+		},
+		children: {
+			control: false,
+			description:
+				'One or more `<SegmentedControl.Item>` children. Each Item carries its own `value` and visible label.',
+		},
+	},
+} satisfies Meta<typeof SegmentedControl.Root>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		defaultValue: 'medium',
+		children: (
+			<>
+				<SegmentedControl.Item value="small">Small</SegmentedControl.Item>
+				<SegmentedControl.Item value="medium">Medium</SegmentedControl.Item>
+				<SegmentedControl.Item value="large">Large</SegmentedControl.Item>
+			</>
+		),
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Three options with the middle one selected by default. Click any item to change the selection; the previously selected item deselects automatically.',
+			},
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const radios = canvas.getAllByRole('radio');
+
+		// Middle item starts checked because `defaultValue="medium"`.
+		expect(radios[1]?.getAttribute('aria-checked')).toBe('true');
+
+		await userEvent.click(radios[0]!);
+		expect(radios[0]?.getAttribute('aria-checked')).toBe('true');
+		expect(radios[1]?.getAttribute('aria-checked')).toBe('false');
+
+		await userEvent.click(radios[2]!);
+		expect(radios[2]?.getAttribute('aria-checked')).toBe('true');
+		expect(radios[0]?.getAttribute('aria-checked')).toBe('false');
+	},
+};
+
+export const Sizes: Story = {
+	args: {
+		defaultValue: 'b',
+		children: (
+			<SegmentedControl.Item value="b">Placeholder</SegmentedControl.Item>
+		),
+	},
+	render: () => (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+			<SegmentedControl.Root defaultValue="b" size="sm">
+				<SegmentedControl.Item value="a">Small A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">Small B</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">Small C</SegmentedControl.Item>
+			</SegmentedControl.Root>
+
+			<SegmentedControl.Root defaultValue="b" size="md">
+				<SegmentedControl.Item value="a">Medium A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">Medium B</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">Medium C</SegmentedControl.Item>
+			</SegmentedControl.Root>
+
+			<SegmentedControl.Root defaultValue="b" size="lg">
+				<SegmentedControl.Item value="a">Large A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">Large B</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">Large C</SegmentedControl.Item>
+			</SegmentedControl.Root>
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Three size variants stacked vertically: `sm`, `md`, and `lg`. The size axis controls item height, horizontal padding, and label font size.',
+			},
+		},
+	},
+};
+
+export const Orientations: Story = {
+	args: {
+		defaultValue: 'b',
+		children: (
+			<SegmentedControl.Item value="b">Placeholder</SegmentedControl.Item>
+		),
+	},
+	render: () => (
+		<div style={{ display: 'flex', gap: '1.5rem', alignItems: 'flex-start' }}>
+			<SegmentedControl.Root defaultValue="b" orientation="horizontal">
+				<SegmentedControl.Item value="a">Day</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">Week</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">Month</SegmentedControl.Item>
+			</SegmentedControl.Root>
+
+			<SegmentedControl.Root defaultValue="b" orientation="vertical">
+				<SegmentedControl.Item value="a">Day</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">Week</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">Month</SegmentedControl.Item>
+			</SegmentedControl.Root>
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Horizontal (Left/Right arrow navigation) and vertical (Up/Down arrow navigation) layouts side by side. Cross-axis arrow keys are intentional no-ops in both orientations.',
+			},
+		},
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		defaultValue: 'b',
+		disabled: true,
+		children: (
+			<>
+				<SegmentedControl.Item value="a">First</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">Second</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">Third</SegmentedControl.Item>
+			</>
+		),
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'A disabled control still renders the current selection so the consumer can read the value, but interaction is suppressed. The Root carries `aria-disabled="true"`.',
+			},
+		},
+	},
+};
+
+export const TwoItems: Story = {
+	args: {
+		defaultValue: 'on',
+		children: (
+			<>
+				<SegmentedControl.Item value="off">Off</SegmentedControl.Item>
+				<SegmentedControl.Item value="on">On</SegmentedControl.Item>
+			</>
+		),
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'A two-item segmented control. The "three or more" recommendation is advisory; two items render normally and emit no warning. Use this when a binary visual is more familiar than a Switch.',
+			},
+		},
+	},
+};
+
+// Wrapper for the Controlled story: keeps the useState call inside a real
+// component so React's rules-of-hooks linter is satisfied. Storybook calls
+// the wrapper as JSX, not as a bare render function.
+function ControlledExample() {
+	const [value, setValue] = useState<string>('medium');
+	return (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+			<SegmentedControl.Root value={value} onValueChange={setValue}>
+				<SegmentedControl.Item value="small">Small</SegmentedControl.Item>
+				<SegmentedControl.Item value="medium">Medium</SegmentedControl.Item>
+				<SegmentedControl.Item value="large">Large</SegmentedControl.Item>
+			</SegmentedControl.Root>
+			<span style={{ fontSize: '0.875rem' }}>
+				Current value:
+				{' '}
+				<code>{value}</code>
+			</span>
+		</div>
+	);
+}
+
+export const Controlled: Story = {
+	args: {
+		defaultValue: 'medium',
+		children: (
+			<SegmentedControl.Item value="medium">Placeholder</SegmentedControl.Item>
+		),
+	},
+	render: () => <ControlledExample />,
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Controlled usage: a parent component owns the selection via `useState` and passes `value` plus `onValueChange` to the Root. The current state renders alongside the control so the wiring is visible.',
+			},
+		},
+	},
+};
+
+export const HorizontalKeyboard: Story = {
+	args: {
+		defaultValue: 'a',
+		orientation: 'horizontal',
+		children: (
+			<>
+				<SegmentedControl.Item value="a">Alpha</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">Beta</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">Gamma</SegmentedControl.Item>
+			</>
+		),
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Horizontal control with a play function that verifies Right Arrow moves both focus and selection to the next item, and that Down Arrow is a no-op.',
+			},
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const radios = canvas.getAllByRole('radio');
+
+		// Focus the first item so subsequent keyboard events have a target.
+		radios[0]!.focus();
+		expect(radios[0]).toHaveFocus();
+		expect(radios[0]?.getAttribute('aria-checked')).toBe('true');
+
+		// Right Arrow moves focus and selection to the next item.
+		await userEvent.keyboard('{ArrowRight}');
+		expect(radios[1]).toHaveFocus();
+		expect(radios[1]?.getAttribute('aria-checked')).toBe('true');
+
+		// Down Arrow is a no-op on a horizontal control.
+		await userEvent.keyboard('{ArrowDown}');
+		expect(radios[1]).toHaveFocus();
+		expect(radios[1]?.getAttribute('aria-checked')).toBe('true');
+	},
+};
+
+export const VerticalKeyboard: Story = {
+	args: {
+		defaultValue: 'a',
+		orientation: 'vertical',
+		children: (
+			<>
+				<SegmentedControl.Item value="a">One</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">Two</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">Three</SegmentedControl.Item>
+			</>
+		),
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Vertical control with a play function that verifies Down Arrow moves both focus and selection to the next item, and that Right Arrow is a no-op.',
+			},
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const radios = canvas.getAllByRole('radio');
+
+		radios[0]!.focus();
+		expect(radios[0]).toHaveFocus();
+		expect(radios[0]?.getAttribute('aria-checked')).toBe('true');
+
+		// Down Arrow moves focus and selection on a vertical control.
+		await userEvent.keyboard('{ArrowDown}');
+		expect(radios[1]).toHaveFocus();
+		expect(radios[1]?.getAttribute('aria-checked')).toBe('true');
+
+		// Right Arrow is a no-op on a vertical control.
+		await userEvent.keyboard('{ArrowRight}');
+		expect(radios[1]).toHaveFocus();
+		expect(radios[1]?.getAttribute('aria-checked')).toBe('true');
+	},
+};

--- a/packages/react/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/react/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,0 +1,399 @@
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	SegmentedControl,
+	segmentedControlItemVariants,
+	segmentedControlRootVariants,
+} from './SegmentedControl';
+
+describe('segmentedControl', () => {
+	afterEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+	});
+
+	it('renders Root and Item with the expected data-slot attributes', () => {
+		const { container } = render(
+			<SegmentedControl.Root defaultValue="b">
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">C</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		expect(
+			container.querySelector('[data-slot=\'segmented-control-root\']'),
+		).toBeInTheDocument();
+		expect(
+			container.querySelectorAll('[data-slot=\'segmented-control-item\']'),
+		).toHaveLength(3);
+	});
+
+	it('applies role="radiogroup" on Root and role="radio" on each Item', () => {
+		const { getByRole, getAllByRole } = render(
+			<SegmentedControl.Root defaultValue="a">
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		expect(getByRole('radiogroup')).toBeInTheDocument();
+		expect(getAllByRole('radio')).toHaveLength(2);
+	});
+
+	it('merges a consumer className with the CVA baseline via cn() on Root', () => {
+		const { container } = render(
+			<SegmentedControl.Root defaultValue="a" className="my-custom-root">
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		const root = container.querySelector<HTMLElement>(
+			'[data-slot=\'segmented-control-root\']',
+		);
+		expect(root?.className).toContain('my-custom-root');
+		// CVA baseline classes survive the merge — sample one stable utility
+		// from the Root's `cva` first argument.
+		expect(root?.className).toContain('inline-flex');
+	});
+
+	it('merges a consumer className with the CVA baseline via cn() on Item', () => {
+		const { container } = render(
+			<SegmentedControl.Root defaultValue="a">
+				<SegmentedControl.Item value="a" className="my-custom-item">
+					A
+				</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		const item = container.querySelector<HTMLElement>(
+			'[data-slot=\'segmented-control-item\']',
+		);
+		expect(item?.className).toContain('my-custom-item');
+		expect(item?.className).toContain('inline-flex');
+	});
+
+	it('resolves the size axis through the segmentedControlRootVariants helper', () => {
+		// sm -> h-7 on items, md -> h-8, lg -> h-10. Verify the exposed helper
+		// keeps producing distinct class strings so the variant axis can't
+		// silently collapse during refactor.
+		const sm = segmentedControlItemVariants({
+			size: 'sm',
+			orientation: 'horizontal',
+		});
+		const md = segmentedControlItemVariants({
+			size: 'md',
+			orientation: 'horizontal',
+		});
+		const lg = segmentedControlItemVariants({
+			size: 'lg',
+			orientation: 'horizontal',
+		});
+
+		expect(sm).toContain('h-7');
+		expect(md).toContain('h-8');
+		expect(lg).toContain('h-10');
+		expect(sm).not.toBe(md);
+		expect(md).not.toBe(lg);
+	});
+
+	it('resolves the orientation axis through the segmentedControlRootVariants helper', () => {
+		const horizontal = segmentedControlRootVariants({
+			size: 'md',
+			orientation: 'horizontal',
+			disabled: false,
+		});
+		const vertical = segmentedControlRootVariants({
+			size: 'md',
+			orientation: 'vertical',
+			disabled: false,
+		});
+
+		expect(horizontal).toContain('flex-row');
+		expect(vertical).toContain('flex-col');
+	});
+
+	it('resolves the disabled axis through the segmentedControlRootVariants helper', () => {
+		const off = segmentedControlRootVariants({
+			size: 'md',
+			orientation: 'horizontal',
+			disabled: false,
+		});
+		const on = segmentedControlRootVariants({
+			size: 'md',
+			orientation: 'horizontal',
+			disabled: true,
+		});
+
+		expect(on).toContain('pointer-events-none');
+		expect(off).not.toContain('pointer-events-none');
+	});
+
+	it('propagates Root size and orientation to each Item via context', () => {
+		const { container } = render(
+			<SegmentedControl.Root defaultValue="a" size="lg" orientation="vertical">
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		const items = container.querySelectorAll<HTMLElement>(
+			'[data-slot=\'segmented-control-item\']',
+		);
+		for (const item of items) {
+			expect(item.className).toContain('h-10');
+			expect(item.className).toContain('w-full');
+		}
+	});
+
+	it('marks exactly one Item as checked in an uncontrolled tree', () => {
+		const { getAllByRole } = render(
+			<SegmentedControl.Root defaultValue="b">
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">C</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		const radios = getAllByRole('radio');
+		const checked = radios.filter(
+			(r) => r.getAttribute('aria-checked') === 'true',
+		);
+		expect(checked).toHaveLength(1);
+		expect(checked[0]).toHaveTextContent('B');
+	});
+
+	it('switches selection on click and deselects the previously selected Item', () => {
+		const { getAllByRole, getByText } = render(
+			<SegmentedControl.Root defaultValue="a">
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		fireEvent.click(getByText('B'));
+
+		const radios = getAllByRole('radio');
+		const checked = radios.filter(
+			(r) => r.getAttribute('aria-checked') === 'true',
+		);
+		expect(checked).toHaveLength(1);
+		expect(checked[0]).toHaveTextContent('B');
+	});
+
+	it('honors a controlled value: ignores internal click changes when value is fixed', () => {
+		// With `value` set and no `onValueChange`, the consumer is the source
+		// of truth. The wrapper must not flip aria-checked locally.
+		const { getAllByRole, getByText, rerender } = render(
+			<SegmentedControl.Root value="a">
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		fireEvent.click(getByText('B'));
+
+		let checked = getAllByRole('radio').filter(
+			(r) => r.getAttribute('aria-checked') === 'true',
+		);
+		expect(checked[0]).toHaveTextContent('A');
+
+		// Now mimic an external update flipping the controlled value.
+		rerender(
+			<SegmentedControl.Root value="b">
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+		checked = getAllByRole('radio').filter(
+			(r) => r.getAttribute('aria-checked') === 'true',
+		);
+		expect(checked[0]).toHaveTextContent('B');
+	});
+
+	it('calls onValueChange with the new string value on selection', () => {
+		const onValueChange = vi.fn();
+		const { getByText } = render(
+			<SegmentedControl.Root defaultValue="a" onValueChange={onValueChange}>
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		fireEvent.click(getByText('B'));
+		expect(onValueChange).toHaveBeenCalledWith('b');
+	});
+
+	it('reflects aria-disabled on the Root when disabled', () => {
+		const { getByRole } = render(
+			<SegmentedControl.Root defaultValue="a" disabled>
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		expect(getByRole('radiogroup').getAttribute('aria-disabled')).toBe('true');
+	});
+
+	it('swallows cross-axis arrow keys: ArrowDown on a horizontal control does nothing', () => {
+		const onValueChange = vi.fn();
+		const { getAllByRole } = render(
+			<SegmentedControl.Root
+				defaultValue="b"
+				orientation="horizontal"
+				onValueChange={onValueChange}
+			>
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">C</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		const radios = getAllByRole('radio');
+		const middle = radios[1]!;
+		middle.focus();
+
+		fireEvent.keyDown(middle, { key: 'ArrowDown' });
+		fireEvent.keyDown(middle, { key: 'ArrowUp' });
+
+		expect(onValueChange).not.toHaveBeenCalled();
+		const stillChecked = radios.filter(
+			(r) => r.getAttribute('aria-checked') === 'true',
+		);
+		expect(stillChecked[0]).toHaveTextContent('B');
+	});
+
+	it('swallows cross-axis arrow keys: ArrowRight on a vertical control does nothing', () => {
+		const onValueChange = vi.fn();
+		const { getAllByRole } = render(
+			<SegmentedControl.Root
+				defaultValue="b"
+				orientation="vertical"
+				onValueChange={onValueChange}
+			>
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">C</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		const radios = getAllByRole('radio');
+		const middle = radios[1]!;
+		middle.focus();
+
+		fireEvent.keyDown(middle, { key: 'ArrowLeft' });
+		fireEvent.keyDown(middle, { key: 'ArrowRight' });
+
+		expect(onValueChange).not.toHaveBeenCalled();
+		const stillChecked = radios.filter(
+			(r) => r.getAttribute('aria-checked') === 'true',
+		);
+		expect(stillChecked[0]).toHaveTextContent('B');
+	});
+
+	it('jumps focus and selection to the first item on Home in a horizontal control', () => {
+		const onValueChange = vi.fn();
+		const { getAllByRole } = render(
+			<SegmentedControl.Root
+				defaultValue="b"
+				orientation="horizontal"
+				onValueChange={onValueChange}
+			>
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">C</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		const radios = getAllByRole('radio');
+		const middle = radios[1]!;
+		middle.focus();
+
+		fireEvent.keyDown(middle, { key: 'Home' });
+
+		expect(onValueChange).toHaveBeenCalledWith('a');
+		expect(document.activeElement).toBe(radios[0]);
+	});
+
+	it('jumps focus and selection to the last item on End in a horizontal control', () => {
+		const onValueChange = vi.fn();
+		const { getAllByRole } = render(
+			<SegmentedControl.Root
+				defaultValue="b"
+				orientation="horizontal"
+				onValueChange={onValueChange}
+			>
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">C</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		const radios = getAllByRole('radio');
+		const middle = radios[1]!;
+		middle.focus();
+
+		fireEvent.keyDown(middle, { key: 'End' });
+
+		expect(onValueChange).toHaveBeenCalledWith('c');
+		expect(document.activeElement).toBe(radios[2]);
+	});
+
+	it('supports Home and End in a vertical control', () => {
+		const onValueChange = vi.fn();
+		const { getAllByRole } = render(
+			<SegmentedControl.Root
+				defaultValue="b"
+				orientation="vertical"
+				onValueChange={onValueChange}
+			>
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+				<SegmentedControl.Item value="c">C</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		const radios = getAllByRole('radio');
+		const middle = radios[1]!;
+		middle.focus();
+
+		fireEvent.keyDown(middle, { key: 'End' });
+		expect(onValueChange).toHaveBeenLastCalledWith('c');
+		expect(document.activeElement).toBe(radios[2]);
+
+		fireEvent.keyDown(radios[2]!, { key: 'Home' });
+		expect(onValueChange).toHaveBeenLastCalledWith('a');
+		expect(document.activeElement).toBe(radios[0]);
+	});
+
+	it('emits a structured warning when rendered with zero items', () => {
+		const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		render(<SegmentedControl.Root>{[]}</SegmentedControl.Root>);
+
+		expect(spy).toHaveBeenCalledWith('[unbranded-ds]', {
+			component: 'SegmentedControl',
+			issue: 'no-items',
+		});
+	});
+
+	it('renders two items without emitting a warning (edge case)', () => {
+		const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		render(
+			<SegmentedControl.Root defaultValue="a">
+				<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+				<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+			</SegmentedControl.Root>,
+		);
+
+		const noItemsWarnings = spy.mock.calls.filter(
+			(args) =>
+				typeof args[1] === 'object'
+				&& args[1] !== null
+				&& (args[1] as { issue?: string }).issue === 'no-items',
+		);
+		expect(noItemsWarnings).toHaveLength(0);
+	});
+});

--- a/packages/react/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/react/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,0 +1,217 @@
+/* eslint-disable react-refresh/only-export-components -- shadcn pattern co-locates segmentedControlVariants with the SegmentedControl components */
+'use client';
+
+import type { VariantProps } from 'class-variance-authority';
+
+import { Radio as RadioPrimitive } from '@base-ui-components/react/radio';
+import { RadioGroup as RadioGroupPrimitive } from '@base-ui-components/react/radio-group';
+import { cva } from 'class-variance-authority';
+import * as React from 'react';
+
+import { cn } from '../../lib/cn';
+import { warn } from '../../lib/warn';
+
+const segmentedControlRootVariants = cva(
+	// Connected pill: rounded outer wrapper that clips inner items via overflow.
+	// Border + background give the container a visible footprint distinct from
+	// the inner items. The flex direction inverts on the vertical axis.
+	'group/segmented-control inline-flex w-fit overflow-hidden rounded-md border border-input bg-muted p-0.5 text-muted-foreground outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+	{
+		variants: {
+			size: {
+				sm: 'gap-px text-xs',
+				md: 'gap-px text-sm',
+				lg: 'gap-px text-base',
+			},
+			orientation: {
+				horizontal: 'flex-row',
+				vertical: 'flex-col',
+			},
+			disabled: {
+				true: 'pointer-events-none',
+				false: '',
+			},
+		},
+		defaultVariants: {
+			size: 'md',
+			orientation: 'horizontal',
+			disabled: false,
+		},
+	},
+);
+
+const segmentedControlItemVariants = cva(
+	// Each item is a focusable segment. The selected segment lifts onto a
+	// solid background; unselected segments fade. Inner corners stay subtle
+	// because the outer wrapper provides the outer pill curve.
+	'relative inline-flex shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-[calc(var(--radius-md)-2px)] border border-transparent font-medium whitespace-nowrap transition-colors outline-none select-none hover:text-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-checked:bg-background data-checked:text-foreground data-checked:shadow-sm data-disabled:pointer-events-none data-disabled:opacity-50 dark:data-checked:bg-input/30 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
+	{
+		variants: {
+			size: {
+				sm: 'h-7 px-2 text-xs',
+				md: 'h-8 px-2.5 text-sm',
+				lg: 'h-10 px-3.5 text-base',
+			},
+			orientation: {
+				horizontal: 'flex-1',
+				vertical: 'w-full justify-start',
+			},
+		},
+		defaultVariants: {
+			size: 'md',
+			orientation: 'horizontal',
+		},
+	},
+);
+
+interface SegmentedControlRootProps {
+	value?: string;
+	defaultValue?: string;
+	onValueChange?: (value: string) => void;
+	size?: 'sm' | 'md' | 'lg';
+	orientation?: 'horizontal' | 'vertical';
+	disabled?: boolean;
+	children: React.ReactNode;
+	className?: string;
+}
+
+interface SegmentedControlItemProps {
+	value: string;
+	disabled?: boolean;
+	children: React.ReactNode;
+	className?: string;
+}
+
+// Component-level context propagates the Root's size and orientation down to
+// each Item without forcing the consumer to repeat the props at every leaf.
+interface SegmentedControlContextValue {
+	size: NonNullable<VariantProps<typeof segmentedControlItemVariants>['size']>;
+	orientation: NonNullable<VariantProps<typeof segmentedControlItemVariants>['orientation']>;
+}
+
+const SegmentedControlContext = React.createContext<SegmentedControlContextValue>({
+	size: 'md',
+	orientation: 'horizontal',
+});
+
+function Root({
+	className,
+	size = 'md',
+	orientation = 'horizontal',
+	disabled = false,
+	value,
+	defaultValue,
+	onValueChange,
+	children,
+	...props
+}: SegmentedControlRootProps) {
+	// Empty-children warning runs post-mount so SSR stays clean. React's
+	// Children.count traverses only the direct children, which is what the
+	// "no items" edge case actually targets.
+	React.useEffect(() => {
+		if (React.Children.count(children) === 0) {
+			warn({ component: 'SegmentedControl', issue: 'no-items' });
+		}
+	}, [children]);
+
+	// Base UI's RadioGroup wraps CompositeRoot with orientation='both', so
+	// all four arrow keys move focus by default and Home/End are disabled
+	// (enableHomeAndEndKeys: false). FR-025 requires strict-axis arrows AND
+	// Home/End in both orientations (WAI-ARIA radiogroup pattern), so we
+	// intercept those keys in the capture phase before CompositeRoot's own
+	// handler sees them.
+	const onKeyDownCapture = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+		const isCrossAxis
+			= (orientation === 'horizontal' && (event.key === 'ArrowUp' || event.key === 'ArrowDown'))
+				|| (orientation === 'vertical' && (event.key === 'ArrowLeft' || event.key === 'ArrowRight'));
+		if (isCrossAxis) {
+			event.preventDefault();
+			event.stopPropagation();
+			return;
+		}
+		if (event.key === 'Home' || event.key === 'End') {
+			event.preventDefault();
+			event.stopPropagation();
+			const items = event.currentTarget.querySelectorAll<HTMLElement>(
+				'[data-slot="segmented-control-item"]:not([data-disabled])',
+			);
+			if (items.length === 0) {
+				return;
+			}
+			const target = event.key === 'Home' ? items[0] : items[items.length - 1];
+			target?.focus();
+			target?.click();
+		}
+	};
+
+	const contextValue = React.useMemo<SegmentedControlContextValue>(
+		() => ({ size, orientation }),
+		[size, orientation],
+	);
+
+	return (
+		<SegmentedControlContext.Provider value={contextValue}>
+			<RadioGroupPrimitive
+				data-slot="segmented-control-root"
+				data-orientation={orientation}
+				data-size={size}
+				aria-orientation={orientation}
+				disabled={disabled}
+				value={value}
+				defaultValue={defaultValue}
+				onValueChange={(next) => {
+					if (typeof next === 'string') {
+						onValueChange?.(next);
+					}
+				}}
+				onKeyDownCapture={onKeyDownCapture}
+				className={cn(
+					segmentedControlRootVariants({ size, orientation, disabled }),
+					className,
+				)}
+				{...props}
+			>
+				{children}
+			</RadioGroupPrimitive>
+		</SegmentedControlContext.Provider>
+	);
+}
+
+function Item({
+	className,
+	value,
+	disabled = false,
+	children,
+	...props
+}: SegmentedControlItemProps) {
+	// Pull size/orientation from the Root via context so the Item picks up
+	// CVA variants without the consumer wiring them at every leaf.
+	const { size, orientation } = React.useContext(SegmentedControlContext);
+
+	return (
+		<RadioPrimitive.Root
+			data-slot="segmented-control-item"
+			value={value}
+			disabled={disabled}
+			className={cn(
+				segmentedControlItemVariants({ size, orientation }),
+				className,
+			)}
+			{...props}
+		>
+			{children}
+		</RadioPrimitive.Root>
+	);
+}
+
+const SegmentedControl = {
+	Root,
+	Item,
+};
+
+export {
+	SegmentedControl,
+	segmentedControlItemVariants,
+	segmentedControlRootVariants,
+};
+export type { SegmentedControlItemProps, SegmentedControlRootProps };

--- a/packages/react/src/components/SegmentedControl/index.ts
+++ b/packages/react/src/components/SegmentedControl/index.ts
@@ -1,0 +1,9 @@
+export {
+	SegmentedControl,
+	segmentedControlItemVariants,
+	segmentedControlRootVariants,
+} from './SegmentedControl';
+export type {
+	SegmentedControlItemProps,
+	SegmentedControlRootProps,
+} from './SegmentedControl';

--- a/packages/react/src/components/SkipLink/SkipLink.stories.tsx
+++ b/packages/react/src/components/SkipLink/SkipLink.stories.tsx
@@ -1,0 +1,170 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
+import { SkipLink } from './SkipLink';
+
+const meta = {
+	title: 'Components/SkipLink',
+	component: SkipLink,
+	tags: ['autodocs'],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'A "skip to main content" link that stays visually hidden until it receives keyboard focus. Addresses WCAG 2.4.1 (Bypass Blocks) by giving keyboard and screen-reader users a way past long navigation. Renders as a native anchor whose `href` points at the matching target `id`; activation relies on browser anchor behavior, so no JavaScript runs at click time.',
+			},
+		},
+	},
+	argTypes: {
+		targetId: {
+			control: 'text',
+			description:
+				'The `id` of the element to jump to when activated. The rendered anchor receives an `href` of `#` followed by this value. Defaults to `"main"`.',
+			table: { defaultValue: { summary: '"main"' } },
+		},
+		children: {
+			control: 'text',
+			description:
+				'The visible link label. Defaults to `"Skip to main content"`. Screen readers announce this label whether or not the link is visually rendered.',
+			table: { defaultValue: { summary: '"Skip to main content"' } },
+		},
+		className: {
+			control: 'text',
+			description:
+				'Extra Tailwind utilities merged onto the rendered anchor via `cn()`. Use this to adjust the focus-revealed treatment without redeclaring the hidden baseline.',
+		},
+	},
+} satisfies Meta<typeof SkipLink>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {},
+	render: (args) => (
+		<div>
+			<SkipLink {...args} />
+			<nav aria-label="Primary">
+				<a href="#one">One</a>
+				{' | '}
+				<a href="#two">Two</a>
+			</nav>
+			<main id="main" tabIndex={-1} style={{ paddingTop: '1rem' }}>
+				<h1>Main content</h1>
+				<p>
+					Press Tab from the address bar (or click into the canvas and press
+					Tab) to reveal the skip link in the upper-left corner.
+				</p>
+			</main>
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Renders a SkipLink with the default `targetId` of `"main"`. The story pairs it with a `<main id="main">` so activation has somewhere to land. The link is invisible until the user tabs to it.',
+			},
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const link = canvas.getByRole('link', { name: /skip to main content/i });
+
+		// Before focus, the sr-only baseline keeps the link out of the
+		// visual layout for sighted users.
+		expect(link.className).toContain('sr-only');
+
+		// Tab from the document root moves focus to the first focusable
+		// element, which is the SkipLink itself.
+		await userEvent.tab();
+		expect(link).toHaveFocus();
+	},
+};
+
+export const CustomTarget: Story = {
+	args: { targetId: 'content', children: 'Skip to content' },
+	render: (args) => (
+		<div>
+			<SkipLink {...args} />
+			<nav aria-label="Primary">
+				<a href="#one">One</a>
+			</nav>
+			<main id="content" tabIndex={-1} style={{ paddingTop: '1rem' }}>
+				<h1>Content region</h1>
+				<p>This region uses `id="content"` instead of the default `"main"`.</p>
+			</main>
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Pass a custom `targetId` to point at any element on the page. The matching element needs the same `id` for the browser to scroll and focus it on activation.',
+			},
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const link = canvas.getByRole('link', { name: /skip to content/i });
+
+		await userEvent.tab();
+		expect(link).toHaveFocus();
+		expect(link.getAttribute('href')).toBe('#content');
+
+		// Pressing Enter activates the native anchor. The browser handles
+		// the scroll-and-focus jump; we just confirm the keystroke does
+		// not throw and the link has the right target wiring.
+		await userEvent.keyboard('{Enter}');
+	},
+};
+
+export const MultipleSkipTargets: Story = {
+	render: () => (
+		<div>
+			<SkipLink targetId="main">Skip to main content</SkipLink>
+			<SkipLink targetId="nav">Skip to navigation</SkipLink>
+			<SkipLink targetId="footer">Skip to footer</SkipLink>
+			<nav id="nav" aria-label="Primary" tabIndex={-1}>
+				<h2>Navigation</h2>
+				<a href="#one">One</a>
+				{' | '}
+				<a href="#two">Two</a>
+			</nav>
+			<main id="main" tabIndex={-1} style={{ paddingTop: '1rem' }}>
+				<h1>Main content</h1>
+				<p>Tab through the page to reach each SkipLink in turn.</p>
+			</main>
+			<footer id="footer" tabIndex={-1} style={{ paddingTop: '1rem' }}>
+				<h2>Footer</h2>
+				<p>End of page.</p>
+			</footer>
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Three SkipLinks point at three different landmarks. Each is independently focusable and activates its own anchor target, which gives a keyboard user fine-grained control over where they land.',
+			},
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const mainLink = canvas.getByRole('link', { name: /skip to main content/i });
+		const navLink = canvas.getByRole('link', { name: /skip to navigation/i });
+		const footerLink = canvas.getByRole('link', { name: /skip to footer/i });
+
+		expect(mainLink.getAttribute('href')).toBe('#main');
+		expect(navLink.getAttribute('href')).toBe('#nav');
+		expect(footerLink.getAttribute('href')).toBe('#footer');
+
+		// Tab cycles through the three links in DOM order.
+		await userEvent.tab();
+		expect(mainLink).toHaveFocus();
+
+		await userEvent.tab();
+		expect(navLink).toHaveFocus();
+
+		await userEvent.tab();
+		expect(footerLink).toHaveFocus();
+	},
+};

--- a/packages/react/src/components/SkipLink/SkipLink.test.tsx
+++ b/packages/react/src/components/SkipLink/SkipLink.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SkipLink } from './SkipLink';
+
+describe('skipLink', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('defaults targetId to "main" and renders href="#main"', () => {
+		const { getByRole } = render(<SkipLink />);
+		const link = getByRole('link');
+		expect(link.getAttribute('href')).toBe('#main');
+	});
+
+	it('builds href from a custom targetId', () => {
+		const { getByRole } = render(<SkipLink targetId="content" />);
+		const link = getByRole('link');
+		expect(link.getAttribute('href')).toBe('#content');
+	});
+
+	it('renders the default "Skip to main content" text', () => {
+		const { getByRole } = render(<SkipLink />);
+		expect(getByRole('link').textContent).toBe('Skip to main content');
+	});
+
+	it('passes custom children through unchanged', () => {
+		const { getByRole } = render(<SkipLink>Jump to nav</SkipLink>);
+		expect(getByRole('link').textContent).toBe('Jump to nav');
+	});
+
+	it('merges a consumer className with the sr-only baseline via cn()', () => {
+		const { getByRole } = render(<SkipLink className="custom-class" />);
+		const link = getByRole('link');
+		expect(link.className).toContain('sr-only');
+		expect(link.className).toContain('focus-visible:not-sr-only');
+		expect(link.className).toContain('custom-class');
+	});
+
+	it('renders an <a> element, not a <button>', () => {
+		// Guards against accidental refactors to a button — the spec requires
+		// native anchor behavior so the browser handles focus and scroll.
+		const { getByRole } = render(<SkipLink />);
+		expect(getByRole('link').tagName).toBe('A');
+	});
+
+	it('applies the data-slot="skip-link" attribute', () => {
+		const { getByRole } = render(<SkipLink />);
+		expect(getByRole('link').getAttribute('data-slot')).toBe('skip-link');
+	});
+});

--- a/packages/react/src/components/SkipLink/SkipLink.tsx
+++ b/packages/react/src/components/SkipLink/SkipLink.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import type * as React from 'react';
+
+import { cn } from '../../lib/cn';
+
+interface SkipLinkProps {
+	/**
+	 * The `id` of the element to jump to when the link is activated. The
+	 * rendered anchor's `href` becomes `#${targetId}`.
+	 */
+	targetId?: string;
+	/**
+	 * The visible link text shown once the link receives focus. Screen readers
+	 * read this label whether or not the link is visually rendered.
+	 */
+	children?: React.ReactNode;
+	/**
+	 * Extra Tailwind utilities merged onto the rendered anchor. Use it to
+	 * override the focus-revealed treatment without redeclaring the hidden
+	 * baseline.
+	 */
+	className?: string;
+}
+
+/**
+ * A "skip to main content" link. Renders as a native `<a>` that stays
+ * visually hidden until it receives keyboard focus, then reveals at the
+ * top-left of the viewport so a keyboard or screen-reader user can jump
+ * past long navigation. Addresses WCAG 2.4.1 (Bypass Blocks).
+ *
+ * The component is intentionally thin: it relies on native anchor behavior
+ * for focus and scroll on activation, and it does not call
+ * `preventDefault()` or run programmatic scroll. The consumer is
+ * responsible for placing a matching `id` on the target element.
+ *
+ * Multiple `<SkipLink>` instances may share a page, each pointing at its
+ * own `targetId`. The component takes no layout opinion on how stacked
+ * instances render together.
+ *
+ * @example
+ * ```tsx
+ * <SkipLink />
+ * <main id="main">...</main>
+ * ```
+ *
+ * @example Multiple targets
+ * ```tsx
+ * <SkipLink targetId="main">Skip to main content</SkipLink>
+ * <SkipLink targetId="nav">Skip to navigation</SkipLink>
+ * <SkipLink targetId="footer">Skip to footer</SkipLink>
+ * ```
+ */
+function SkipLink({
+	targetId = 'main',
+	children = 'Skip to main content',
+	className,
+}: SkipLinkProps) {
+	return (
+		<a
+			data-slot="skip-link"
+			href={`#${targetId}`}
+			className={cn(
+				'sr-only',
+				'focus-visible:not-sr-only focus-visible:fixed focus-visible:top-2 focus-visible:left-2 focus-visible:z-50',
+				'focus-visible:inline-flex focus-visible:items-center focus-visible:rounded-md focus-visible:border focus-visible:border-ring focus-visible:bg-primary focus-visible:px-3 focus-visible:py-2',
+				'focus-visible:text-sm focus-visible:font-medium focus-visible:text-primary-foreground focus-visible:shadow-md',
+				'focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50',
+				className,
+			)}
+		>
+			{children}
+		</a>
+	);
+}
+
+export { SkipLink };
+export type { SkipLinkProps };

--- a/packages/react/src/components/SkipLink/index.ts
+++ b/packages/react/src/components/SkipLink/index.ts
@@ -1,0 +1,2 @@
+export { SkipLink } from './SkipLink';
+export type { SkipLinkProps } from './SkipLink';

--- a/packages/react/src/components/Slider/Slider.stories.tsx
+++ b/packages/react/src/components/Slider/Slider.stories.tsx
@@ -1,0 +1,253 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
+import { Slider } from './Slider';
+
+const meta = {
+	title: 'Components/Slider',
+	component: Slider.Root,
+	tags: ['autodocs'],
+	argTypes: {
+		value: {
+			description:
+				'Controlled value. Always an array of numbers. A single-value slider passes `[50]`; a range slider passes `[20, 80]`. Pair with `onValueChange` to drive the value yourself.',
+			control: 'object',
+		},
+		defaultValue: {
+			description:
+				'Uncontrolled initial value. Same array shape as `value`: `[50]` for a single thumb, `[20, 80]` for a range.',
+			control: 'object',
+		},
+		min: {
+			description: 'Lower bound of the value range, inclusive. Default 0.',
+			control: 'number',
+		},
+		max: {
+			description: 'Upper bound of the value range, inclusive. Default 100.',
+			control: 'number',
+		},
+		step: {
+			description:
+				'Increment for keyboard and drag. Default 1. Values at or below zero fall back to 1 and emit a structured warning.',
+			control: 'number',
+		},
+		onValueChange: {
+			description:
+				'Fires on every value change. Receives the new value as `number[]`, matching the shape of `value` and `defaultValue`.',
+			action: 'value-changed',
+		},
+		size: {
+			description: 'Visual size axis. Affects track height and thumb diameter.',
+			control: 'select',
+			options: ['sm', 'md', 'lg'],
+		},
+		orientation: {
+			description:
+				'Layout axis. Horizontal sliders stretch along the inline axis; vertical sliders along the block axis.',
+			control: 'select',
+			options: ['horizontal', 'vertical'],
+		},
+		disabled: {
+			description:
+				'When true, blocks drag, keyboard, and focus on the thumbs. The slider still renders with the current value.',
+			control: 'boolean',
+		},
+		className: {
+			description: 'Additional classes merged onto `Slider.Root` via `cn()`.',
+			control: 'text',
+		},
+	},
+} satisfies Meta<typeof Slider.Root>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: () => (
+		<div style={{ width: '320px' }}>
+			<Slider.Root defaultValue={[50]} min={0} max={100} step={1}>
+				<Slider.Control>
+					<Slider.Track>
+						<Slider.Indicator />
+					</Slider.Track>
+					<Slider.Thumb />
+				</Slider.Control>
+			</Slider.Root>
+		</div>
+	),
+};
+
+export const Sizes: Story = {
+	render: () => (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '24px', width: '320px' }}>
+			{(['sm', 'md', 'lg'] as const).map((size) => (
+				<Slider.Root key={size} defaultValue={[50]} size={size}>
+					<Slider.Control>
+						<Slider.Track>
+							<Slider.Indicator />
+						</Slider.Track>
+						<Slider.Thumb />
+					</Slider.Control>
+				</Slider.Root>
+			))}
+		</div>
+	),
+};
+
+export const Orientations: Story = {
+	render: () => (
+		<div style={{ display: 'flex', gap: '48px', alignItems: 'flex-start' }}>
+			<div style={{ width: '320px' }}>
+				<Slider.Root defaultValue={[50]} orientation="horizontal">
+					<Slider.Control>
+						<Slider.Track>
+							<Slider.Indicator />
+						</Slider.Track>
+						<Slider.Thumb />
+					</Slider.Control>
+				</Slider.Root>
+			</div>
+			<div style={{ height: '240px' }}>
+				<Slider.Root defaultValue={[50]} orientation="vertical">
+					<Slider.Control>
+						<Slider.Track>
+							<Slider.Indicator />
+						</Slider.Track>
+						<Slider.Thumb />
+					</Slider.Control>
+				</Slider.Root>
+			</div>
+		</div>
+	),
+};
+
+export const Range: Story = {
+	render: () => (
+		<div style={{ width: '320px' }}>
+			<Slider.Root defaultValue={[20, 80]}>
+				<Slider.Control>
+					<Slider.Track>
+						<Slider.Indicator />
+					</Slider.Track>
+					<Slider.Thumb />
+					<Slider.Thumb />
+				</Slider.Control>
+			</Slider.Root>
+		</div>
+	),
+};
+
+export const Disabled: Story = {
+	render: () => (
+		<div style={{ width: '320px' }}>
+			<Slider.Root defaultValue={[50]} disabled>
+				<Slider.Control>
+					<Slider.Track>
+						<Slider.Indicator />
+					</Slider.Track>
+					<Slider.Thumb />
+				</Slider.Control>
+			</Slider.Root>
+		</div>
+	),
+};
+
+// Stateful render extracted so the hook lives inside a real React component
+// rather than the inline render function (which the linter does not see as a
+// component).
+function ControlledSliderExample() {
+	const [value, setValue] = useState<number[]>([42]);
+	return (
+		<div style={{ width: '320px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
+			<Slider.Root value={value} onValueChange={setValue}>
+				<Slider.Control>
+					<Slider.Track>
+						<Slider.Indicator />
+					</Slider.Track>
+					<Slider.Thumb />
+				</Slider.Control>
+			</Slider.Root>
+			<output style={{ fontSize: '14px' }}>
+				{`Value: ${value.join(', ')}`}
+			</output>
+		</div>
+	);
+}
+
+export const Controlled: Story = {
+	render: () => <ControlledSliderExample />,
+};
+
+export const KeyboardIncrement: Story = {
+	render: () => (
+		<div style={{ width: '320px' }}>
+			<Slider.Root defaultValue={[50]}>
+				<Slider.Control>
+					<Slider.Track>
+						<Slider.Indicator />
+					</Slider.Track>
+					<Slider.Thumb />
+				</Slider.Control>
+			</Slider.Root>
+		</div>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const thumb = canvas.getByRole('slider');
+		thumb.focus();
+		await userEvent.keyboard('{ArrowRight}');
+		await expect(thumb).toHaveAttribute('aria-valuenow', '51');
+	},
+};
+
+export const KeyboardHomeEnd: Story = {
+	render: () => (
+		<div style={{ width: '320px' }}>
+			<Slider.Root defaultValue={[50]}>
+				<Slider.Control>
+					<Slider.Track>
+						<Slider.Indicator />
+					</Slider.Track>
+					<Slider.Thumb />
+				</Slider.Control>
+			</Slider.Root>
+		</div>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const thumb = canvas.getByRole('slider');
+		thumb.focus();
+		await userEvent.keyboard('{Home}');
+		await expect(thumb).toHaveAttribute('aria-valuenow', '0');
+		await userEvent.keyboard('{End}');
+		await expect(thumb).toHaveAttribute('aria-valuenow', '100');
+	},
+};
+
+export const Touch: Story = {
+	render: () => (
+		<div style={{ width: '320px' }}>
+			<Slider.Root defaultValue={[50]}>
+				<Slider.Control>
+					<Slider.Track>
+						<Slider.Indicator />
+					</Slider.Track>
+					<Slider.Thumb />
+				</Slider.Control>
+			</Slider.Root>
+		</div>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const thumb = canvas.getByRole('slider');
+		// FR-019: touch input resolves to the same onValueChange pathway as
+		// pointer and keyboard. This play asserts the thumb is reachable via a
+		// simulated touch pointer and keeps aria-valuenow exposed afterwards.
+		await userEvent.pointer({
+			keys: '[TouchA>]',
+			target: thumb,
+		});
+		await userEvent.pointer({ keys: '[/TouchA]' });
+		await expect(thumb).toHaveAttribute('aria-valuenow');
+	},
+};

--- a/packages/react/src/components/Slider/Slider.test.tsx
+++ b/packages/react/src/components/Slider/Slider.test.tsx
@@ -1,0 +1,271 @@
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Slider } from './Slider';
+
+function renderSingle(props: Parameters<typeof Slider.Root>[0] = { children: null }) {
+	return render(
+		<Slider.Root {...props}>
+			<Slider.Control>
+				<Slider.Track>
+					<Slider.Indicator />
+				</Slider.Track>
+				<Slider.Thumb />
+			</Slider.Control>
+		</Slider.Root>,
+	);
+}
+
+function renderRange(
+	props: Parameters<typeof Slider.Root>[0] = { children: null },
+) {
+	return render(
+		<Slider.Root {...props}>
+			<Slider.Control>
+				<Slider.Track>
+					<Slider.Indicator />
+				</Slider.Track>
+				<Slider.Thumb />
+				<Slider.Thumb />
+			</Slider.Control>
+		</Slider.Root>,
+	);
+}
+
+describe('slider', () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('slot composition', () => {
+		it('renders all five slots with matching data-slot attributes', () => {
+			const { container } = renderSingle({
+				defaultValue: [50],
+				children: null,
+			});
+
+			expect(container.querySelector('[data-slot=\'slider-root\']')).toBeInTheDocument();
+			expect(container.querySelector('[data-slot=\'slider-control\']')).toBeInTheDocument();
+			expect(container.querySelector('[data-slot=\'slider-track\']')).toBeInTheDocument();
+			expect(container.querySelector('[data-slot=\'slider-indicator\']')).toBeInTheDocument();
+			expect(container.querySelector('[data-slot=\'slider-thumb\']')).toBeInTheDocument();
+		});
+
+		it('renders two thumbs in range mode', () => {
+			const { container } = renderRange({
+				defaultValue: [20, 80],
+				children: null,
+			});
+
+			const thumbs = container.querySelectorAll('[data-slot=\'slider-thumb\']');
+			expect(thumbs.length).toBe(2);
+		});
+	});
+
+	describe('cVA variant resolution', () => {
+		it('applies the default md size when no size prop is given', () => {
+			const { container } = renderSingle({ defaultValue: [50], children: null });
+			const root = container.querySelector('[data-slot=\'slider-root\']');
+			expect(root?.getAttribute('data-size')).toBe('md');
+		});
+
+		it('reflects the size prop through data-size', () => {
+			const { container } = renderSingle({ defaultValue: [50], size: 'lg', children: null });
+			const root = container.querySelector('[data-slot=\'slider-root\']');
+			expect(root?.getAttribute('data-size')).toBe('lg');
+		});
+
+		it('reflects the orientation prop through data-orientation', () => {
+			const { container } = renderSingle({
+				defaultValue: [50],
+				orientation: 'vertical',
+				children: null,
+			});
+			const root = container.querySelector('[data-slot=\'slider-root\']');
+			expect(root?.getAttribute('data-orientation')).toBe('vertical');
+		});
+
+		it('reflects disabled through data-disabled', () => {
+			const { container } = renderSingle({
+				defaultValue: [50],
+				disabled: true,
+				children: null,
+			});
+			const root = container.querySelector('[data-slot=\'slider-root\']');
+			expect(root?.hasAttribute('data-disabled')).toBe(true);
+		});
+	});
+
+	describe('className merging via cn()', () => {
+		it('merges a consumer className onto Slider.Root', () => {
+			const { container } = renderSingle({
+				defaultValue: [50],
+				className: 'my-slider',
+				children: null,
+			});
+			const root = container.querySelector('[data-slot=\'slider-root\']');
+			expect(root?.className).toContain('my-slider');
+		});
+
+		it('merges a consumer className onto Slider.Thumb', () => {
+			const { container } = render(
+				<Slider.Root defaultValue={[50]}>
+					<Slider.Control>
+						<Slider.Track>
+							<Slider.Indicator />
+						</Slider.Track>
+						<Slider.Thumb className="my-thumb" />
+					</Slider.Control>
+				</Slider.Root>,
+			);
+			const thumb = container.querySelector('[data-slot=\'slider-thumb\']');
+			expect(thumb?.className).toContain('my-thumb');
+		});
+	});
+
+	describe('validation: value-out-of-range', () => {
+		it('clamps a value above max and emits a structured warning', async () => {
+			renderSingle({ defaultValue: [150], min: 0, max: 100, children: null });
+			// The warn helper runs in a useEffect, so let the microtask queue drain.
+			await Promise.resolve();
+			expect(warnSpy).toHaveBeenCalledWith(
+				'[unbranded-ds]',
+				expect.objectContaining({
+					component: 'Slider',
+					issue: 'value-out-of-range',
+					prop: 'defaultValue',
+					got: [150],
+					clamped: [100],
+				}),
+			);
+		});
+
+		it('clamps a value below min and emits a structured warning', async () => {
+			renderSingle({ value: [-10], min: 0, max: 100, children: null });
+			await Promise.resolve();
+			expect(warnSpy).toHaveBeenCalledWith(
+				'[unbranded-ds]',
+				expect.objectContaining({
+					component: 'Slider',
+					issue: 'value-out-of-range',
+					prop: 'value',
+					got: [-10],
+					clamped: [0],
+				}),
+			);
+		});
+
+		it('does not warn when every value sits inside the range', async () => {
+			renderSingle({ defaultValue: [50], min: 0, max: 100, children: null });
+			await Promise.resolve();
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('validation: invalid-step', () => {
+		it('falls back to step 1 and emits a structured warning when step is zero', async () => {
+			renderSingle({ defaultValue: [50], step: 0, children: null });
+			await Promise.resolve();
+			expect(warnSpy).toHaveBeenCalledWith(
+				'[unbranded-ds]',
+				expect.objectContaining({
+					component: 'Slider',
+					issue: 'invalid-step',
+					got: 0,
+					fallback: 1,
+				}),
+			);
+		});
+
+		it('falls back to step 1 and emits a structured warning when step is negative', async () => {
+			renderSingle({ defaultValue: [50], step: -5, children: null });
+			await Promise.resolve();
+			expect(warnSpy).toHaveBeenCalledWith(
+				'[unbranded-ds]',
+				expect.objectContaining({
+					component: 'Slider',
+					issue: 'invalid-step',
+					got: -5,
+					fallback: 1,
+				}),
+			);
+		});
+	});
+
+	describe('validation: invalid-bounds', () => {
+		it('swaps to [min, min+1] and emits a structured warning when min equals max', async () => {
+			renderSingle({ defaultValue: [50], min: 100, max: 100, children: null });
+			await Promise.resolve();
+			expect(warnSpy).toHaveBeenCalledWith(
+				'[unbranded-ds]',
+				expect.objectContaining({
+					component: 'Slider',
+					issue: 'invalid-bounds',
+					min: 100,
+					max: 100,
+					swappedTo: [100, 101],
+				}),
+			);
+		});
+
+		it('swaps to [min, min+1] when min is greater than max', async () => {
+			renderSingle({ defaultValue: [50], min: 50, max: 10, children: null });
+			await Promise.resolve();
+			expect(warnSpy).toHaveBeenCalledWith(
+				'[unbranded-ds]',
+				expect.objectContaining({
+					component: 'Slider',
+					issue: 'invalid-bounds',
+					min: 50,
+					max: 10,
+					swappedTo: [50, 51],
+				}),
+			);
+		});
+	});
+
+	describe('value shape contract', () => {
+		it('treats a single-value default as a one-element array', () => {
+			const { container } = renderSingle({ defaultValue: [50], children: null });
+			const thumbs = container.querySelectorAll('[data-slot=\'slider-thumb\']');
+			expect(thumbs.length).toBe(1);
+		});
+
+		it('treats a controlled value as a number[] and renders the corresponding thumbs', () => {
+			const { container } = renderRange({ value: [20, 80], children: null });
+			const thumbs = container.querySelectorAll('[data-slot=\'slider-thumb\']');
+			expect(thumbs.length).toBe(2);
+		});
+
+		it('forwards onValueChange as a number[] callback', () => {
+			const onValueChange = vi.fn();
+			const { container } = render(
+				<Slider.Root defaultValue={[50]} onValueChange={onValueChange}>
+					<Slider.Control>
+						<Slider.Track>
+							<Slider.Indicator />
+						</Slider.Track>
+						<Slider.Thumb />
+					</Slider.Control>
+				</Slider.Root>,
+			);
+
+			// Base UI's Thumb renders a nested <input type="range">. Setting its
+			// value and firing change is the simplest way to drive the change
+			// pathway without simulating drag in jsdom.
+			const input = container.querySelector('input[type=\'range\']') as HTMLInputElement;
+			expect(input).toBeInTheDocument();
+			fireEvent.change(input, { target: { value: '60' } });
+
+			expect(onValueChange).toHaveBeenCalled();
+			const firstCallArg = onValueChange.mock.calls[0]?.[0];
+			expect(Array.isArray(firstCallArg)).toBe(true);
+			expect(firstCallArg).toEqual([60]);
+		});
+	});
+});

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -1,0 +1,318 @@
+/* eslint-disable react-refresh/only-export-components -- shadcn pattern co-locates sliderRootVariants with the Slider components */
+'use client';
+
+import type { VariantProps } from 'class-variance-authority';
+import type * as React from 'react';
+import { Slider as SliderPrimitive } from '@base-ui-components/react/slider';
+import { cva } from 'class-variance-authority';
+
+import { useEffect, useMemo } from 'react';
+import { cn } from '../../lib/cn';
+import { warn } from '../../lib/warn';
+
+const sliderRootVariants = cva(
+	'group/slider relative flex touch-none items-center select-none data-disabled:pointer-events-none data-disabled:opacity-50',
+	{
+		variants: {
+			size: {
+				sm: 'data-[orientation=horizontal]:h-4 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-40 data-[orientation=vertical]:w-4',
+				md: 'data-[orientation=horizontal]:h-5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-48 data-[orientation=vertical]:w-5',
+				lg: 'data-[orientation=horizontal]:h-6 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-56 data-[orientation=vertical]:w-6',
+			},
+			orientation: {
+				horizontal: 'flex-row',
+				vertical: 'flex-col',
+			},
+			disabled: {
+				true: 'pointer-events-none opacity-50',
+				false: '',
+			},
+		},
+		defaultVariants: {
+			size: 'md',
+			orientation: 'horizontal',
+			disabled: false,
+		},
+	},
+);
+
+const sliderControlVariants = cva(
+	'relative flex w-full items-center group-data-[orientation=vertical]/slider:h-full group-data-[orientation=vertical]/slider:w-fit',
+);
+
+const sliderTrackVariants = cva(
+	'relative grow overflow-hidden rounded-full bg-muted group-data-[orientation=horizontal]/slider:h-1.5 group-data-[orientation=horizontal]/slider:w-full group-data-[orientation=vertical]/slider:h-full group-data-[orientation=vertical]/slider:w-1.5',
+);
+
+const sliderIndicatorVariants = cva(
+	'absolute rounded-full bg-primary group-data-[orientation=horizontal]/slider:h-full group-data-[orientation=vertical]/slider:w-full',
+);
+
+const sliderThumbVariants = cva(
+	'block rounded-full border border-primary/50 bg-background shadow-xs ring-ring/50 transition-[color,box-shadow] outline-none focus-visible:ring-3 disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50',
+	{
+		variants: {
+			size: {
+				sm: 'size-3.5',
+				md: 'size-4',
+				lg: 'size-5',
+			},
+		},
+		defaultVariants: {
+			size: 'md',
+		},
+	},
+);
+
+// Base UI's onValueChange receives the value first, plus a details object.
+// We narrow the public surface to just the array — consumers wiring
+// onValueChange should not need to learn Base UI's event-details shape.
+interface SliderRootProps
+	extends Omit<
+		SliderPrimitive.Root.Props<readonly number[]>,
+		'value' | 'defaultValue' | 'onValueChange' | 'size' | 'orientation' | 'disabled'
+	>,
+	VariantProps<typeof sliderRootVariants> {
+	value?: number[];
+	defaultValue?: number[];
+	min?: number;
+	max?: number;
+	step?: number;
+	onValueChange?: (value: number[]) => void;
+	size?: 'sm' | 'md' | 'lg';
+	orientation?: 'horizontal' | 'vertical';
+	disabled?: boolean;
+	className?: string;
+	// Optional in the TypeScript surface so Storybook's argTypes-driven type
+	// inference doesn't force every story to declare children explicitly.
+	// Runtime usage still composes children via the Control/Track/Thumb slots.
+	children?: React.ReactNode;
+}
+
+interface SliderControlProps extends SliderPrimitive.Control.Props {
+	className?: string;
+}
+
+interface SliderTrackProps extends SliderPrimitive.Track.Props {
+	className?: string;
+}
+
+interface SliderIndicatorProps extends SliderPrimitive.Indicator.Props {
+	className?: string;
+}
+
+interface SliderThumbProps extends SliderPrimitive.Thumb.Props {
+	className?: string;
+}
+
+// Validation result for the Root's sanitized props. Validation runs once at
+// the bottom of render, but warn calls happen in useEffect so SSR doesn't see
+// console noise and we don't re-emit on every re-render.
+interface SanitizedProps {
+	min: number;
+	max: number;
+	step: number;
+	value: number[] | undefined;
+	defaultValue: number[] | undefined;
+	warnings: Array<Parameters<typeof warn>[0]>;
+}
+
+function sanitize({
+	min,
+	max,
+	step,
+	value,
+	defaultValue,
+}: {
+	min: number;
+	max: number;
+	step: number;
+	value: number[] | undefined;
+	defaultValue: number[] | undefined;
+}): SanitizedProps {
+	const warnings: Array<Parameters<typeof warn>[0]> = [];
+
+	const safeMin = min;
+	let safeMax = max;
+	if (safeMin >= safeMax) {
+		const swappedTo: [number, number] = [safeMin, safeMin + 1];
+		warnings.push({
+			component: 'Slider',
+			issue: 'invalid-bounds',
+			min,
+			max,
+			swappedTo,
+		});
+		safeMax = safeMin + 1;
+	}
+
+	let safeStep = step;
+	if (safeStep <= 0) {
+		warnings.push({
+			component: 'Slider',
+			issue: 'invalid-step',
+			got: step,
+			fallback: 1,
+		});
+		safeStep = 1;
+	}
+
+	const clamp = (values: number[], propName: 'value' | 'defaultValue'): number[] => {
+		const clamped = values.map((v) => {
+			if (v < safeMin)
+				return safeMin;
+			if (v > safeMax)
+				return safeMax;
+			return v;
+		});
+		const drifted = clamped.some((v, i) => v !== values[i]);
+		if (drifted) {
+			warnings.push({
+				component: 'Slider',
+				issue: 'value-out-of-range',
+				prop: propName,
+				got: values,
+				clamped,
+			});
+		}
+		return clamped;
+	};
+
+	return {
+		min: safeMin,
+		max: safeMax,
+		step: safeStep,
+		value: value === undefined ? undefined : clamp(value, 'value'),
+		defaultValue:
+			defaultValue === undefined ? undefined : clamp(defaultValue, 'defaultValue'),
+		warnings,
+	};
+}
+
+function SliderRoot({
+	className,
+	size = 'md',
+	orientation = 'horizontal',
+	disabled = false,
+	min = 0,
+	max = 100,
+	step = 1,
+	value,
+	defaultValue,
+	onValueChange,
+	children,
+	...props
+}: SliderRootProps) {
+	const sanitized = useMemo(
+		() => sanitize({ min, max, step, value, defaultValue }),
+		[min, max, step, value, defaultValue],
+	);
+
+	// Warnings emit on the client only — useEffect doesn't run on the server,
+	// which keeps SSR output clean and avoids re-emitting on every render.
+	useEffect(() => {
+		for (const payload of sanitized.warnings) {
+			warn(payload);
+		}
+	}, [sanitized.warnings]);
+
+	// PageUp/PageDown should move 10% of the range, rounded to the nearest step.
+	// Base UI honours `largeStep` natively; the default is 10, which is wrong
+	// when the range is anything other than 0-100. Recompute it here.
+	const largeStep = useMemo(() => {
+		const tenPercent = (sanitized.max - sanitized.min) * 0.1;
+		const rounded = Math.round(tenPercent / sanitized.step) * sanitized.step;
+		return rounded > 0 ? rounded : sanitized.step;
+	}, [sanitized.min, sanitized.max, sanitized.step]);
+
+	const handleValueChange = onValueChange
+		? (next: readonly number[]) => onValueChange([...next])
+		: undefined;
+
+	return (
+		<SliderPrimitive.Root<readonly number[]>
+			data-slot="slider-root"
+			data-size={size}
+			data-orientation={orientation}
+			data-disabled={disabled ? '' : undefined}
+			min={sanitized.min}
+			max={sanitized.max}
+			step={sanitized.step}
+			largeStep={largeStep}
+			value={sanitized.value}
+			defaultValue={sanitized.defaultValue}
+			onValueChange={handleValueChange}
+			disabled={disabled}
+			orientation={orientation}
+			className={cn(sliderRootVariants({ size, orientation, disabled }), className)}
+			{...props}
+		>
+			{children}
+		</SliderPrimitive.Root>
+	);
+}
+
+function SliderControl({ className, ...props }: SliderControlProps) {
+	return (
+		<SliderPrimitive.Control
+			data-slot="slider-control"
+			className={cn(sliderControlVariants(), className)}
+			{...props}
+		/>
+	);
+}
+
+function SliderTrack({ className, ...props }: SliderTrackProps) {
+	return (
+		<SliderPrimitive.Track
+			data-slot="slider-track"
+			className={cn(sliderTrackVariants(), className)}
+			{...props}
+		/>
+	);
+}
+
+function SliderIndicator({ className, ...props }: SliderIndicatorProps) {
+	return (
+		<SliderPrimitive.Indicator
+			data-slot="slider-indicator"
+			className={cn(sliderIndicatorVariants(), className)}
+			{...props}
+		/>
+	);
+}
+
+function SliderThumb({ className, ...props }: SliderThumbProps) {
+	return (
+		<SliderPrimitive.Thumb
+			data-slot="slider-thumb"
+			className={cn(sliderThumbVariants(), className)}
+			{...props}
+		/>
+	);
+}
+
+const Slider = {
+	Root: SliderRoot,
+	Control: SliderControl,
+	Track: SliderTrack,
+	Indicator: SliderIndicator,
+	Thumb: SliderThumb,
+};
+
+export {
+	Slider,
+	sliderControlVariants,
+	sliderIndicatorVariants,
+	sliderRootVariants,
+	sliderThumbVariants,
+	sliderTrackVariants,
+};
+
+export type {
+	SliderControlProps,
+	SliderIndicatorProps,
+	SliderRootProps,
+	SliderThumbProps,
+	SliderTrackProps,
+};

--- a/packages/react/src/components/Slider/index.ts
+++ b/packages/react/src/components/Slider/index.ts
@@ -1,0 +1,8 @@
+export { Slider } from './Slider';
+export type {
+	SliderControlProps,
+	SliderIndicatorProps,
+	SliderRootProps,
+	SliderThumbProps,
+	SliderTrackProps,
+} from './Slider';

--- a/packages/react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,184 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
+import { Button } from '../Button/Button';
+import { Tooltip } from './Tooltip';
+
+const meta = {
+	title: 'Components/Tooltip',
+	component: Tooltip.Provider,
+	tags: ['autodocs'],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'A token-styled tooltip wrapping Base UI\'s Tooltip primitives. Opens on hover after a configurable delay, on keyboard focus immediately, and on tap on touch devices. Dismisses on Escape. Content portals to `document.body` so it can escape ancestors that clip overflow. Honors `prefers-reduced-motion: reduce` by skipping the open and close transitions.',
+			},
+		},
+	},
+	argTypes: {
+		delayDuration: {
+			control: 'number',
+			description:
+				'Hover delay before the tooltip opens, in milliseconds. Keyboard focus bypasses this delay and opens the tooltip immediately. Default 700.',
+		},
+		container: {
+			control: false,
+			description:
+				'Portal mount target for `Tooltip.Content`. Defaults to `document.body`, which lets the tooltip escape ancestors with `overflow: hidden` or `overflow: clip`. Pass an HTMLElement to mount the portal somewhere else (useful when a fixed parent owns the stacking context you want to land in).',
+		},
+		onOpenChange: {
+			action: 'openChange',
+			description:
+				'Fires when the open state changes, including hover, keyboard focus, tap, Escape, and outside press. The argument is the new open state.',
+		},
+	},
+} satisfies Meta<typeof Tooltip.Provider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		delayDuration: 200,
+	},
+	render: (args) => (
+		<Tooltip.Provider {...args}>
+			<Tooltip.Trigger>
+				<Button variant="outline">Hover me</Button>
+			</Tooltip.Trigger>
+			<Tooltip.Content>Helpful detail</Tooltip.Content>
+		</Tooltip.Provider>
+	),
+};
+
+export const Sides: Story = {
+	args: { delayDuration: 200 },
+	render: (args) => (
+		<div className="flex flex-wrap items-center justify-center gap-8 p-16">
+			{(['top', 'right', 'bottom', 'left'] as const).map((side) => (
+				<Tooltip.Provider key={side} {...args}>
+					<Tooltip.Trigger>
+						<Button variant="outline">{side}</Button>
+					</Tooltip.Trigger>
+					<Tooltip.Content side={side}>
+						Side:
+						{' '}
+						{side}
+					</Tooltip.Content>
+				</Tooltip.Provider>
+			))}
+		</div>
+	),
+};
+
+export const Alignments: Story = {
+	args: { delayDuration: 200 },
+	render: (args) => (
+		<div className="flex flex-wrap items-center justify-center gap-8 p-16">
+			{(['start', 'center', 'end'] as const).map((align) => (
+				<Tooltip.Provider key={align} {...args}>
+					<Tooltip.Trigger>
+						<Button variant="outline">{align}</Button>
+					</Tooltip.Trigger>
+					<Tooltip.Content side="bottom" align={align}>
+						Align:
+						{' '}
+						{align}
+					</Tooltip.Content>
+				</Tooltip.Provider>
+			))}
+		</div>
+	),
+};
+
+export const WrappingInlineElement: Story = {
+	name: 'Wrapping an inline element',
+	args: { delayDuration: 200 },
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Use `<Tooltip.Trigger asChild>` to attach tooltip behavior to a non-button element without injecting an extra `<button>`. The citation pattern below preserves the original `<sup><a>` DOM, which matters for screen readers and inline typography.',
+			},
+		},
+	},
+	render: (args) => (
+		<p className="text-sm">
+			Reading text with a citation
+			<sup>
+				<Tooltip.Provider {...args}>
+					<Tooltip.Trigger asChild>
+						<a href="#source-1" className="ml-0.5 text-primary underline">
+							[1]
+						</a>
+					</Tooltip.Trigger>
+					<Tooltip.Content>Source: Smith et al., 2024</Tooltip.Content>
+				</Tooltip.Provider>
+			</sup>
+			{' '}
+			and more body text after it.
+		</p>
+	),
+};
+
+export const HoverToOpen: Story = {
+	name: 'Hover to open',
+	args: { delayDuration: 0 },
+	render: (args) => (
+		<Tooltip.Provider {...args}>
+			<Tooltip.Trigger>
+				<Button variant="outline">Hover target</Button>
+			</Tooltip.Trigger>
+			<Tooltip.Content>Tooltip is open</Tooltip.Content>
+		</Tooltip.Provider>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const trigger = canvas.getByRole('button', { name: 'Hover target' });
+		await userEvent.hover(trigger);
+		// Content portals to document.body, so query the document, not the canvas.
+		const content = await within(document.body).findByText('Tooltip is open');
+		await expect(content).toBeVisible();
+	},
+};
+
+export const KeyboardFocusToOpen: Story = {
+	name: 'Keyboard focus opens immediately',
+	args: { delayDuration: 700 },
+	render: (args) => (
+		<Tooltip.Provider {...args}>
+			<Tooltip.Trigger>
+				<Button variant="outline">Focus target</Button>
+			</Tooltip.Trigger>
+			<Tooltip.Content>Opened by keyboard</Tooltip.Content>
+		</Tooltip.Provider>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const trigger = canvas.getByRole('button', { name: 'Focus target' });
+		trigger.focus();
+		const content = await within(document.body).findByText('Opened by keyboard');
+		await expect(content).toBeVisible();
+	},
+};
+
+export const EscapeDismisses: Story = {
+	name: 'Escape dismisses',
+	args: { delayDuration: 0 },
+	render: (args) => (
+		<Tooltip.Provider {...args}>
+			<Tooltip.Trigger>
+				<Button variant="outline">Open then Escape</Button>
+			</Tooltip.Trigger>
+			<Tooltip.Content>Will close on Escape</Tooltip.Content>
+		</Tooltip.Provider>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const trigger = canvas.getByRole('button', { name: 'Open then Escape' });
+		trigger.focus();
+		await within(document.body).findByText('Will close on Escape');
+		await userEvent.keyboard('{Escape}');
+		await expect(trigger).toHaveFocus();
+	},
+};

--- a/packages/react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,122 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Tooltip } from './Tooltip';
+
+describe('tooltip', () => {
+	it('renders the provider and trigger with data-slot attributes', () => {
+		const { container } = render(
+			<Tooltip.Provider>
+				<Tooltip.Trigger>Trigger</Tooltip.Trigger>
+				<Tooltip.Content>Content</Tooltip.Content>
+			</Tooltip.Provider>,
+		);
+
+		expect(container.querySelector('[data-slot=\'tooltip-provider\']')).toBeInTheDocument();
+		expect(container.querySelector('[data-slot=\'tooltip-trigger\']')).toBeInTheDocument();
+	});
+
+	it('renders a <button> when asChild is omitted', () => {
+		const { container } = render(
+			<Tooltip.Provider>
+				<Tooltip.Trigger>Trigger</Tooltip.Trigger>
+				<Tooltip.Content>Content</Tooltip.Content>
+			</Tooltip.Provider>,
+		);
+
+		const trigger = container.querySelector('[data-slot=\'tooltip-trigger\']');
+		expect(trigger?.tagName).toBe('BUTTON');
+	});
+
+	it('asChild preserves the child element type instead of injecting a button', () => {
+		// US1 scenario 5: the citation pattern with <sup><a>...</a></sup> must
+		// keep the anchor tag so the original DOM and screen-reader semantics
+		// survive the wrapping.
+		const { container } = render(
+			<Tooltip.Provider>
+				<Tooltip.Trigger asChild>
+					<a href="#source" data-testid="citation-link">
+						[1]
+					</a>
+				</Tooltip.Trigger>
+				<Tooltip.Content>Source</Tooltip.Content>
+			</Tooltip.Provider>,
+		);
+
+		const link = container.querySelector('[data-testid=\'citation-link\']');
+		expect(link).not.toBeNull();
+		expect(link?.tagName).toBe('A');
+		expect(container.querySelector('button')).toBeNull();
+	});
+
+	it('asChild forwards the data-slot to the rendered child element', () => {
+		const { container } = render(
+			<Tooltip.Provider>
+				<Tooltip.Trigger asChild>
+					<a href="#anchor" data-testid="link">
+						[1]
+					</a>
+				</Tooltip.Trigger>
+				<Tooltip.Content>Tip</Tooltip.Content>
+			</Tooltip.Provider>,
+		);
+
+		const link = container.querySelector('[data-testid=\'link\']');
+		expect(link?.getAttribute('data-slot')).toBe('tooltip-trigger');
+	});
+
+	it('merges className from wrapper into the rendered trigger button', () => {
+		const { container } = render(
+			<Tooltip.Provider>
+				<Tooltip.Trigger className="my-trigger">Trigger</Tooltip.Trigger>
+				<Tooltip.Content>Content</Tooltip.Content>
+			</Tooltip.Provider>,
+		);
+
+		const trigger = container.querySelector('[data-slot=\'tooltip-trigger\']');
+		expect(trigger?.className).toContain('my-trigger');
+	});
+
+	it('exposes the compound shape with Provider, Trigger, and Content', () => {
+		expect(typeof Tooltip.Provider).toBe('function');
+		expect(typeof Tooltip.Trigger).toBe('function');
+		expect(typeof Tooltip.Content).toBe('function');
+	});
+
+	it('accepts custom delayDuration without throwing', () => {
+		// Default is 700ms; this also exercises the path where consumers
+		// override the delay. The actual delay timing is Base UI's
+		// responsibility — we just confirm the prop is accepted at the
+		// wrapper boundary.
+		expect(() =>
+			render(
+				<Tooltip.Provider delayDuration={150}>
+					<Tooltip.Trigger>Trigger</Tooltip.Trigger>
+					<Tooltip.Content>Content</Tooltip.Content>
+				</Tooltip.Provider>,
+			),
+		).not.toThrow();
+	});
+
+	it('accepts custom side and align on Content without throwing', () => {
+		// Defaults are 'top' and 'center' per the contract. Confirming all
+		// other documented values pass typecheck and render gives us safety
+		// against breaking the prop surface.
+		const sides = ['top', 'right', 'bottom', 'left'] as const;
+		const aligns = ['start', 'center', 'end'] as const;
+
+		for (const side of sides) {
+			for (const align of aligns) {
+				expect(() =>
+					render(
+						<Tooltip.Provider>
+							<Tooltip.Trigger>Trigger</Tooltip.Trigger>
+							<Tooltip.Content side={side} align={align}>
+								Content
+							</Tooltip.Content>
+						</Tooltip.Provider>,
+					),
+				).not.toThrow();
+			}
+		}
+	});
+});

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { Tooltip as TooltipPrimitive } from '@base-ui-components/react/tooltip';
+import * as React from 'react';
+
+import { cn } from '../../lib/cn';
+
+// Threads the Provider-level portal target down to Content's Portal without
+// asking consumers to pass it through both slots. Base UI's Provider only
+// shares delay grouping; container is a Portal-level concern, so we bridge it
+// here to keep our wrapper API single-pair-friendly per the contract.
+const TooltipContainerContext = React.createContext<HTMLElement | null | undefined>(undefined);
+
+interface TooltipProviderProps {
+	children?: React.ReactNode;
+	/**
+	 * Hover delay before the tooltip opens, in milliseconds. Keyboard focus
+	 * opens the tooltip immediately and ignores this value.
+	 */
+	delayDuration?: number;
+	/**
+	 * Portal mount target for `Tooltip.Content`. Defaults to `document.body`,
+	 * which lets the tooltip escape ancestors that clip overflow.
+	 */
+	container?: HTMLElement | null;
+	/**
+	 * Fires when the open state changes from any source (hover, focus, tap,
+	 * Escape, outside press).
+	 */
+	onOpenChange?: (open: boolean) => void;
+}
+
+function TooltipProvider({
+	children,
+	delayDuration = 700,
+	container,
+	onOpenChange,
+}: TooltipProviderProps) {
+	return (
+		<TooltipContainerContext value={container}>
+			<TooltipPrimitive.Provider delay={delayDuration}>
+				<TooltipPrimitive.Root
+					onOpenChange={
+						onOpenChange
+							? (open) => {
+									onOpenChange(open);
+								}
+							: undefined
+					}
+				>
+					<div data-slot="tooltip-provider" style={{ display: 'contents' }}>
+						{children}
+					</div>
+				</TooltipPrimitive.Root>
+			</TooltipPrimitive.Provider>
+		</TooltipContainerContext>
+	);
+}
+
+interface TooltipTriggerProps {
+	children?: React.ReactNode;
+	className?: string;
+	/**
+	 * When true, forwards trigger props to the single child element instead of
+	 * rendering an extra `<button>`. Required for citation patterns like
+	 * `<sup><a/></sup>` where the original DOM shape must be preserved.
+	 */
+	asChild?: boolean;
+}
+
+function TooltipTrigger({ asChild = false, className, children, ...props }: TooltipTriggerProps) {
+	if (asChild) {
+		const child = React.Children.only(children) as React.ReactElement<{ className?: string }>;
+		// Base UI's `render` prop replaces the underlying element. Passing the
+		// child element here is how we preserve the caller's DOM tag (e.g. an
+		// <a> inside a <sup>) while still attaching tooltip event handlers.
+		return (
+			<TooltipPrimitive.Trigger
+				data-slot="tooltip-trigger"
+				render={React.cloneElement(child, {
+					className: cn(className, child.props.className),
+				})}
+				{...props}
+			/>
+		);
+	}
+
+	return (
+		<TooltipPrimitive.Trigger
+			data-slot="tooltip-trigger"
+			className={cn(className)}
+			{...props}
+		>
+			{children}
+		</TooltipPrimitive.Trigger>
+	);
+}
+
+interface TooltipContentProps {
+	children?: React.ReactNode;
+	className?: string;
+	/**
+	 * Which edge of the trigger the content anchors against. Base UI flips this
+	 * automatically when the chosen edge would clip against the viewport.
+	 */
+	side?: 'top' | 'right' | 'bottom' | 'left';
+	/**
+	 * Alignment of the content along the chosen side. `'start'` and `'end'`
+	 * align to the leading and trailing edges of the trigger; `'center'`
+	 * centers along the axis.
+	 */
+	align?: 'start' | 'center' | 'end';
+}
+
+function TooltipContent({
+	children,
+	className,
+	side = 'top',
+	align = 'center',
+	...props
+}: TooltipContentProps) {
+	const container = React.use(TooltipContainerContext);
+
+	return (
+		<TooltipPrimitive.Portal container={container ?? undefined}>
+			<TooltipPrimitive.Positioner side={side} align={align} sideOffset={4}>
+				<TooltipPrimitive.Popup
+					data-slot="tooltip-content"
+					className={cn(
+						'z-50 w-fit origin-(--transform-origin) rounded-md bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md ring-1 ring-foreground/10 transition-[opacity,transform] duration-150 motion-reduce:transition-none motion-reduce:duration-0 data-instant:duration-0 data-open:opacity-100 data-closed:opacity-0',
+						className,
+					)}
+					{...props}
+				>
+					{children}
+				</TooltipPrimitive.Popup>
+			</TooltipPrimitive.Positioner>
+		</TooltipPrimitive.Portal>
+	);
+}
+
+const Tooltip = {
+	Provider: TooltipProvider,
+	Trigger: TooltipTrigger,
+	Content: TooltipContent,
+};
+
+export { Tooltip };
+export type { TooltipContentProps, TooltipProviderProps, TooltipTriggerProps };

--- a/packages/react/src/components/Tooltip/index.ts
+++ b/packages/react/src/components/Tooltip/index.ts
@@ -1,0 +1,6 @@
+export { Tooltip } from './Tooltip';
+export type {
+	TooltipContentProps,
+	TooltipProviderProps,
+	TooltipTriggerProps,
+} from './Tooltip';

--- a/packages/react/src/components/__ssr__.test.tsx
+++ b/packages/react/src/components/__ssr__.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * SSR smoke test for the four primitives added in spec 004.
+ *
+ * Constitution Section IX bullet 6 requires components to render server-side
+ * without accessing `window`, `document`, or other browser-only globals at
+ * render time. This file renders each component via `renderToString` and
+ * fails if any of them throws or accesses a browser global during render.
+ *
+ * Browser-API access in `useEffect` is fine — effects don't run during SSR.
+ */
+
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { SegmentedControl } from './SegmentedControl';
+import { SkipLink } from './SkipLink';
+import { Slider } from './Slider';
+import { Tooltip } from './Tooltip';
+
+describe('ssr safety (constitution §IX bullet 6)', () => {
+	it('renders Tooltip server-side without error', () => {
+		expect(() =>
+			renderToString(
+				<Tooltip.Provider>
+					<Tooltip.Trigger>Hover</Tooltip.Trigger>
+					<Tooltip.Content>Detail</Tooltip.Content>
+				</Tooltip.Provider>,
+			),
+		).not.toThrow();
+	});
+
+	it('renders SkipLink server-side without error', () => {
+		expect(() => renderToString(<SkipLink>Skip to main content</SkipLink>)).not.toThrow();
+	});
+
+	it('renders SkipLink as a real anchor with the right href on the server', () => {
+		const html = renderToString(<SkipLink targetId="main">Skip</SkipLink>);
+		expect(html).toContain('<a');
+		expect(html).toContain('href="#main"');
+	});
+
+	it('renders Slider server-side without error in single-value mode', () => {
+		expect(() =>
+			renderToString(
+				<Slider.Root defaultValue={[50]}>
+					<Slider.Control>
+						<Slider.Track>
+							<Slider.Indicator />
+						</Slider.Track>
+						<Slider.Thumb />
+					</Slider.Control>
+				</Slider.Root>,
+			),
+		).not.toThrow();
+	});
+
+	it('renders Slider server-side without error in range mode', () => {
+		expect(() =>
+			renderToString(
+				<Slider.Root defaultValue={[20, 80]}>
+					<Slider.Control>
+						<Slider.Track>
+							<Slider.Indicator />
+						</Slider.Track>
+						<Slider.Thumb />
+						<Slider.Thumb />
+					</Slider.Control>
+				</Slider.Root>,
+			),
+		).not.toThrow();
+	});
+
+	it('renders SegmentedControl server-side without error', () => {
+		expect(() =>
+			renderToString(
+				<SegmentedControl.Root defaultValue="b">
+					<SegmentedControl.Item value="a">A</SegmentedControl.Item>
+					<SegmentedControl.Item value="b">B</SegmentedControl.Item>
+					<SegmentedControl.Item value="c">C</SegmentedControl.Item>
+				</SegmentedControl.Root>,
+			),
+		).not.toThrow();
+	});
+});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,9 +5,13 @@ export * from './components/Checkbox';
 export * from './components/Dialog';
 export * from './components/Input';
 export * from './components/Label';
+export * from './components/SegmentedControl';
 export * from './components/Select';
+export * from './components/SkipLink';
+export * from './components/Slider';
 export * from './components/Switch';
 export * from './components/Tabs';
+export * from './components/Tooltip';
 export * from './components/VisuallyHidden';
 
 // Utilities

--- a/packages/react/src/lib/warn.test.ts
+++ b/packages/react/src/lib/warn.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { warn } from './warn';
+
+describe('warn', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('emits via console.warn with the [unbranded-ds] prefix', () => {
+		warn({ component: 'Slider', issue: 'value-out-of-range' });
+		expect(console.warn).toHaveBeenCalledWith(
+			'[unbranded-ds]',
+			expect.objectContaining({
+				component: 'Slider',
+				issue: 'value-out-of-range',
+			}),
+		);
+	});
+
+	it('passes through additional payload fields verbatim', () => {
+		warn({
+			component: 'Slider',
+			issue: 'value-out-of-range',
+			prop: 'value',
+			got: 150,
+			clamped: 100,
+		});
+		expect(console.warn).toHaveBeenCalledWith('[unbranded-ds]', {
+			component: 'Slider',
+			issue: 'value-out-of-range',
+			prop: 'value',
+			got: 150,
+			clamped: 100,
+		});
+	});
+
+	it('treats the payload as a plain object — no transformation', () => {
+		const payload = { component: 'SegmentedControl', issue: 'no-items' };
+		warn(payload);
+		const callArgs = vi.mocked(console.warn).mock.calls[0];
+		expect(callArgs?.[1]).toBe(payload);
+	});
+});

--- a/packages/react/src/lib/warn.ts
+++ b/packages/react/src/lib/warn.ts
@@ -1,0 +1,21 @@
+/**
+ * Emit a structured warning to the console for runtime validation failures.
+ *
+ * Used by components when an input is invalid but recoverable (e.g., Slider
+ * receiving a value outside [min, max] — clamped, then warned). Agents and
+ * dev tools parse the second argument as a JSON-shaped object directly, so
+ * the shape stays stable.
+ *
+ * The wrapper does not throw on invalid input — that would break consumer
+ * pages over a misconfiguration. See spec 004 FR-020 and FR-034.
+ */
+
+export interface WarnPayload {
+	component: string;
+	issue: string;
+	[key: string]: unknown;
+}
+
+export function warn(payload: WarnPayload): void {
+	console.warn('[unbranded-ds]', payload);
+}

--- a/specs/004-primitive-set-expansion/checklists/requirements.md
+++ b/specs/004-primitive-set-expansion/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Primitive set expansion
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- References to `@base-ui-components/react`, Tailwind, the `.sr-only` utility, and Changesets appear in the spec because each is a load-bearing constitution choice (Sections IV, VIII) or a shipped capability from a prior spec (002, 003). These are project realities the spec describes, not implementation decisions being made here.
+- No clarifications required. The brief at `tmp/spec-004-primitive-set-expansion.md` is thorough enough to specify without ambiguity. Sensible defaults are documented in the Assumptions section.
+- Spec amended 2026-05-16 in response to downstream feedback. The feedback added five clarifications: touch behavior for Tooltip and Slider (FR-007, FR-019), `asChild` over inline elements on Tooltip (US1 scenarios, FR-030 named story), Tooltip portal default and `container` passthrough (FR-008), multiple `<SkipLink>` instances on one page (FR-013, US2 scenario, FR-030 named story), and explicit Base UI slot-name parity (FR-036). No prop API was added; all amendments document Base UI defaults the wrapper inherits or pin previously-implicit constraints.
+- `/speckit.clarify` session 2026-05-16 resolved 11 questions across four domains (Tooltip, Slider, SegmentedControl, cross-cutting). All recorded in spec's `## Clarifications` section. The SSR-safety question prompted a constitution amendment (1.0.1 → 1.0.2) adding SSR safety as a new Section IX bullet, bundled into this spec's branch.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/004-primitive-set-expansion/contracts/SegmentedControl.md
+++ b/specs/004-primitive-set-expansion/contracts/SegmentedControl.md
@@ -1,0 +1,78 @@
+# Contract: SegmentedControl
+
+Public API exposed by `@unbranded-ds/react`'s SegmentedControl, as exported from `packages/react/src/components/SegmentedControl/index.ts` and re-exported from `packages/react/src/index.ts`.
+
+## Type signatures
+
+```ts
+import type * as React from 'react';
+
+interface SegmentedControlRootProps {
+	value?: string; // controlled
+	defaultValue?: string; // uncontrolled
+	onValueChange?: (value: string) => void;
+	size?: 'sm' | 'md' | 'lg'; // default 'md'
+	orientation?: 'horizontal' | 'vertical'; // default 'horizontal'
+	disabled?: boolean; // default false
+	children: React.ReactNode;
+	className?: string;
+}
+
+interface SegmentedControlItemProps {
+	value: string; // required
+	disabled?: boolean; // default false (per-item disable)
+	children: React.ReactNode;
+	className?: string;
+}
+
+declare const SegmentedControl: {
+	Root: React.FC<SegmentedControlRootProps>;
+	Item: React.FC<SegmentedControlItemProps>;
+};
+
+export { SegmentedControl };
+export type { SegmentedControlItemProps, SegmentedControlRootProps };
+```
+
+## Composition rules
+
+- `<SegmentedControl.Root>` holds one or more `<SegmentedControl.Item>` children
+- Each Item MUST have a unique `value` string
+- The Root accepts `value` (controlled) OR `defaultValue` (uncontrolled), not both
+
+## Behavior contract
+
+### Selection
+
+- Exactly one Item is selected at a time
+- Click on an Item → that Item becomes selected, the previously selected Item deselects
+- `onValueChange` fires with the new selected value
+
+### Keyboard (FR-025, strict axis)
+
+| Orientation | Key                      | Effect                                 |
+| ----------- | ------------------------ | -------------------------------------- |
+| Horizontal  | Left Arrow / Right Arrow | Move focus and selection between Items |
+| Horizontal  | Up Arrow / Down Arrow    | No-op                                  |
+| Vertical    | Up Arrow / Down Arrow    | Move focus and selection between Items |
+| Vertical    | Left Arrow / Right Arrow | No-op                                  |
+| Both        | Home                     | Jump to first Item                     |
+| Both        | End                      | Jump to last Item                      |
+
+### ARIA (FR-024)
+
+- `<SegmentedControl.Root>` exposes `role="radiogroup"`
+- Each `<SegmentedControl.Item>` exposes `role="radio"` with `aria-checked` reflecting selection
+- Disabled Root or Item: `aria-disabled="true"`
+
+### Edge cases
+
+- Fewer than three Items: renders normally with no warning (per spec edge case; the "three or more" guidance is advisory)
+- Zero Items: renders an empty wrapper and emits `console.warn('[unbranded-ds]', { component: 'SegmentedControl', issue: 'no-items' })`
+- Duplicate `value` strings across Items: Base UI's RadioGroup behavior applies (the first match wins for selection); not enforced or warned by the wrapper
+
+## What this contract does NOT cover
+
+- Multi-select. This is a single-select control by ARIA semantics; for multi-select, compose `<Checkbox>` elements instead.
+- Item-with-icon-only is supported (Item children accept any `ReactNode`), but the accessible name is the consumer's responsibility — add `aria-label` on the Item if children are purely decorative.
+- Animated indicator that visually slides between selected Items — out of scope for 0.3.0; consumers can layer this on via CSS if desired.

--- a/specs/004-primitive-set-expansion/contracts/SkipLink.md
+++ b/specs/004-primitive-set-expansion/contracts/SkipLink.md
@@ -1,0 +1,41 @@
+# Contract: SkipLink
+
+Public API exposed by `@unbranded-ds/react`'s SkipLink, as exported from `packages/react/src/components/SkipLink/index.ts` and re-exported from `packages/react/src/index.ts`.
+
+## Type signature
+
+```ts
+import type * as React from 'react';
+
+interface SkipLinkProps {
+	targetId?: string; // default 'main'
+	children?: React.ReactNode; // default 'Skip to main content'
+	className?: string;
+}
+
+declare const SkipLink: React.FC<SkipLinkProps>;
+
+export { SkipLink };
+export type { SkipLinkProps };
+```
+
+## Composition rules
+
+- `SkipLink` is rendered as the first focusable element on a page, typically inside the layout's outermost wrapper before navigation.
+- Multiple `SkipLink` instances may be rendered on the same page, each with its own `targetId`. Each instance is independent.
+- The component takes no opinion on how multiple instances stack visually. Layout is the consumer's responsibility.
+
+## Behavior contract
+
+- Renders as a native `<a href="#${targetId}">` element
+- Visually hidden via the `.sr-only` utility (from spec 002) when not focused
+- Visible when focused, via a `:focus-visible` CSS reveal — no JS required
+- Activation (Enter key or click) relies on native browser anchor behavior: scroll to and focus the matching element
+- Component does NOT call `preventDefault()` and does NOT perform programmatic scroll
+- If `targetId` references a non-existent element, activation is a no-op. The component does not throw or emit a warning; this is a graceful-degradation choice, since a missing target is a consumer misconfiguration that should never break the page.
+
+## What this contract does NOT cover
+
+- Smooth-scroll behavior: applies CSS `scroll-behavior: smooth` on `html` or `body` if desired, but the component does not configure this.
+- Custom scroll offset for fixed headers: a consumer-side concern; handle with CSS `scroll-margin-top` on the target element.
+- Automatic injection of the `id="main"` attribute on the consumer's main content element. The consumer must add this themselves.

--- a/specs/004-primitive-set-expansion/contracts/Slider.md
+++ b/specs/004-primitive-set-expansion/contracts/Slider.md
@@ -1,0 +1,119 @@
+# Contract: Slider
+
+Public API exposed by `@unbranded-ds/react`'s Slider, as exported from `packages/react/src/components/Slider/index.ts` and re-exported from `packages/react/src/index.ts`.
+
+## Type signatures
+
+```ts
+import type * as React from 'react';
+
+interface SliderRootProps {
+	value?: number[]; // controlled; e.g. [50] or [20, 80]
+	defaultValue?: number[]; // uncontrolled
+	min?: number; // default 0
+	max?: number; // default 100
+	step?: number; // default 1
+	onValueChange?: (value: number[]) => void;
+	size?: 'sm' | 'md' | 'lg'; // default 'md'
+	orientation?: 'horizontal' | 'vertical'; // default 'horizontal'
+	disabled?: boolean; // default false
+	children?: React.ReactNode;
+	className?: string;
+}
+
+interface SliderControlProps {
+	children?: React.ReactNode;
+	className?: string;
+}
+
+interface SliderTrackProps {
+	children?: React.ReactNode;
+	className?: string;
+}
+
+interface SliderIndicatorProps {
+	className?: string;
+}
+
+interface SliderThumbProps {
+	className?: string;
+}
+
+declare const Slider: {
+	Root: React.FC<SliderRootProps>;
+	Control: React.FC<SliderControlProps>;
+	Track: React.FC<SliderTrackProps>;
+	Indicator: React.FC<SliderIndicatorProps>;
+	Thumb: React.FC<SliderThumbProps>;
+};
+
+export { Slider };
+export type {
+	SliderControlProps,
+	SliderIndicatorProps,
+	SliderRootProps,
+	SliderThumbProps,
+	SliderTrackProps,
+};
+```
+
+## Composition rules
+
+- Single-value: one `<Slider.Thumb>` inside `<Slider.Control>`
+- Range (two-thumb): two `<Slider.Thumb>` elements inside `<Slider.Control>`
+- `<Slider.Indicator>` is optional. Include it when a filled-portion visualization is desired; omit for a thumb-only slider.
+- `<Slider.Track>` can hold the `<Slider.Indicator>` as a child or render the Indicator as a sibling, depending on the layout the design calls for.
+- TypeScript marks `children` as optional on `Slider.Root` and `Slider.Control` for the same Storybook-typing reason noted in the Tooltip contract. Runtime composition still requires the slot tree.
+
+## Value shape
+
+- `value` and `defaultValue` are ALWAYS `number[]`
+- Single-value usage: `[50]`
+- Range usage: `[20, 80]`
+- `onValueChange` receives the same shape
+
+## Behavior contract
+
+### Validation (FR-020)
+
+- `value[i]` outside `[min, max]` → clamped to nearest valid value, emits `console.warn('[unbranded-ds]', { component: 'Slider', issue: 'value-out-of-range', prop: 'value', got, clamped })`
+- `step <= 0` → falls back to `1`, emits `{ component: 'Slider', issue: 'invalid-step', got, fallback: 1 }`
+- `min >= max` → swaps to `[min, min+1]`, emits `{ component: 'Slider', issue: 'invalid-bounds', min, max, swappedTo }`
+- Component never throws on invalid props
+
+### Keyboard (FR-018)
+
+| Key                     | Effect                                                     |
+| ----------------------- | ---------------------------------------------------------- |
+| Arrow Up / Arrow Right  | Increment by `step`                                        |
+| Arrow Down / Arrow Left | Decrement by `step`                                        |
+| Home                    | Jump to `min`                                              |
+| End                     | Jump to `max`                                              |
+| PageUp                  | Increment by 10% of `(max - min)`, rounded to nearest step |
+| PageDown                | Decrement by 10% of `(max - min)`, rounded to nearest step |
+
+### Touch (FR-019)
+
+- Tap on track → focused thumb jumps to tapped position
+- Drag a thumb with finger → continuous value change
+- All input modes (pointer, keyboard, touch) resolve to the same `onValueChange` pathway
+
+### Range collision
+
+When dragging one thumb past another, the dragged thumb stops at the other's current value minus one step. The thumbs cannot cross.
+
+### ARIA (FR-021)
+
+- Each thumb exposes `role="slider"`, `aria-valuemin`, `aria-valuemax`, `aria-valuenow`
+- Range mode: each thumb carries its own ARIA values independently
+
+### Disabled state
+
+- No drag, no keyboard, no focus on thumbs
+- Each thumb carries `aria-disabled="true"`
+
+## What this contract does NOT cover
+
+- Visible numeric value labels — the consumer renders these via a separate node if needed; the Slider itself does not include a label slot
+- Tooltip-on-thumb showing current value — compose with `<Tooltip>` over a `<Slider.Thumb>` if desired
+- Tick marks or visible track stops — out of scope for 0.3.0

--- a/specs/004-primitive-set-expansion/contracts/Tooltip.md
+++ b/specs/004-primitive-set-expansion/contracts/Tooltip.md
@@ -1,0 +1,60 @@
+# Contract: Tooltip
+
+Public API exposed by `@unbranded-ds/react`'s Tooltip, as exported from `packages/react/src/components/Tooltip/index.ts` and re-exported from `packages/react/src/index.ts`.
+
+## Type signatures
+
+```ts
+import type * as React from 'react';
+
+interface TooltipProviderProps {
+	children?: React.ReactNode;
+	delayDuration?: number; // default 700ms
+	container?: HTMLElement | null; // portal target, default document.body
+	onOpenChange?: (open: boolean) => void;
+}
+
+interface TooltipTriggerProps {
+	asChild?: boolean; // default false
+	children?: React.ReactNode;
+	className?: string;
+}
+
+interface TooltipContentProps {
+	side?: 'top' | 'right' | 'bottom' | 'left'; // default 'top'
+	align?: 'start' | 'center' | 'end'; // default 'center'
+	children?: React.ReactNode;
+	className?: string;
+}
+
+declare const Tooltip: {
+	Provider: React.FC<TooltipProviderProps>;
+	Trigger: React.FC<TooltipTriggerProps>;
+	Content: React.FC<TooltipContentProps>;
+};
+
+export { Tooltip };
+export type { TooltipContentProps, TooltipProviderProps, TooltipTriggerProps };
+```
+
+## Composition rules
+
+- `Tooltip.Trigger` and `Tooltip.Content` MUST be descendants of a `Tooltip.Provider`. Rendering them outside throws via Base UI.
+- One `Tooltip.Provider` hosts one Trigger and one Content. The wrapper collapses Base UI's `Provider` + `Root` into the single `Tooltip.Provider` slot, so each tooltip instance gets its own Provider. Consumers needing several tooltips render several Providers.
+- `Tooltip.Trigger asChild` requires exactly one child element. Multiple or zero children throw a React error from Base UI.
+- TypeScript marks `children` as optional on all three slot prop interfaces. Storybook's `Meta<typeof Tooltip.Provider>` inference treats `args` as partial, so requiring `children` at the type level produced spurious typecheck errors in stories whose `render` function supplies children directly. Runtime usage still requires the slot composition; the type relaxation is only an authoring concern.
+
+## Behavior contract
+
+- Hover the Trigger → Content opens after `delayDuration` ms
+- Focus the Trigger via keyboard → Content opens immediately, no delay
+- Escape while Content is open → Content closes, focus stays on Trigger
+- Tap the Trigger on touch → Content toggles (tap-to-toggle); tap outside → Content closes
+- `prefers-reduced-motion: reduce` → open and close transitions are instant via Tailwind `motion-reduce:` override
+- Content portals to `document.body` by default, escaping ancestor `overflow: hidden`
+
+## What this contract does NOT cover
+
+- Z-index stacking is deferred to a future z-index token spec. Consumers override via CSS if needed.
+- Animation curves and durations beyond `motion-reduce` are Tailwind built-ins for now; DS motion tokens land after spec 006.
+- Authored a11y label for the trigger when `asChild` wraps a non-interactive element — the consumer is responsible for ensuring the child element is focusable and has an accessible name.

--- a/specs/004-primitive-set-expansion/data-model.md
+++ b/specs/004-primitive-set-expansion/data-model.md
@@ -1,0 +1,215 @@
+# Data Model: Primitive set expansion
+
+This document describes the structural model — components, slot composition, props, internal state, events — for the four new primitives. There is no persisted data; the "model" here is React component shape.
+
+## Tooltip
+
+**Composition**: `<Tooltip.Provider>` wraps one or more `<Tooltip.Trigger>` + `<Tooltip.Content>` pairs. Wraps Base UI's Tooltip primitives.
+
+### Slot components
+
+| Slot | Underlying Base UI | Role |
+|---|---|---|
+| `<Tooltip.Provider>` | `Tooltip.Provider` | Configuration boundary (delayDuration, portal container) |
+| `<Tooltip.Trigger>` | `Tooltip.Trigger` | The element that opens the tooltip on hover, focus, or tap |
+| `<Tooltip.Content>` | `Tooltip.Content` | The floating panel |
+
+### Props — Provider
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `delayDuration` | `number` | `700` | Hover-open delay in milliseconds |
+| `container` | `HTMLElement \| null` | `document.body` | Portal mount target |
+| `onOpenChange` | `(open: boolean) => void` | — | Pass-through from Base UI |
+
+### Props — Trigger
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `asChild` | `boolean` | `false` | When true, passes props to the single child instead of injecting a `<button>` |
+| `className` | `string` | — | Merged via `cn()` |
+
+### Props — Content
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `side` | `'top' \| 'right' \| 'bottom' \| 'left'` | `'top'` | Position relative to trigger |
+| `align` | `'start' \| 'center' \| 'end'` | `'center'` | Alignment along the side |
+| `className` | `string` | — | Merged via `cn()` |
+
+### State
+
+Open / closed, managed entirely by Base UI. The wrapper does not introduce wrapper-controlled state.
+
+### Events
+
+The wrapper does not add new events. Base UI's `onOpenChange` on the Provider is exposed.
+
+### Behavior contracts
+
+- Touch: inherits Base UI's default tap-to-toggle with outside-tap dismissal (FR-007)
+- Reduced motion: Tailwind `motion-reduce:transition-none motion-reduce:duration-0` applied to Content open and close (FR-004)
+- Portal: Content portals to `document.body` by default, escaping `overflow: hidden` ancestors (FR-008)
+
+---
+
+## SkipLink
+
+**Composition**: A single component, not slot-based. Renders a native `<a href="#${targetId}">` element underneath.
+
+### Props
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `targetId` | `string` | `'main'` | The `id` of the element to jump to |
+| `children` | `ReactNode` | `'Skip to main content'` | The link text |
+| `className` | `string` | — | Merged via `cn()` |
+
+### State
+
+No internal state. Visibility is driven by the CSS `:focus-visible` pseudo-class, not by component state.
+
+### Events
+
+Native anchor `onClick`. The wrapper does NOT call `preventDefault()`. Native browser anchor navigation handles focus and scroll on activation.
+
+### Behavior contracts
+
+- Visually hidden until focused, using the `.sr-only` utility (FR-009)
+- Revealed on `:focus-visible` (FR-009)
+- Activation moves keyboard focus and viewport scroll to the target element via browser-native behavior (FR-011)
+- Multiple instances on the same page work independently; the wrapper takes no layout opinion (FR-013)
+- If `targetId` references a non-existent element, activation is a no-op — no throw, no warning
+
+---
+
+## Slider
+
+**Composition**: `<Slider.Root>` contains a `<Slider.Control>`, which contains a `<Slider.Track>` (optionally wrapping a `<Slider.Indicator>`) and one or two `<Slider.Thumb>` elements. Wraps Base UI's Slider primitives.
+
+### Slot components
+
+| Slot | Underlying Base UI | Role |
+|---|---|---|
+| `<Slider.Root>` | `Slider.Root` | Container; holds value state |
+| `<Slider.Control>` | `Slider.Control` | The interactive surface where pointer and touch events are captured |
+| `<Slider.Track>` | `Slider.Track` | Visual track background |
+| `<Slider.Indicator>` | `Slider.Indicator` | Filled portion of the track |
+| `<Slider.Thumb>` | `Slider.Thumb` | Draggable handle; one for single-value, two for range |
+
+### Props — Root
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `value` | `number[]` | — | Controlled. Single-value: `[50]`; range: `[20, 80]` |
+| `defaultValue` | `number[]` | `[min]` | Uncontrolled |
+| `min` | `number` | `0` | Lower bound (inclusive) |
+| `max` | `number` | `100` | Upper bound (inclusive) |
+| `step` | `number` | `1` | Increment for keyboard and drag |
+| `onValueChange` | `(value: number[]) => void` | — | Fired on every value change |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | CVA size axis |
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | CVA orientation axis |
+| `disabled` | `boolean` | `false` | Disables drag, keyboard, and focus on thumbs |
+| `className` | `string` | — | Merged via `cn()` |
+
+### Props — Control, Track, Indicator, Thumb
+
+All accept `className` (merged via `cn()`). Track accepts `children` (commonly the Indicator). Thumb is self-closing.
+
+### Validation behavior (FR-020)
+
+- A `value[i]` outside `[min, max]` is clamped to the nearest valid value. Emits `console.warn('[unbranded-ds]', { component: 'Slider', issue: 'value-out-of-range', prop: 'value', got, clamped })`
+- `step <= 0` falls back to `1`. Emits `{ component: 'Slider', issue: 'invalid-step', got, fallback: 1 }`
+- `min >= max` swaps to `[min, min+1]`. Emits `{ component: 'Slider', issue: 'invalid-bounds', min, max, swappedTo }`
+- Component never throws on invalid props
+
+### Keyboard (FR-018)
+
+| Key | Effect |
+|---|---|
+| Arrow Up / Arrow Right | Increment focused thumb by `step` |
+| Arrow Down / Arrow Left | Decrement focused thumb by `step` |
+| Home | Jump focused thumb to `min` |
+| End | Jump focused thumb to `max` |
+| PageUp | Increment by 10% of `(max - min)`, rounded to nearest step |
+| PageDown | Decrement by 10% of `(max - min)`, rounded to nearest step |
+
+### Touch (FR-019)
+
+- Tap on track → focused thumb jumps to tapped position
+- Drag a thumb with finger → continuous value change
+- All input modes (pointer, keyboard, touch) resolve to the same `onValueChange` pathway
+
+### Range thumb collision
+
+When dragging one thumb past another, the dragged thumb stops at the other's current value minus one step. The thumbs cannot cross.
+
+### ARIA (FR-021)
+
+- Each thumb exposes `role="slider"`, `aria-valuemin`, `aria-valuemax`, `aria-valuenow`
+- Range mode: each thumb has independent ARIA values
+
+---
+
+## SegmentedControl
+
+**Composition**: `<SegmentedControl.Root>` contains two or more `<SegmentedControl.Item>` children. Wraps Base UI's RadioGroup primitives.
+
+### Slot components
+
+| Slot | Underlying Base UI | Role |
+|---|---|---|
+| `<SegmentedControl.Root>` | `RadioGroup.Root` | Container; holds selected value |
+| `<SegmentedControl.Item>` | `RadioGroup.Item` | A single option |
+
+### Props — Root
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `value` | `string` | — | Controlled selected value |
+| `defaultValue` | `string` | — | Uncontrolled initial selected value |
+| `onValueChange` | `(value: string) => void` | — | Fired on selection change |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | CVA size axis |
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | CVA orientation axis |
+| `disabled` | `boolean` | `false` | Disables all items |
+| `className` | `string` | — | Merged via `cn()` |
+
+### Props — Item
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `value` | `string` | — | Required. The value this item represents |
+| `disabled` | `boolean` | `false` | Per-item disable |
+| `children` | `ReactNode` | — | Visible label |
+| `className` | `string` | — | Merged via `cn()` |
+
+### ARIA (FR-024)
+
+- `<SegmentedControl.Root>` exposes `role="radiogroup"`
+- Each `<SegmentedControl.Item>` exposes `role="radio"` with `aria-checked`
+- Disabled Root or Item: `aria-disabled="true"`
+
+### Keyboard (FR-025, strict axis)
+
+| Orientation | Key | Effect |
+|---|---|---|
+| Horizontal | Left Arrow / Right Arrow | Move focus and selection between items |
+| Horizontal | Up Arrow / Down Arrow | No-op |
+| Vertical | Up Arrow / Down Arrow | Move focus and selection between items |
+| Vertical | Left Arrow / Right Arrow | No-op |
+| Both | Home | Jump to first item |
+| Both | End | Jump to last item |
+
+### Edge cases
+
+- Fewer than three items: renders normally, no warning (per spec edge case; the "three or more" guidance is advisory)
+- Zero items: renders empty wrapper, emits `console.warn('[unbranded-ds]', { component: 'SegmentedControl', issue: 'no-items' })`
+
+---
+
+## Cross-component invariants
+
+- Slot names match Base UI's exactly (FR-036)
+- Variant prop names use the shared vocabulary `variant`, `size`, `intent`, `disabled` (FR-037); no bespoke synonyms
+- All wrappers are SSR-safe: no `window`, `document`, or other browser-only global access at render time (Constitution Section IX bullet 6)
+- All structured warnings use `console.warn('[unbranded-ds]', payload)` with `payload` shaped as `{ component, issue, ... }` (FR-034)

--- a/specs/004-primitive-set-expansion/plan.md
+++ b/specs/004-primitive-set-expansion/plan.md
@@ -1,0 +1,147 @@
+# Implementation Plan: Primitive set expansion
+
+**Branch**: `004-primitive-set-expansion` | **Date**: 2026-05-16 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/004-primitive-set-expansion/spec.md`
+
+## Summary
+
+Add four React components — Tooltip, SkipLink, Slider, SegmentedControl — to `@unbranded-ds/react`. Tooltip and Slider wrap Base UI primitives. SegmentedControl wraps Base UI's RadioGroup with segmented-control visual styling. SkipLink is a thin in-house component built on a native `<a href>` plus the `.sr-only` utility from spec 002. All four follow the existing slot-and-variant patterns, ship in a bundled `@unbranded-ds/react@0.3.0` release, and meet Constitution Section IX DoD (including the SSR-safety gate added in 1.0.2 alongside this spec). Constitution Section XI is not yet ratified, but its bridge rules — predictable slot and prop naming, humanizer pass on autodocs, no prose three-item lists, structured failure output — apply to this work per the spec's brief.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, strict mode, no `any` (Constitution Section VIII)
+
+**Primary Dependencies**:
+
+- `@base-ui-components/react` — peer dependency. Tooltip primitive (Provider/Trigger/Content), Slider primitive (Root/Control/Track/Indicator/Thumb), RadioGroup primitive (Root/Item)
+- `react` and `react-dom` 18+ — peer dependencies
+- `@unbranded-ds/tokens@^0.2.0` — Tailwind preset + CSS variables
+- `class-variance-authority` (`cva`) — variant logic
+- `clsx` + `tailwind-merge` exposed as `cn()` — class composition
+- `tsup` — ESM-only build
+- Tailwind CSS v4 via `@unbranded-ds/react/preset.css`
+
+**Storage**: N/A (component library; no persisted data)
+
+**Testing**:
+
+- Vitest — unit tests in `packages/react`
+- Storybook Test addon — interaction tests via `play` functions
+- `@storybook/addon-a11y` + test-runner — accessibility tests with zero `serious` or `critical` violations gate
+
+**Target Platform**: Modern evergreen browsers (Chrome, Firefox, Safari, Edge — current and one prior major), with SSR safety for Next.js, Remix, and other server-rendering React frameworks (Constitution Section IX #6)
+
+**Project Type**: React component library (sub-package within pnpm monorepo)
+
+**Performance Goals**: Each new component adds negligible runtime cost beyond the wrapped Base UI primitive. Combined gzipped bundle-size target for the four together: under 8 KB. No formal latency target — component interaction must feel instant.
+
+**Constraints**:
+
+- WCAG 2.2 AA across all stories for the four new components (axe rule enforces serious and critical violations)
+- SSR-safe — no `window` or `document` access at render time (Constitution Section IX #6)
+- No hardcoded colors, radii, spacing, font sizes, or shadows (existing lint rule)
+- No new wrapper API for things Base UI already exposes (FR-036 slot-name parity)
+- All four components ship in one `@unbranded-ds/react@0.3.0` release; the Version Packages PR opened by Changesets is held until all four merge
+
+**Scale/Scope**:
+
+- 4 new components added to the existing 10 components
+- ~16–20 stories total across the four (Default + variant stories + named stories per FR-030)
+- ~16–24 unit tests covering CVA, `cn()` merging, and wrapper-specific logic
+- ~12–16 play function assertions covering primary interactions
+- 1 constitution amendment item (Section IX #6 SSR safety) bundled in this branch
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution version at planning time: **1.0.2** (amended on this branch to add Section IX #6 SSR safety; see `.specify/memory/constitution.md` SYNC IMPACT REPORT).
+
+| Section | Gate | Status | Notes |
+|---|---|---|---|
+| I. Repository shape | No new packages | Pass | All work in `packages/react`; no new top-level packages |
+| II. Tokens independent of components | Tokens unchanged | Pass | No edits to `packages/tokens` |
+| III. Theming contract | No new theming surface | Pass | Components consume tokens via the Tailwind preset |
+| IV. Components thin and unopinionated | Base UI wraps, tokens only, `className` merged via `cn()`, no `@unbranded-ds/tokens` runtime import | Pass | Tooltip, Slider, and SegmentedControl wrap Base UI primitives; SkipLink is a native `<a>` + `.sr-only` |
+| V. Stories source of truth | Default + variants + play function + autodocs | Pass | FR-030 names required stories per component; FR-031 mandates humanizer pass |
+| VI. Testing — three layers | Unit + interaction + a11y | Pass | All three required by FR-030 and FR-033 |
+| VII. Deployment and MCP | No MCP surface change | Pass | New components surface through existing `@storybook/addon-mcp` |
+| VIII. Tooling baseline | Per Section VIII | Pass | No tool substitutions |
+| IX. DoD per component | All nine bullets | Pass | Including new bullet 6 (SSR safety) |
+| X. Governance | Constitution Check + per-PR changeset | Pass | Branch amends constitution; each component PR adds a `.changeset/*.md` declaring `@unbranded-ds/react: minor` |
+
+No violations. Complexity tracking section below stays empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-primitive-set-expansion/
+├── plan.md                    # This file
+├── spec.md                    # Feature specification
+├── research.md                # Phase 0 output
+├── data-model.md              # Phase 1 output
+├── quickstart.md              # Phase 1 output
+├── contracts/                 # Phase 1 output
+│   ├── Tooltip.md
+│   ├── SkipLink.md
+│   ├── Slider.md
+│   └── SegmentedControl.md
+├── checklists/
+│   └── requirements.md        # Spec quality checklist
+└── tasks.md                   # Phase 2 output, created by /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+packages/react/src/
+├── components/
+│   ├── Tooltip/                       # NEW (this spec)
+│   │   ├── Tooltip.tsx
+│   │   ├── Tooltip.stories.tsx
+│   │   ├── Tooltip.test.tsx
+│   │   └── index.ts
+│   ├── SkipLink/                      # NEW (this spec)
+│   │   ├── SkipLink.tsx
+│   │   ├── SkipLink.stories.tsx
+│   │   ├── SkipLink.test.tsx
+│   │   └── index.ts
+│   ├── Slider/                        # NEW (this spec)
+│   │   ├── Slider.tsx
+│   │   ├── Slider.stories.tsx
+│   │   ├── Slider.test.tsx
+│   │   └── index.ts
+│   ├── SegmentedControl/              # NEW (this spec)
+│   │   ├── SegmentedControl.tsx
+│   │   ├── SegmentedControl.stories.tsx
+│   │   ├── SegmentedControl.test.tsx
+│   │   └── index.ts
+│   ├── Button/                        # existing (0.1.0)
+│   ├── Card/                          # existing (0.1.0)
+│   ├── Checkbox/                      # existing (0.1.0)
+│   ├── Dialog/                        # existing (0.1.0)
+│   ├── Input/                         # existing (0.1.0)
+│   ├── Label/                         # existing (0.1.0)
+│   ├── Select/                        # existing (0.1.0)
+│   ├── Switch/                        # existing (0.1.0)
+│   ├── Tabs/                          # existing (0.1.0)
+│   └── VisuallyHidden/                # existing (0.2.0, from spec 002)
+├── lib/                               # existing utilities (cn(), etc.)
+└── index.ts                           # add 4 new re-exports
+
+.changeset/                            # per-PR changesets, see FR-038
+├── add-tooltip.md                     # @unbranded-ds/react: minor
+├── add-skiplink.md                    # @unbranded-ds/react: minor
+├── add-slider.md                      # @unbranded-ds/react: minor
+└── add-segmentedcontrol.md            # @unbranded-ds/react: minor
+```
+
+**Structure Decision**: Each component is its own directory under `packages/react/src/components/`, matching the pattern from 0.1.0 and 0.2.0. The directory contains exactly the four files mandated by FR-027 (`<Component>.tsx`, `<Component>.stories.tsx`, `<Component>.test.tsx`, `index.ts`). Each component is re-exported from `packages/react/src/index.ts` (FR-028).
+
+Each component lands as one PR with its own `.changeset/*.md` file declaring a minor bump on `@unbranded-ds/react`. The four changesets coalesce into the same `@unbranded-ds/react@0.3.0` release once the Version Packages PR is merged (FR-038, SC-006). A separate changeset for the constitution amendment is unnecessary because the constitution lives outside `packages/*` — the existing `changeset-check.yml` gate does not require a changeset for `.specify/memory/` changes.
+
+## Complexity Tracking
+
+No violations. The plan stays within constitution.

--- a/specs/004-primitive-set-expansion/quickstart.md
+++ b/specs/004-primitive-set-expansion/quickstart.md
@@ -1,0 +1,188 @@
+# Quickstart: Primitive set expansion
+
+Minimal working examples for the four new components in `@unbranded-ds/react@0.3.0`. Each example aims for five lines or fewer of import-and-use code (SC-001).
+
+## Install
+
+```bash
+pnpm add @unbranded-ds/react@^0.3.0 @unbranded-ds/tokens@^0.2.0 @base-ui-components/react react react-dom
+```
+
+Wire the Tailwind preset once (already done if you migrated from 0.1.0 per spec 002):
+
+```css
+@import 'tailwindcss';
+@import '@unbranded-ds/react/preset.css';
+```
+
+## Tooltip
+
+```tsx
+import { Tooltip } from '@unbranded-ds/react';
+
+<Tooltip.Provider>
+  <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+  <Tooltip.Content>Helpful detail</Tooltip.Content>
+</Tooltip.Provider>
+```
+
+### Wrapping an inline element (citation pattern)
+
+```tsx
+<Tooltip.Provider>
+  <sup>
+    <Tooltip.Trigger asChild>
+      <a href="#source-P-04">[P-04]</a>
+    </Tooltip.Trigger>
+  </sup>
+  <Tooltip.Content>Spencer interview, NPR 2017</Tooltip.Content>
+</Tooltip.Provider>
+```
+
+`asChild` passes the trigger props onto the existing `<a>`, so the original markup is preserved.
+
+### Positioning
+
+```tsx
+<Tooltip.Content side="right" align="start">Detail</Tooltip.Content>
+```
+
+Defaults are `side="top"` and `align="center"`.
+
+## SkipLink
+
+```tsx
+import { SkipLink } from '@unbranded-ds/react';
+
+<SkipLink>Skip to main content</SkipLink>
+<main id="main">...</main>
+```
+
+### Multiple skip targets
+
+```tsx
+<SkipLink targetId="main">Skip to main</SkipLink>
+<SkipLink targetId="nav">Skip to navigation</SkipLink>
+<SkipLink targetId="footer">Skip to footer</SkipLink>
+```
+
+Layout the instances however you want — the component takes no layout opinion.
+
+## Slider
+
+### Single-value
+
+```tsx
+import { Slider } from '@unbranded-ds/react';
+
+<Slider.Root defaultValue={[50]} min={0} max={100}>
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+    </Slider.Track>
+    <Slider.Thumb />
+  </Slider.Control>
+</Slider.Root>
+```
+
+### Range (two-thumb)
+
+```tsx
+<Slider.Root defaultValue={[20, 80]} min={0} max={100}>
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+    </Slider.Track>
+    <Slider.Thumb />
+    <Slider.Thumb />
+  </Slider.Control>
+</Slider.Root>
+```
+
+### Controlled
+
+```tsx
+const [value, setValue] = useState<number[]>([50]);
+
+<Slider.Root value={value} onValueChange={setValue}>
+  <Slider.Control>
+    <Slider.Track><Slider.Indicator /></Slider.Track>
+    <Slider.Thumb />
+  </Slider.Control>
+</Slider.Root>
+```
+
+`value` is always `number[]` — single is `[50]`, range is `[20, 80]`. `onValueChange` receives the same shape.
+
+## SegmentedControl
+
+```tsx
+import { SegmentedControl } from '@unbranded-ds/react';
+
+<SegmentedControl.Root defaultValue="medium">
+  <SegmentedControl.Item value="small">S</SegmentedControl.Item>
+  <SegmentedControl.Item value="medium">M</SegmentedControl.Item>
+  <SegmentedControl.Item value="large">L</SegmentedControl.Item>
+</SegmentedControl.Root>
+```
+
+### Controlled with onValueChange
+
+```tsx
+const [size, setSize] = useState('medium');
+
+<SegmentedControl.Root value={size} onValueChange={setSize}>
+  <SegmentedControl.Item value="small">S</SegmentedControl.Item>
+  <SegmentedControl.Item value="medium">M</SegmentedControl.Item>
+  <SegmentedControl.Item value="large">L</SegmentedControl.Item>
+</SegmentedControl.Root>
+```
+
+## Variants
+
+The shared variant axes apply where they're meaningful:
+
+```tsx
+<Slider.Root size="lg" orientation="vertical">...</Slider.Root>
+<SegmentedControl.Root size="sm" orientation="horizontal">...</SegmentedControl.Root>
+```
+
+`disabled` is supported on Slider and SegmentedControl Roots, and per-item on `SegmentedControl.Item`.
+
+## Common compositions
+
+### Slider with tooltip showing current value
+
+```tsx
+<Slider.Root value={value} onValueChange={setValue}>
+  <Slider.Control>
+    <Slider.Track><Slider.Indicator /></Slider.Track>
+    <Tooltip.Provider>
+      <Tooltip.Trigger asChild>
+        <Slider.Thumb />
+      </Tooltip.Trigger>
+      <Tooltip.Content>{value[0]}</Tooltip.Content>
+    </Tooltip.Provider>
+  </Slider.Control>
+</Slider.Root>
+```
+
+Combines the inline-element pattern (`asChild` on a Slider.Thumb) with a tooltip that reflects the controlled value.
+
+## Bundle size
+
+The combined gzipped size for the four components together targets under 8 KB. Each component is tree-shakeable, so importing only what you use keeps the cost proportional.
+
+## SSR
+
+All four components are safe to render server-side (Constitution Section IX bullet 6 — added in 1.0.2 alongside this spec). They access `window` and `document` only inside post-mount effects, never at render time. Next.js, Remix, and other SSR frameworks should work without `'use client'` boundaries on these wrappers, though framework-level rules may still require the directive on consumer code that uses state.
+
+## Errors and warnings
+
+If you pass invalid props, the component does not throw — it clamps to a sensible value and emits a structured warning to `console.warn` for dev-tool and agent consumption:
+
+```text
+[unbranded-ds] { component: 'Slider', issue: 'value-out-of-range', prop: 'value', got: 150, clamped: 100 }
+```
+
+The second argument to `console.warn` is always a plain object with at least `{ component, issue }`.

--- a/specs/004-primitive-set-expansion/research.md
+++ b/specs/004-primitive-set-expansion/research.md
@@ -1,0 +1,185 @@
+# Research: Primitive set expansion
+
+This document records the technical decisions made during planning for spec 004. The spec is fully clarified — eleven questions were resolved during `/speckit.clarify` on 2026-05-16, recorded in spec.md's `## Clarifications` section. This file captures the implementation-level decisions that shape how those clarifications get realized.
+
+## Decision: Wrap Base UI Tooltip primitives for `<Tooltip>`
+
+**Decision**: `<Tooltip>` exposes `Provider`, `Trigger`, and `Content` slot components that pass through to `@base-ui-components/react`'s Tooltip primitives. The wrapper adds CVA variant styling and the tokens-driven visual treatment.
+
+**Rationale**:
+
+- Constitution Section IV mandates Base UI as the primitive source for components in this package
+- Base UI handles open and close state, escape-to-dismiss, hover and focus triggers, portal mounting, and touch behavior (tap-to-toggle, outside-tap dismissal)
+- Spec FR-036 requires exact slot-name parity with Base UI; the wrapper's `Trigger` is Base UI's `Trigger`
+- `asChild` pass-through preserves the inline-element wrapping pattern needed by US1 acceptance scenario 5
+
+**Alternatives considered**:
+
+- Rolling our own tooltip on top of the native `popover` API or Floating UI directly: rejected because it duplicates effort, ties us to browser support nuances, and creates a divergent API surface from the rest of the package
+- Wrapping Radix Tooltip instead of Base UI: rejected per Constitution Section IV (Base UI variant of shadcn/ui only)
+
+## Decision: Wrap Base UI Slider primitives for `<Slider>`
+
+**Decision**: `<Slider>` exposes `Root`, `Control`, `Track`, `Thumb`, and `Indicator` slot components from `@base-ui-components/react`'s Slider. The wrapper supports both single-value (`value: [50]`) and range (`value: [20, 80]`) usage from day one of 0.3.0.
+
+**Rationale**:
+
+- Base UI's Slider handles drag, pointer events, touch (tap-to-position, drag-with-finger), keyboard (Arrow keys, Home, End, PageUp, PageDown), and ARIA labeling on each thumb
+- Range support is built in via a multi-thumb configuration on `Slider.Root`
+- Always-array shape for `value` and `defaultValue` (FR-016, clarification Round 2 Q1) matches Base UI's pattern and gives `onValueChange` a single signature
+
+**Alternatives considered**:
+
+- Native HTML `<input type="range">`: rejected because the native element cannot do range (two-thumb) mode without pairing two inputs, which loses the connected ARIA semantics
+- Discriminated-union value shape (`number` for single, `[number, number]` for range): rejected during clarification — uniform `number[]` is simpler for consumers and matches Base UI
+
+## Decision: Wrap Base UI RadioGroup for `<SegmentedControl>`
+
+**Decision**: `<SegmentedControl>` exposes `Root` and `Item` slot components that pass through to `@base-ui-components/react`'s RadioGroup primitives. The wrapper styles them as a connected, pill-shaped segmented control via CVA + Tailwind utilities. ARIA semantics use `role="radiogroup"` with `role="radio"` items (FR-024).
+
+**Rationale**:
+
+- Mutually-exclusive selection from a fixed set is the exact ARIA model of a radio group; the visual difference between "radio buttons" and "segmented control" is purely Tailwind styling
+- Base UI's RadioGroup handles focus management, roving-tabindex, and arrow-key navigation; we constrain the navigation to strict-axis arrows per FR-025 (clarification Round 3 Q2)
+- Slot names `Root` and `Item` match Base UI's RadioGroup exactly, satisfying FR-036
+- Rolling our own with `<input type="radio">` plus styled labels would duplicate Base UI's keyboard and focus work
+
+**Alternatives considered**:
+
+- Roll our own using native `<input type="radio">` elements with styled labels: rejected because Base UI's RadioGroup already gives us correct ARIA, focus management, and keyboard behavior for free
+- Wrap Base UI's Tabs primitive: rejected — Tabs has different semantics (tabpanel content, value-keyed visibility) that do not fit a presentation-only selection control
+
+## Decision: Implement `<SkipLink>` as a native anchor, no Base UI wrapper
+
+**Decision**: `<SkipLink>` renders a native `<a href="#${targetId}">` element with the `.sr-only` utility (from spec 002) for the hidden state and a `focus-visible` reveal for the focused state. The component does NOT call `preventDefault()` or perform programmatic scroll.
+
+**Rationale**:
+
+- Resolved during clarification (Round 4 Q4) — native browser behavior is sufficient
+- Activating an anchor with a matching fragment ID natively scrolls to and focuses the target element
+- No JS required for the core a11y pattern, which preserves graceful degradation when JS fails
+- Base UI does not expose a SkipLink primitive (it's an a11y idiom, not a UI primitive), which justifies the in-house implementation — and the surface area is genuinely tiny (≈10 lines plus styles)
+- The `.sr-only` utility shipping in 0.2.0 already covers the visually-hidden state
+
+**Alternatives considered**:
+
+- Button with programmatic focus and scroll: rejected during clarification — loses no-JS behavior and reintroduces complexity (manual focus calls, manual scroll behavior) for no a11y or UX benefit
+- Anchor with `preventDefault()` and custom scroll behavior: rejected — the spec calls out browser-native focus and scroll as authoritative (FR-011)
+
+## Decision: Structured warning format
+
+**Decision**: All structured warnings emit via `console.warn('[unbranded-ds]', payload)` where `payload` is a plain JSON-shaped object containing at minimum `{ component: string, issue: string }` and additional context-specific fields. No separate `report()` API. No custom window events.
+
+**Rationale**:
+
+- Resolved during clarification (Round 4 Q1)
+- Agents and dev tools parse the `console.warn` second argument as an object literal directly
+- No new wrapper API surface to learn, maintain, or document
+- Production-build strip via dead-code elimination is trivial if a future spec wants it (wrap calls in a `__DEV__` flag), but not required for 0.3.0
+
+**Alternatives considered**:
+
+- Dedicated `report(event)` utility function: rejected — adds wrapper-specific API consumers would have to learn
+- Custom `window.dispatchEvent` event: rejected — devtools-only path, requires consumers to opt into a listener, console output goes silent
+
+**Payload shape examples** (per-component details in `data-model.md`):
+
+```ts
+// Slider out-of-range
+{ component: 'Slider', issue: 'value-out-of-range', prop: 'value', got: 150, clamped: 100 }
+
+// Slider invalid step
+{ component: 'Slider', issue: 'invalid-step', got: -2, fallback: 1 }
+
+// Slider invalid bounds
+{ component: 'Slider', issue: 'invalid-bounds', min: 50, max: 10, swappedTo: [50, 51] }
+
+// SegmentedControl empty item set
+{ component: 'SegmentedControl', issue: 'no-items' }
+```
+
+## Decision: SSR safety via post-mount-only browser-API access
+
+**Decision**: Every component renders server-side without accessing `window`, `document`, or other browser-only globals at render time. All browser-API access (focus management, viewport queries, portal-target lookup) happens inside `useEffect` or `useLayoutEffect` post-mount.
+
+**Rationale**:
+
+- Codified in Constitution Section IX bullet 6 (added 1.0.2 alongside this spec)
+- Base UI primitives are already SSR-safe; the wrapper inherits and must not regress
+- React 18's `useId` is available where stable IDs are needed during render, so we never need `Math.random()` or DOM lookups for ID generation
+
+**Alternatives considered**:
+
+- Conditional `typeof window !== 'undefined'` checks scattered throughout render: rejected — leaks hydration mismatches and is harder to audit
+- A blanket `'use client'` directive: out of scope — that is a Next.js-specific concern, not a wrapper-package concern. Consumers add the directive in their app code if their framework needs it.
+
+## Decision: Reduced-motion handling for `<Tooltip>` transitions
+
+**Decision**: When `prefers-reduced-motion: reduce` is true, the Tooltip open and close transitions are skipped entirely (instant show and hide). Tailwind's `motion-reduce:` variant applies the override directly in CSS.
+
+**Rationale**:
+
+- Resolved during clarification (Round 1 Q3)
+- WCAG SC 2.3.3 compliance
+- Tailwind v4 has the `motion-reduce:` modifier built in; no JS required to detect the OS preference
+- A CSS-only approach avoids hydration mismatches and runtime cost
+
+**Alternatives considered**:
+
+- Shorten the transition to ~50ms instead of skipping: rejected — partial motion can still bother sensitive users; the spec's standard is "skip"
+- JS-based detection via `matchMedia('(prefers-reduced-motion: reduce)')`: rejected — CSS-only is cheaper, avoids a re-render, and works on initial paint
+
+## Decision: CVA variants follow the shared vocabulary
+
+**Decision**: All four components use `class-variance-authority` with the shared vocabulary:
+
+- `size`: `'sm' | 'md' | 'lg'` (Slider, SegmentedControl)
+- `orientation`: `'horizontal' | 'vertical'` (Slider, SegmentedControl)
+- `disabled`: `boolean` (Slider, SegmentedControl; SkipLink and Tooltip do not have a meaningful disabled state)
+
+Tooltip has no `size` or `orientation` CVA variants — its positioning is via `side` and `align` props on `Tooltip.Content`, which are pass-through to Base UI and not CVA axes. SkipLink has no CVA variants at all — its visible state is focus-driven, not a variant.
+
+**Rationale**:
+
+- FR-037 (shared variant vocabulary)
+- Consistency with existing Button, Card, Input, Switch, Tabs, etc.
+
+**Alternatives considered**:
+
+- Per-component bespoke variant names (e.g., `tone`, `weight`): rejected — explicitly prohibited by FR-037
+
+## Decision: Storybook story patterns
+
+**Decision**: Each component ships with the following stories at minimum:
+
+- **Default** — the simplest working render
+- **Variant stories** — one story per CVA variant axis (e.g., "Sizes", "Orientations", "Disabled")
+- **State stories** where applicable (e.g., "Range" for Slider, "Multiple Items Selected" not applicable since SegmentedControl is single-select)
+- **Required named stories** per FR-030:
+  - Tooltip: "Wrapping an inline element" — demonstrates `<Tooltip.Trigger asChild>` over a non-button child
+  - SkipLink: "Multiple skip targets" — three SkipLinks pointing at different `targetId`s
+  - Slider: a touch-event play function variant using `pointerType: 'touch'`, verifying tap-to-position and drag-with-finger
+
+**Rationale**:
+
+- Constitution Section V: stories are the contract surface for documentation, manual QA, interaction tests, accessibility tests, and MCP introspection
+- Spec FR-030 mandates the named stories
+
+**Alternatives considered**:
+
+- One sprawling kitchen-sink story per component: rejected — autodocs work better with discrete stories per variant, and play functions need focused setup
+
+## Decision: Per-PR changeset granularity
+
+**Decision**: Each of the four component PRs adds its own `.changeset/*.md` file declaring `@unbranded-ds/react: minor`. The Version Packages PR opened by Changesets after each merge is held until all four merge, so the four bumps coalesce into one `0.3.0` release.
+
+**Rationale**:
+
+- FR-038 and SC-006 require a single bundled release
+- Each PR independently satisfies the `changeset-check.yml` gate
+- Per-PR changesets give each component its own CHANGELOG entry once Changesets processes the release
+
+**Alternatives considered**:
+
+- One bundled changeset on the last PR: rejected — earlier PRs would fail the changeset-check gate
+- Four separate minor releases (0.3.0 → 0.6.0): rejected per spec — the four are part of one cohesive scope

--- a/specs/004-primitive-set-expansion/spec.md
+++ b/specs/004-primitive-set-expansion/spec.md
@@ -1,0 +1,217 @@
+# Feature Specification: Primitive set expansion
+
+**Feature Branch**: `004-primitive-set-expansion`
+**Created**: 2026-05-16
+**Status**: Draft
+**Input**: User description: "Primitive set expansion — add Tooltip, SkipLink, Slider, and SegmentedControl components" (full brief at `tmp/spec-004-primitive-set-expansion.md`)
+
+## Clarifications
+
+### Session 2026-05-16
+
+- Q: What should `<Tooltip.Provider delayDuration>` default to? → A: 700ms (matches Base UI's default)
+- Q: What should `<Tooltip.Content side>` default to? → A: `top` (matches Base UI; most conventional)
+- Q: How should Tooltip handle `prefers-reduced-motion: reduce`? → A: Skip the transition entirely (instant show/hide per WCAG SC 2.3.3)
+- Q: What shape should `<Slider value>` and `defaultValue` use? → A: Always `number[]` (single is `[50]`, range is `[20, 80]`); matches Base UI
+- Q: How should Slider handle invalid configurations (`step <= 0`, `min >= max`)? → A: Same clamp-and-warn pattern as out-of-range values; component keeps rendering
+- Q: How should `<SegmentedControl>` behave with fewer than three items? → A: Render normally, no warning (the "three or more" guidance is advisory)
+- Q: Which arrow keys navigate `<SegmentedControl>`? → A: Strict axis — horizontal uses Left/Right only, vertical uses Up/Down only (WAI-ARIA radiogroup pattern)
+- Q: What does a "structured warning" look like in practice? → A: `console.warn('[unbranded-ds]', { component, issue, prop, ... })` — no new wrapper API surface; second arg is a JSON-shaped object
+- Q: Is RTL support in scope for 0.3.0? → A: Inherit Base UI's RTL handling for wrapped primitives; no wrapper-added RTL tests in this release. Documented as an assumption.
+- Q: Should the spec require SSR safety as an explicit FR? → A: SSR safety is a cross-cutting expectation, not spec-004-specific. Codified in Constitution Section IX (amended to 1.0.2 on 2026-05-16 alongside this spec) — all components in `packages/react` render server-side without `window` / `document` access at render time.
+- Q: How should `<SkipLink>` be implemented? → A: Native `<a href="#targetId">` element relying on browser anchor behavior for focus and scroll; no `preventDefault`, no programmatic scroll
+
+## User Scenarios & Testing _(mandatory)_
+
+Four consumer-facing user stories, one per component. Each is independently shippable: a consumer who needs only one of these primitives gets full value from the corresponding PR. The recommended ship order matches priority (Tooltip first, SegmentedControl last), but no story depends on another's code.
+
+### User Story 1 - Tooltip for contextual help (Priority: P1)
+
+A consumer building a DS-driven application needs to show short contextual information when a user hovers or focuses an element. Examples include citation hovers in a research UI, control labels on a complex form, and icon-button explanations.
+
+Today the consumer must wire `@base-ui-components/react`'s Tooltip primitive themselves, style it from scratch against tokens, and verify keyboard and screen-reader behavior. After this feature, importing `<Tooltip>` from `@unbranded-ds/react` delivers a token-styled, ARIA-compliant tooltip with one line of import.
+
+**Why this priority**: Tooltip is the highest-demand primitive in the for-coleman feedback, has the smallest design surface of the four, and unblocks the citation hover and control-label patterns that appear in nearly every consumer integration.
+
+**Independent Test**: A consumer adds `<Tooltip.Provider>`, `<Tooltip.Trigger>`, and `<Tooltip.Content>` to a page. Hovering or keyboard-focusing the trigger reveals the content. Pressing Escape dismisses it. Axe reports no `serious` or `critical` violations.
+
+**Acceptance Scenarios**:
+
+1. **Given** a page with a Tooltip wrapping a button, **When** a user hovers the button with a pointer, **Then** the tooltip content appears after the configured delay and disappears on pointer leave
+2. **Given** a page with a Tooltip wrapping a button, **When** a keyboard user tabs focus to the button, **Then** the tooltip content appears without requiring hover and disappears on blur
+3. **Given** an open tooltip, **When** the user presses Escape, **Then** the tooltip closes and focus remains on the trigger
+4. **Given** a tooltip with `side="top"` and `align="center"`, **When** the tooltip opens, **Then** it renders above the trigger and is horizontally centered relative to it
+5. **Given** a `<Tooltip.Trigger asChild>` wrapping a non-button inline element (`<sup>`, `<a>`, or `<span>`), **When** the user hovers or focuses that element, **Then** the tooltip opens and the original DOM shape is preserved (no extra `<button>` is injected)
+6. **Given** a Tooltip rendered inside a container with `overflow: hidden`, **When** the tooltip opens, **Then** its content is not clipped by the container, because the content portals out to `document.body`
+
+---
+
+### User Story 2 - SkipLink for keyboard accessibility (Priority: P2)
+
+A consumer building any keyboard-accessible page needs a "skip to main content" link as the first focusable element so that screen-reader and keyboard-only users can bypass long navigation. WCAG 2.4.1 requires this pattern; building it correctly involves a focus-visible reveal of an otherwise-hidden link plus a programmatic jump to a content anchor.
+
+Today the consumer either rolls this by hand or skips it entirely (which fails an a11y audit). After this feature, importing `<SkipLink>` and placing it at the top of the layout delivers the pattern without any custom CSS or focus management.
+
+**Why this priority**: A11y staple required for WCAG compliance. The implementation is small (roughly ten lines plus styles), the design has no debatable surface, and it complements the `.sr-only` utility shipped in spec 002.
+
+**Independent Test**: A consumer renders `<SkipLink>` as the first child of their layout. Pressing Tab on page load reveals the link and focuses it; pressing Enter scrolls and focuses the element matching `targetId` (default `main`).
+
+**Acceptance Scenarios**:
+
+1. **Given** a page with `<SkipLink>` placed before all other interactive content, **When** a keyboard user presses Tab once after page load, **Then** the SkipLink becomes visible and receives focus
+2. **Given** a focused SkipLink with the default `targetId` of `main`, **When** the user presses Enter, **Then** the viewport scrolls to and focuses the element with `id="main"`
+3. **Given** a SkipLink with `targetId="content"` and a corresponding `<main id="content">`, **When** the user activates the link, **Then** focus moves to that element
+4. **Given** a SkipLink that has not yet been focused, **When** the page renders, **Then** the link is visually hidden but remains in the DOM and accessible to screen readers
+5. **Given** a page with three SkipLinks pointing to different `targetId`s, **When** the user tabs through them, **Then** each is independently focusable and activatable, and pressing Enter on any one moves focus to its own target
+
+---
+
+### User Story 3 - Slider for numeric range input (Priority: P3)
+
+A consumer building UIs with continuous numeric controls (audio volume, BPM, color hue, opacity, threshold sliders) needs a draggable slider that also supports keyboard input. The for-coleman application has three concrete uses: tempo control, jungle-mode tempo, and chop velocity.
+
+Today, building a slider that handles drag, keyboard arrows, Home/End, PageUp/PageDown, ARIA labeling, and value display is a significant per-application investment. After this feature, importing `<Slider>` delivers all of that with token-driven styling.
+
+**Why this priority**: Real demand in the for-coleman scorecard. Largest design surface of the four (track, thumb, indicator, optional value display, optional second thumb for range mode), which is why it ships third rather than first. Tooltip and SkipLink land faster and clear the way.
+
+**Independent Test**: A consumer renders `<Slider>` with min, max, step, and a default value. Drag changes the value; arrow keys increment and decrement by step; Home and End jump to min and max. A range variant accepts two values and renders two thumbs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Slider with `min=0`, `max=100`, `step=1`, `defaultValue=50`, **When** a user presses Right Arrow while the thumb is focused, **Then** the value becomes 51
+2. **Given** the same Slider, **When** the user presses Home, **Then** the value becomes 0; **When** the user presses End, **Then** the value becomes 100
+3. **Given** the same Slider, **When** a user drags the thumb along the track, **Then** the value updates continuously and the indicator visually reflects the new position
+4. **Given** a range Slider with two values `[20, 80]`, **When** the user focuses the lower thumb and presses Right Arrow, **Then** only the lower value increments and the upper value is unchanged
+5. **Given** a disabled Slider, **When** the user attempts to drag or use keyboard, **Then** the value does not change and the thumb does not receive focus
+
+---
+
+### User Story 4 - SegmentedControl for mutually-exclusive selection (Priority: P4)
+
+A consumer needs a connected, multi-option control where exactly one option is selected at a time. The canonical use case is the upcoming ThemeToggle in spec 008 (light, dark, system), but the primitive is generic: view-mode toggles, filter sets, and segmented navigation are all common patterns.
+
+Today the consumer either uses radio inputs (correct semantics, wrong visual) or styled buttons with manual ARIA wiring (correct visual, fragile semantics). After this feature, importing `<SegmentedControl>` delivers a connected control with radio-input semantics under the hood.
+
+**Why this priority**: Lower immediate demand than the others, but ships now because spec 008's ThemeToggle composes this primitive. Landing it here unblocks 008 without requiring a primitive-only release in between.
+
+**Independent Test**: A consumer renders `<SegmentedControl.Root defaultValue="medium">` with three `<SegmentedControl.Item value="small|medium|large">` children. Clicking an item changes the selection; arrow keys navigate; only one item is selected at any time.
+
+**Acceptance Scenarios**:
+
+1. **Given** a SegmentedControl with three items and the middle one selected, **When** the user clicks the first item, **Then** the first item becomes selected and the middle item deselects
+2. **Given** the same control with focus on the selected item, **When** the user presses Right Arrow, **Then** the next item receives focus and becomes selected
+3. **Given** the same control, **When** rendered as HTML, **Then** it is announced as a radiogroup with the correct number of options to assistive technology
+4. **Given** a disabled SegmentedControl, **When** the user attempts to interact, **Then** no selection change occurs and items do not receive focus
+
+---
+
+### Edge Cases
+
+- **Tooltip with empty or undefined content**: The component renders nothing and emits no portal node, rather than an empty bubble.
+- **SkipLink target does not exist**: If the element matching `targetId` is missing, activation is a no-op. The component does not throw, since runtime errors would break consumer pages over a misconfiguration.
+- **Slider value out of bounds**: A controlled value below `min` or above `max` is clamped to the nearest valid value, and the component emits a structured warning identifying the prop, the offending value, and the clamped result.
+- **Slider with `step` larger than `max - min`**: The slider snaps to `min` and `max` as the only valid stops; arrow keys jump between them.
+- **Range Slider with thumb collision**: When dragging one thumb past the other, the thumbs do not cross; the dragged thumb stops at the other's current value minus one step.
+- **SegmentedControl with two items**: Renders and behaves correctly with no warning. The "three or more" guidance from the brief is advisory, not a component-enforced constraint.
+- **SegmentedControl with no items**: Renders an empty wrapper and emits a structured warning.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+**Tooltip**
+
+- **FR-001**: `<Tooltip>` MUST expose `Trigger`, `Content`, and `Provider` slot components matching the existing slot vocabulary across the package
+- **FR-002**: `<Tooltip.Content>` MUST accept a `side` prop with values `top`, `right`, `bottom`, `left` (default: `top`) and an `align` prop with values `start`, `center`, `end` (default: `center`)
+- **FR-003**: `<Tooltip.Provider>` MUST accept a `delayDuration` prop (numeric, milliseconds) that controls how long the user must hover before the tooltip opens. Default: `700` (matches Base UI).
+- **FR-004**: Tooltip open and close transitions MUST use Tailwind's built-in duration utilities in this release; a follow-up after spec 006 will migrate to DS motion tokens. When the user's `prefers-reduced-motion: reduce` is set, the wrapper MUST skip the transition entirely (instant show/hide), per WCAG SC 2.3.3.
+- **FR-005**: Tooltip MUST be dismissable by pressing Escape, with focus remaining on the trigger
+- **FR-006**: Tooltip MUST be reachable and dismissable via keyboard alone
+- **FR-007**: On touch devices, Tooltip MUST inherit Base UI's default tap-to-toggle behavior with outside-tap dismissal. The wrapper MUST NOT override this behavior or expose alternate touch modes via prop. Designs that need inline content on small screens render that content directly rather than wrapping it in Tooltip.
+- **FR-008**: Tooltip content MUST portal to `document.body` by default, escaping ancestor `overflow: hidden` or `overflow: clip` boundaries. Base UI's `container` prop on `Tooltip.Provider` MUST pass through to allow consumers to mount the portal at a different node. Default stacking-context defers to consumer CSS for this release; a z-index token spec will land in a future release.
+
+**SkipLink**
+
+- **FR-009**: `<SkipLink>` MUST render visually hidden when not focused and visible when focused, using the `.sr-only` utility from spec 002 plus a `focus-visible` reveal
+- **FR-010**: `<SkipLink>` MUST accept a `targetId` prop (default `main`) identifying the element to jump to on activation
+- **FR-011**: `<SkipLink>` MUST be implemented as a native `<a href="#${targetId}">` element. Activation MUST rely on browser anchor behavior to move keyboard focus and viewport scroll to the target. The wrapper MUST NOT call `preventDefault()` or perform programmatic scroll — this preserves no-JS behavior and avoids divergence from native focus semantics.
+- **FR-012**: `<SkipLink>` MUST remain accessible to screen readers even when visually hidden
+- **FR-013**: Multiple `<SkipLink>` instances on the same page MUST work independently, each pointing at its own `targetId`. The component MUST NOT take a layout opinion on how multiple instances render together; composing their layout is the consumer's responsibility.
+
+**Slider**
+
+- **FR-014**: `<Slider>` MUST expose `Root`, `Control`, `Track`, `Thumb`, and `Indicator` slot components
+- **FR-015**: `<Slider>` MUST support single-value usage (one thumb, one value) and range usage (two thumbs, two values) from this release
+- **FR-016**: `<Slider>` MUST accept `min`, `max`, `step`, `value` (controlled), `defaultValue` (uncontrolled), and an `onValueChange` callback. `value` and `defaultValue` MUST be `number[]` in all cases: single-value usage uses a one-element array (`[50]`), range usage uses a two-element array (`[20, 80]`). The `onValueChange` callback receives the same shape.
+- **FR-017**: `<Slider>` MUST support the variant axes `size` (`sm`, `md`, `lg`), `orientation` (`horizontal`, `vertical`), and `disabled` (boolean)
+- **FR-018**: `<Slider>` MUST support keyboard interaction: Arrow keys change by `step`, Home and End jump to min and max, PageUp and PageDown change by a larger increment (10% of range by default)
+- **FR-019**: `<Slider>` MUST support touch input: tap-to-position on the track and drag-with-finger on the thumb. All input modes (pointer drag, keyboard, touch) resolve to the same value-change pathway.
+- **FR-020**: When a controlled value is outside `[min, max]`, `<Slider>` MUST clamp the value and emit a structured warning per FR-034 with `{ component: 'Slider', issue: 'value-out-of-range', prop, got, clamped }`. The same clamp-and-warn pattern MUST apply to other invalid configurations: `step <= 0` falls back to `1` (`issue: 'invalid-step'`); `min >= max` swaps to `[min, min+1]` (`issue: 'invalid-bounds'`). The component MUST keep rendering; invalid props are never grounds for throwing.
+- **FR-021**: `<Slider>` MUST be ARIA-compliant: each thumb exposes `role="slider"`, `aria-valuemin`, `aria-valuemax`, and `aria-valuenow`
+
+**SegmentedControl**
+
+- **FR-022**: `<SegmentedControl>` MUST expose `Root` and `Item` slot components
+- **FR-023**: `<SegmentedControl>` MUST support the variant axes `size` (`sm`, `md`, `lg`), `orientation` (`horizontal`, `vertical`), and `disabled` (boolean)
+- **FR-024**: `<SegmentedControl>` MUST be implemented on radio-input semantics (`role="radiogroup"` with `role="radio"` items) so assistive technology announces it correctly
+- **FR-025**: `<SegmentedControl>` MUST support keyboard navigation following the WAI-ARIA radiogroup pattern. In horizontal orientation, Left and Right Arrow move focus and selection between items; in vertical orientation, Up and Down Arrow do the same. Cross-axis arrow keys are no-ops. Home and End jump to the first and last items in both orientations.
+- **FR-026**: `<SegmentedControl>` MUST allow controlled (`value` + `onValueChange`) and uncontrolled (`defaultValue`) usage
+
+**Cross-cutting (applies to all four components)**
+
+- **FR-027**: Each component MUST live in `packages/react/src/components/<Component>/` with at minimum `index.ts`, `<Component>.tsx`, `<Component>.stories.tsx`, and `<Component>.test.tsx`
+- **FR-028**: Each component MUST be re-exported from `packages/react/src/index.ts`
+- **FR-029**: Each component MUST style itself entirely through Tailwind utilities that resolve to tokens; the existing lint rule against hardcoded colors, radii, spacing, font sizes, and shadows applies
+- **FR-030**: Each component's Storybook page MUST include a Default story plus one story per meaningful variant or state, and at least one `play` function exercising the primary interaction. Required named stories: a "Wrapping an inline element" story on Tooltip demonstrating `<Tooltip.Trigger asChild>` over a non-button child; a "Multiple skip targets" story on SkipLink exercising tab-through behavior across multiple instances; a touch-event play function variant on Slider (using `pointerType: 'touch'`) that verifies tap-to-position and drag-with-finger.
+- **FR-031**: Each component's autodocs prose MUST be written for both human and agent audiences and MUST pass a humanizer review before merge
+- **FR-032**: Autodocs prose MUST NOT contain three-item prose enumerations; variant enums with three options (e.g., `size: 'sm' | 'md' | 'lg'`) are code lists and are exempt
+- **FR-033**: Each component MUST report zero `serious` or `critical` axe violations across all of its stories
+- **FR-034**: Where a component performs runtime validation (e.g., Slider out-of-range values), it MUST emit a structured warning via `console.warn('[unbranded-ds]', payload)` where `payload` is a plain JSON-shaped object with at minimum `{ component: string, issue: string }` and additional fields describing the context. Agents and dev tools parsing the console can read the second argument directly. The wrapper MUST NOT add a separate `report()` API or custom window events for this.
+- **FR-035**: Slot component names MUST match across components: a `Root` is a `Root` everywhere, a `Trigger` is a `Trigger` everywhere, an `Item` is an `Item` everywhere
+- **FR-036**: Slot names MUST also match Base UI's primitive slot names exactly — no renames, no aliases. Base UI's composition documentation is authoritative for slot composition. The wrapper adds CVA-driven styling and variants only.
+- **FR-037**: Variant prop names MUST use the shared vocabulary (`variant`, `size`, `intent`, `disabled`); bespoke synonyms are not allowed
+- **FR-038**: Each component PR MUST include a `.changeset/*.md` file declaring `@unbranded-ds/react: minor`; the Version Packages PR is held until all four merge and ships them together in `@unbranded-ds/react@0.3.0`
+
+### Key Entities
+
+- **Tooltip**: A floating-content primitive composed of `Trigger`, `Content`, and `Provider`. Attributes: position (`side`, `align`), delay (`delayDuration`), open state. Wraps `@base-ui-components/react`'s Tooltip primitives.
+- **SkipLink**: A keyboard-only navigation primitive. Attributes: `targetId`, focus-visible state, accessible label. Built directly on the `.sr-only` utility plus a focus-reveal pattern.
+- **Slider**: A numeric-range input primitive composed of `Root`, `Control`, `Track`, `Thumb`, and `Indicator`. Attributes: `min`, `max`, `step`, `value` or `defaultValue` (single or two-element for range), `orientation`, `size`, `disabled`. Wraps `@base-ui-components/react`'s Slider primitives.
+- **SegmentedControl**: A mutually-exclusive selection primitive composed of `Root` and `Item`. Attributes: `value` or `defaultValue`, item set, `orientation`, `size`, `disabled`. Built on radio-input semantics.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A consumer can render a working Tooltip, SkipLink, Slider, or SegmentedControl in five lines or fewer of import-and-use code, with no custom CSS required
+- **SC-002**: Keyboard-only users can complete every primary interaction in every component (open and dismiss Tooltip, activate SkipLink, change Slider value, change SegmentedControl selection) without a pointer
+- **SC-003**: Every story across the four components reports zero `serious` or `critical` axe violations in CI
+- **SC-004**: The for-coleman scorecard moves from 4 of 6 to 5 of 6 component-coverage items after this release lands; the remaining item (ThemeToggle) is unblocked by SegmentedControl
+- **SC-005**: An agent querying the published MCP endpoint can retrieve autodocs for each of the four new components, with prop descriptions sufficient to compose a working example without reading source
+- **SC-006**: All four components ship in a single `@unbranded-ds/react@0.3.0` release; the Version Packages PR opened by Changesets is held until each of the four component PRs has merged to main
+
+## Assumptions
+
+- All four components ship in the same `@unbranded-ds/react@0.3.0` release. Each PR adds its own changeset declaring a minor bump on `@unbranded-ds/react`; the Version Packages PR is held until all four merge, so the four bumps coalesce into one minor.
+- The Slider supports both single-value and range modes from day one of 0.3.0, per the for-coleman brief. Range mode is not deferred.
+- Tooltip touch-device behavior follows Base UI's primitive defaults (long-press to open, tap-outside to close). The wrapper does not override this.
+- The recommended PR order (Tooltip, SkipLink, Slider, SegmentedControl) reflects priority and review-cost ordering. The components have no code-level dependencies on each other, so a parallel-implementation track is feasible if reviewer bandwidth allows.
+- Constitution Section XI is not yet ratified. The bridge rules listed in the brief (predictable slot and prop naming, humanizer on autodocs, no prose three-item lists, structured failure output) apply to this work as if Section XI were live.
+- Sidecar `*.usage.md` files are not part of this spec. They land in spec 005's retrofit, which will be informed by the four components shipped here.
+- The Toast / Status region, the `<VisuallyHidden>` component as a public export, and the Form wrapper are deferred to later specs and are explicitly out of scope.
+- RTL (right-to-left language) behavior is inherited from Base UI's primitive handling for Tooltip and Slider. The wrapper adds no RTL-specific logic and the spec does not require RTL-specific story coverage in 0.3.0. Components must not break when rendered in an RTL context, but verification is on the consumer until a future spec adds explicit RTL test coverage.
+
+## Dependencies
+
+- Spec 002 (consumer DX preset) must be live, since SkipLink uses the `.sr-only` utility that 002 wired up. Shipped as `@unbranded-ds/tokens@0.2.0` and `@unbranded-ds/react@0.2.0` on 2026-05-15 and manually published to npm on 2026-05-16.
+- Spec 003 (versioning workflow) must be live, since this spec is the first to use the Changesets-managed release flow and the new `changeset-check.yml` PR gate. Merged to main 2026-05-16.
+- `@base-ui-components/react` provides the underlying Tooltip and Slider primitives.
+
+## Out of Scope
+
+- Toast / Status region — deferred to a dedicated future spec covering portaling, queueing, and ARIA live regions
+- `<VisuallyHidden>` component as a public export — the `.sr-only` Tailwind utility shipped in spec 002 covers the common case
+- Form wrapper — deferred until there is a clear opinion on field-level error patterns
+- ThemeToggle — lands in spec 008, which composes the SegmentedControl shipped here
+- Sidecar `*.usage.md` files — land in spec 005's retrofit
+- DS motion tokens for the Tooltip transition — Tailwind's built-in duration utilities are used in this release; a follow-up after spec 006 ships motion tokens will migrate

--- a/specs/004-primitive-set-expansion/tasks.md
+++ b/specs/004-primitive-set-expansion/tasks.md
@@ -1,0 +1,242 @@
+# Tasks: Primitive set expansion
+
+**Input**: Design documents from `/specs/004-primitive-set-expansion/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/Tooltip.md, contracts/SkipLink.md, contracts/Slider.md, contracts/SegmentedControl.md, quickstart.md
+
+**Tests**: Unit tests are required per Constitution Section VI and spec FR-027; interaction tests via Storybook `play` functions are required per FR-030; accessibility tests via the axe story-runner are required per FR-033. Test tasks are included throughout.
+
+**Organization**: Tasks are grouped by user story so each component can be implemented, tested, and shipped as its own PR. The four user-story phases (US1–US4) have no code-level dependencies between them and are designed to run in parallel after the foundational phase completes.
+
+## Format
+
+`- [ ] [ID] [P?] [Story?] Description with file path`
+
+- **[P]**: Can run in parallel with other [P] tasks (different files, no dependencies on incomplete tasks in the same phase)
+- **[Story]**: Maps to user stories from spec.md (US1, US2, US3, US4)
+- All file paths are absolute from the repo root
+
+## Path conventions
+
+This is a React component library inside a pnpm monorepo. New component sources live at `packages/react/src/components/<Component>/`. Shared helpers live at `packages/react/src/lib/`. Re-exports are wired through `packages/react/src/index.ts`. Per-PR changesets live in `.changeset/`.
+
+---
+
+## Phase 1: Setup (shared infrastructure)
+
+**Purpose**: Verify the existing package infrastructure (Base UI peer dep, Tailwind preset, lint rules) is in place for the four new components. No new tooling is introduced.
+
+- [X] T001 Verify `packages/react/package.json` peerDependencies includes `@base-ui-components/react` at a version that exposes `Tooltip`, `Slider`, and `RadioGroup` primitives. Update the version range if necessary.
+
+**Checkpoint**: Setup verified — Foundational work can begin.
+
+---
+
+## Phase 2: Foundational (blocking prerequisites)
+
+**Purpose**: Build shared infrastructure that all four user stories depend on. Without this phase, US3 (Slider) and US4 (SegmentedControl) cannot emit structured warnings per FR-020 and FR-034.
+
+**CRITICAL**: No user-story work begins until this phase completes.
+
+- [X] T002 Add structured-warning helper at `packages/react/src/lib/warn.ts` that wraps `console.warn` with the `[unbranded-ds]` prefix and accepts a typed payload object `{ component: string; issue: string; [key: string]: unknown }`. Used by Slider (FR-020) and SegmentedControl (edge-case handling).
+- [X] T003 [P] Add unit tests for the warn helper at `packages/react/src/lib/warn.test.ts` covering the `[unbranded-ds]` prefix, payload pass-through, and the required `component` + `issue` fields.
+
+**Checkpoint**: Foundation ready — User Story implementation can now begin in parallel across US1, US2, US3, US4.
+
+---
+
+## Phase 3: User Story 1 — Tooltip (Priority: P1) — MVP
+
+**Goal**: Ship `<Tooltip>` wrapping `@base-ui-components/react`'s Tooltip primitives. Token-styled, ARIA-compliant, with `asChild` support for inline-element wrapping (citation pattern) and `prefers-reduced-motion: reduce` honored.
+
+**Independent Test**: A consumer renders `<Tooltip.Provider><Tooltip.Trigger>Hover me</Tooltip.Trigger><Tooltip.Content>Detail</Tooltip.Content></Tooltip.Provider>`. Hover or keyboard-focus reveals the content; Escape dismisses; tap on touch toggles. Axe reports zero `serious` or `critical` violations on the Tooltip stories.
+
+- [X] T004 [US1] Create Tooltip source at `packages/react/src/components/Tooltip/Tooltip.tsx`. Wraps `@base-ui-components/react`'s Tooltip primitives. Exports a compound: `Tooltip.Provider` (props: `delayDuration` default 700, `container`, `onOpenChange`), `Tooltip.Trigger` (prop: `asChild`), `Tooltip.Content` (props: `side` default `top`, `align` default `center`). Applies CVA for Content variants and Tailwind `motion-reduce:transition-none motion-reduce:duration-0` for reduced-motion. Passes `className` through `cn()`. No `window` or `document` access at render time. Implements FR-001 through FR-008 and the clarified defaults.
+- [X] T005 [P] [US1] Create Tooltip stories at `packages/react/src/components/Tooltip/Tooltip.stories.tsx`. Stories: `Default`, `Sides` (top/right/bottom/left), `Alignments` (start/center/end), and the FR-030-required `Wrapping an inline element` story demonstrating `<Tooltip.Trigger asChild>` over an `<a>` inside a `<sup>` (citation pattern). Includes `play` functions for hover-to-open, keyboard-focus-to-open, and Escape-to-dismiss. Autodocs descriptions on every prop, written for both human and agent audiences and reviewed via humanizer pass (FR-031). Implements US1 acceptance scenarios 1–6.
+- [X] T006 [P] [US1] Create Tooltip unit tests at `packages/react/src/components/Tooltip/Tooltip.test.tsx`. Coverage: CVA variant resolution for `side` and `align`; `cn()` className merging on Content; `asChild` pass-through preserves the child element type (assertion: rendered output is the original element, not a `<button>`); default values for `delayDuration` (700), `side` (`top`), `align` (`center`).
+- [X] T007 [US1] Create Tooltip barrel export at `packages/react/src/components/Tooltip/index.ts` re-exporting the `Tooltip` compound and the three prop types (`TooltipProviderProps`, `TooltipTriggerProps`, `TooltipContentProps`).
+- [X] T008 [US1] Add Tooltip re-export to `packages/react/src/index.ts` alongside the existing component exports.
+- [X] T009 [US1] Create `.changeset/add-tooltip.md` declaring `'@unbranded-ds/react': minor` with an autodoc-grade entry per FR-013 of spec 003's quality bar (one short paragraph naming the addition, the canonical usage, and the new acceptance test).
+
+**Checkpoint**: Tooltip is independently functional, tested, story-covered, and ready for PR. The component is consumable through `import { Tooltip } from '@unbranded-ds/react'` once the PR is merged and the Version Packages PR ships 0.3.0.
+
+---
+
+## Phase 4: User Story 2 — SkipLink (Priority: P2)
+
+**Goal**: Ship `<SkipLink>` as a native `<a href="#${targetId}">` with `.sr-only` + `focus-visible` reveal. No `preventDefault`, no programmatic scroll. Multiple instances supported.
+
+**Independent Test**: A consumer renders `<SkipLink />` as the first child of their layout. Pressing Tab on page load reveals the link and focuses it; pressing Enter scrolls and focuses the element matching `targetId` (default `main`). Multiple instances with different `targetId`s work independently. Axe reports zero `serious` or `critical` violations on the SkipLink stories.
+
+- [X] T010 [US2] Create SkipLink source at `packages/react/src/components/SkipLink/SkipLink.tsx`. Native `<a href="#${targetId}">` with `.sr-only` utility (from spec 002) for the hidden state and `focus-visible:not-sr-only` plus tokens-driven background/border/padding for the visible state. Props: `targetId` (default `'main'`), `children` (default `'Skip to main content'`), `className` merged via `cn()`. NO `preventDefault()`. NO programmatic scroll. SSR-safe (no `window`/`document` at render time). Implements FR-009 through FR-013.
+- [X] T011 [P] [US2] Create SkipLink stories at `packages/react/src/components/SkipLink/SkipLink.stories.tsx`. Stories: `Default` (single SkipLink with default targetId), the FR-030-required `Multiple skip targets` story (three SkipLink instances pointing at `main`, `nav`, `footer` with matching anchor elements). Includes `play` functions for tab-to-focus reveal and Enter-to-jump. Autodocs descriptions on every prop, humanizer-reviewed. Implements US2 acceptance scenarios 1–5.
+- [X] T012 [P] [US2] Create SkipLink unit tests at `packages/react/src/components/SkipLink/SkipLink.test.tsx`. Coverage: default `targetId` of `'main'` produces `href="#main"`; custom `targetId` produces matching href; default children text; custom children passes through; `className` merges via `cn()`; component renders a real `<a>` element (regression test against accidentally rendering a `<button>`).
+- [X] T013 [US2] Create SkipLink barrel export at `packages/react/src/components/SkipLink/index.ts` re-exporting `SkipLink` and `SkipLinkProps`.
+- [X] T014 [US2] Add SkipLink re-export to `packages/react/src/index.ts`.
+- [X] T015 [US2] Create `.changeset/add-skiplink.md` declaring `'@unbranded-ds/react': minor` with an autodoc-grade entry.
+
+**Checkpoint**: SkipLink is independently functional, tested, story-covered, and ready for PR.
+
+---
+
+## Phase 5: User Story 3 — Slider (Priority: P3)
+
+**Goal**: Ship `<Slider>` wrapping `@base-ui-components/react`'s Slider primitives. Single-value AND range mode from day one. CVA size/orientation/disabled axes. Structured warnings on invalid props. Pointer, keyboard, and touch all resolve to the same value-change pathway.
+
+**Independent Test**: A consumer renders `<Slider.Root defaultValue={[50]} min={0} max={100}>` with the slot tree. Arrow keys change by step, Home/End jump to min/max, drag works with pointer, tap-to-position works on touch. Range mode (`defaultValue={[20, 80]}`) renders two independent thumbs that cannot cross. Invalid configurations clamp with a structured warning. Axe reports zero `serious` or `critical` violations on the Slider stories.
+
+- [X] T016 [US3] Create Slider source at `packages/react/src/components/Slider/Slider.tsx`. Wraps `@base-ui-components/react`'s Slider primitives. Exports a compound: `Slider.Root` (props: `value`, `defaultValue`, `min` default 0, `max` default 100, `step` default 1, `onValueChange`, `size` default `'md'`, `orientation` default `'horizontal'`, `disabled` default false), `Slider.Control`, `Slider.Track`, `Slider.Indicator`, `Slider.Thumb`. `value`/`defaultValue` always `number[]` (single: `[50]`, range: `[20, 80]`). CVA size/orientation/disabled variants on Root. Uses the shared warn helper from T002 to emit structured payloads for `value-out-of-range`, `invalid-step`, `invalid-bounds` (FR-020). PageUp/PageDown change by 10% of `(max - min)` rounded to nearest step (FR-018). No `window`/`document` at render time. Implements FR-014 through FR-021.
+- [X] T017 [P] [US3] Create Slider stories at `packages/react/src/components/Slider/Slider.stories.tsx`. Stories: `Default` (single-value), `Sizes` (sm/md/lg), `Orientations` (horizontal/vertical), `Range` (two-thumb), `Disabled`, `Controlled` (with onValueChange). `play` functions for keyboard increment via Right Arrow, Home/End jumps, pointer drag, AND the FR-030-required touch variant using `pointerType: 'touch'` to verify tap-to-position and drag-with-finger. Autodocs descriptions on every prop, humanizer-reviewed. Implements US3 acceptance scenarios 1–5.
+- [X] T018 [P] [US3] Create Slider unit tests at `packages/react/src/components/Slider/Slider.test.tsx`. Coverage: CVA variant resolution; `value`/`defaultValue` always `number[]` (single and range); `onValueChange` shape matches; value-out-of-range clamp emits structured warning with `{ component: 'Slider', issue: 'value-out-of-range', prop, got, clamped }`; `step <= 0` falls back to 1 with `issue: 'invalid-step'` warning; `min >= max` swaps to `[min, min+1]` with `issue: 'invalid-bounds'` warning; range thumbs do not cross; `disabled` removes focus from thumbs.
+- [X] T019 [US3] Create Slider barrel export at `packages/react/src/components/Slider/index.ts` re-exporting the `Slider` compound and the five slot props types.
+- [X] T020 [US3] Add Slider re-export to `packages/react/src/index.ts`.
+- [X] T021 [US3] Create `.changeset/add-slider.md` declaring `'@unbranded-ds/react': minor` with an autodoc-grade entry that names single-value AND range support, the structured warning contract, and the touch input pathway.
+
+**Checkpoint**: Slider is independently functional, tested, story-covered, and ready for PR.
+
+---
+
+## Phase 6: User Story 4 — SegmentedControl (Priority: P4)
+
+**Goal**: Ship `<SegmentedControl>` wrapping `@base-ui-components/react`'s RadioGroup primitives, visually styled as a connected pill control. CVA size/orientation/disabled axes. Strict-axis keyboard navigation.
+
+**Independent Test**: A consumer renders `<SegmentedControl.Root defaultValue="b"><Item value="a">A</Item><Item value="b">B</Item><Item value="c">C</Item></SegmentedControl.Root>`. Clicking changes selection; arrow keys navigate strict-axis (Left/Right for horizontal, Up/Down for vertical); `aria-checked` reflects selection. Axe reports zero `serious` or `critical` violations on the SegmentedControl stories.
+
+- [X] T022 [US4] Create SegmentedControl source at `packages/react/src/components/SegmentedControl/SegmentedControl.tsx`. Wraps `@base-ui-components/react`'s RadioGroup primitives. Exports a compound: `SegmentedControl.Root` (props: `value`, `defaultValue`, `onValueChange`, `size` default `'md'`, `orientation` default `'horizontal'`, `disabled` default false), `SegmentedControl.Item` (props: `value` required, `disabled`). CVA size/orientation/disabled axes on Root with a connected pill visual. Strict-axis arrow keys (Left/Right for horizontal, Up/Down for vertical, Home/End in both). Uses the shared warn helper from T002 to emit `{ component: 'SegmentedControl', issue: 'no-items' }` when zero items are rendered (edge case). No `window`/`document` at render time. Implements FR-022 through FR-026.
+- [X] T023 [P] [US4] Create SegmentedControl stories at `packages/react/src/components/SegmentedControl/SegmentedControl.stories.tsx`. Stories: `Default` (three items), `Sizes` (sm/md/lg), `Orientations` (horizontal/vertical), `Disabled`, `Two Items` (edge case — verifies render-with-no-warning), `Controlled` (with onValueChange). `play` functions for click-to-select and arrow-key navigation in both orientations. Autodocs descriptions on every prop, humanizer-reviewed. Implements US4 acceptance scenarios 1–4.
+- [X] T024 [P] [US4] Create SegmentedControl unit tests at `packages/react/src/components/SegmentedControl/SegmentedControl.test.tsx`. Coverage: CVA variant resolution; single-select behavior (selecting one deselects others); strict-axis keyboard mapping (Up/Down on horizontal is a no-op; Left/Right on vertical is a no-op); controlled vs uncontrolled; `role="radiogroup"` and `role="radio"` semantics; zero-items emits structured warning with `{ component: 'SegmentedControl', issue: 'no-items' }`; two-items renders without warning.
+- [X] T025 [US4] Create SegmentedControl barrel export at `packages/react/src/components/SegmentedControl/index.ts` re-exporting the `SegmentedControl` compound and `SegmentedControlRootProps`, `SegmentedControlItemProps`.
+- [X] T026 [US4] Add SegmentedControl re-export to `packages/react/src/index.ts`.
+- [X] T027 [US4] Create `.changeset/add-segmentedcontrol.md` declaring `'@unbranded-ds/react': minor` with an autodoc-grade entry that names the RadioGroup-based semantics and the strict-axis keyboard pattern.
+
+**Checkpoint**: SegmentedControl is independently functional, tested, story-covered, and ready for PR. All four user stories complete.
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+**Purpose**: Final integration verification across the four components, plus the cross-cutting quality gates that aren't tied to a single component.
+
+- [X] T028 [P] Verify SSR safety with a `renderToString` smoke test for all four components at `packages/react/src/components/__ssr__.test.tsx` (or equivalent per-component variants). Each component renders to a string without throwing, with no `window`/`document` access at render time. Satisfies Constitution Section IX bullet 6.
+- [X] T029 [P] Run `pnpm --filter @unbranded-ds/react test` and verify all unit tests pass (warn helper, Tooltip, SkipLink, Slider, SegmentedControl).
+- [X] T030 [P] Run `pnpm --filter @unbranded-ds/storybook dev` and manually verify each of the four components in Storybook: autodocs are populated with humanizer-passed descriptions per FR-029 and FR-031; the Tests panel shows passing play functions; the Accessibility panel shows zero `serious` or `critical` violations per FR-033.
+- [X] T031 Run `pnpm build` (Turbo) and verify `@unbranded-ds/react` builds with the four new components exported, no TypeScript errors, no lint failures (including the no-hardcoded-colors rule per FR-029).
+- [X] T032 Final humanizer review pass on the four component descriptions and all autodoc prop descriptions. Confirm no prose three-item lists (FR-032 — variant enums with three options like `size: 'sm' | 'md' | 'lg'` are code lists and exempt). Confirm bolded inline-header lists are not used.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+```text
+Phase 1 (Setup)
+    ↓
+Phase 2 (Foundational — warn helper + test)
+    ↓
+    ├── Phase 3 (US1 Tooltip)         ⎫
+    ├── Phase 4 (US2 SkipLink)         ⎬ run in parallel
+    ├── Phase 5 (US3 Slider)           ⎪
+    └── Phase 6 (US4 SegmentedControl) ⎭
+    ↓ (all four complete)
+Phase 7 (Polish & Cross-Cutting)
+```
+
+### Within-phase dependencies
+
+For each User Story phase (US1–US4), the internal dependency graph is:
+
+```text
+Source (T-source)
+    ↓
+    ├── Stories (T-stories) [P]
+    └── Unit tests (T-tests) [P]
+    ↓
+Barrel export (T-index)
+    ↓
+Root re-export (T-root)
+    ↓
+Changeset (T-changeset)
+```
+
+The root re-export task touches `packages/react/src/index.ts` — a shared file. If running US1–US4 phases in parallel, the four root-export tasks (T008, T014, T020, T026) WILL produce merge conflicts on `packages/react/src/index.ts`. This is expected: each component PR adds its own line; merge in PR order resolves cleanly. The conflict is procedural, not a [P] concern within a single phase.
+
+### Cross-phase shared file note
+
+`packages/react/src/index.ts` is touched by T008, T014, T020, T026 (one per US phase). These tasks are NOT marked [P] across phases — they're sequential per-phase but each phase's edit is independent of others until merge time.
+
+---
+
+## Parallel Execution Strategy
+
+The user-story phases (3–6) are designed to be implemented by independent agents or developers working in parallel branches. After Phase 2 completes, kick off all four phases simultaneously.
+
+### Within a phase (single agent)
+
+After completing the source task (e.g., T004), the agent can issue parallel tool calls for stories + tests (e.g., T005 and T006 together):
+
+```text
+After T004 (Tooltip source):
+  Issue parallel writes for T005 (stories) and T006 (tests).
+  Then sequential: T007 (index.ts) → T008 (root re-export) → T009 (changeset).
+```
+
+### Across phases (multiple agents)
+
+```text
+After T003 (Foundational checkpoint):
+  Launch four parallel agents:
+    - Agent A: US1 Tooltip      → T004 → T005,T006 → T007 → T008 → T009
+    - Agent B: US2 SkipLink     → T010 → T011,T012 → T013 → T014 → T015
+    - Agent C: US3 Slider       → T016 → T017,T018 → T019 → T020 → T021
+    - Agent D: US4 SegmentedCtl → T022 → T023,T024 → T025 → T026 → T027
+
+  When all four complete:
+    Phase 7 polish tasks (T028–T032).
+```
+
+### Polish phase
+
+T028, T029, T030 are independent verification tasks ([P]). T031 (build) and T032 (humanizer review) are sequential after the others — T031 needs the full source tree built; T032 reads autodoc text once everything is in place.
+
+---
+
+## Implementation Strategy
+
+### MVP scope (single-story shipping option)
+
+If pressure forces a partial release, the MVP is **User Story 1 — Tooltip alone**:
+
+- Setup + Foundational + Phase 3 only (T001–T009)
+- Independently shippable in a `@unbranded-ds/react@0.2.1` release if the bundled-0.3.0 commitment is dropped
+- The other three components defer to a follow-up
+
+Per the spec's SC-006, the intent is to ship all four together as 0.3.0. The MVP option above is a fallback, not the planned path.
+
+### Incremental delivery (recommended)
+
+1. Complete Phase 1 + 2 (setup + foundational warn helper)
+2. Open four parallel PRs for US1–US4, each with its own `.changeset/*.md`
+3. As each PR merges, the Changesets `Version Packages` PR updates but is NOT merged
+4. Once all four have landed on `main`, merge the `Version Packages` PR — Changesets cuts `@unbranded-ds/react@0.3.0` and publishes via the release workflow
+5. Run Phase 7 polish tasks against the final state of `main` (post-merge)
+
+### Notes on the constitution amendment
+
+The Section IX bullet 6 (SSR safety) constitution amendment is already committed on this branch alongside this spec. No task is needed to make that amendment — it landed during planning. T028 enforces the constraint by smoke-testing each component server-side.
+
+---
+
+## Task counts
+
+| Phase | Count | Notes |
+|---|---|---|
+| Phase 1: Setup | 1 | Verification only |
+| Phase 2: Foundational | 2 | Warn helper + its test |
+| Phase 3: US1 Tooltip | 6 | source, stories, tests, index, root, changeset |
+| Phase 4: US2 SkipLink | 6 | Same structure |
+| Phase 5: US3 Slider | 6 | Same structure |
+| Phase 6: US4 SegmentedControl | 6 | Same structure |
+| Phase 7: Polish | 5 | SSR smoke test, test run, Storybook check, build, humanizer review |
+| **Total** | **32** | |
+
+Parallel opportunities: 4 cross-phase tracks (US1–US4) plus 2 within-phase parallel tasks per US phase plus 3 [P] tasks in Phase 7. Maximum theoretical concurrency: 4 simultaneous agents during US implementation, 3 simultaneous tasks during polish.


### PR DESCRIPTION
## Summary

Spec 004 lands four new components in `@unbranded-ds/react`: `Tooltip`, `SkipLink`, `Slider`, and `SegmentedControl`. Tooltip, Slider, and SegmentedControl wrap Base UI primitives. SkipLink is an in-house component built on a native `<a>` plus the `.sr-only` utility from spec 002. All four ship together as `@unbranded-ds/react@0.3.0` when the Changesets release PR merges.

The branch also bumps the constitution (1.0.1 → 1.0.2, PATCH) to add SSR safety as Section IX bullet 6. The existing nine components already satisfy it; this just makes it explicit and mergeable-blocking from here on.

## What's in here

### Components

- [`Tooltip`](./packages/react/src/components/Tooltip/): Provider/Trigger/Content slots, `asChild` for inline-element wrapping (citation pattern), `motion-reduce` honored for WCAG SC 2.3.3
- [`SkipLink`](./packages/react/src/components/SkipLink/): native `<a href="#${targetId}">` with focus-visible reveal, multiple instances supported, no `preventDefault` and no programmatic scroll
- [`Slider`](./packages/react/src/components/Slider/): single-value and range modes from day one, uniform `number[]` value shape, structured warnings on invalid props, touch + keyboard + pointer all resolve to the same `onValueChange` pathway
- [`SegmentedControl`](./packages/react/src/components/SegmentedControl/): wraps Base UI's RadioGroup with strict-axis arrow navigation and Home/End restored. Base UI disables Home/End at the CompositeRoot level, so the wrapper adds them back.

### Foundational

- [`lib/warn.ts`](./packages/react/src/lib/warn.ts): shared structured-warning helper that emits `console.warn('[unbranded-ds]', { component, issue, ... })` for agent and dev-tool consumption

### Constitution amendment

[Section IX bullet 6](./.specify/memory/constitution.md): components must render server-side without `window` or `document` access at render time. Browser-API access lives in `useEffect` or post-mount hooks. Version 1.0.2 (PATCH).

## Test plan

- [ ] CI `verify` job passes (lint, typecheck, unit, build, Storybook test-runner)
- [ ] CI `changeset-check` finds the four `.changeset/add-*.md` files
- [ ] Storybook autodocs render for all four components with humanizer-passed descriptions
- [ ] After merge, Changesets opens a Version Packages PR bumping `@unbranded-ds/react` to `0.3.0`

## Spec artifacts

- [spec.md](./specs/004-primitive-set-expansion/spec.md): user stories, FRs, clarifications session (11 questions resolved)
- [plan.md](./specs/004-primitive-set-expansion/plan.md): technical context, constitution check, file structure
- [research.md](./specs/004-primitive-set-expansion/research.md): wrap-vs-roll-our-own decisions per component
- [contracts/](./specs/004-primitive-set-expansion/contracts/): per-component API contracts
- [tasks.md](./specs/004-primitive-set-expansion/tasks.md): 32 tasks across 7 phases, all complete

## Notes for reviewers

Three places where the implementation diverges from the original contract; the contracts have been updated to match:

1. `children` is optional on the prop interfaces for Tooltip and Slider. Storybook's `Meta<typeof X>` inference treats `args` as partial, and requiring `children` at the type level produced spurious typecheck errors in stories whose `render` supplies the slot tree. Runtime composition still requires children.
2. `Tooltip.Provider` collapses Base UI's `Provider` + `Root` into one wrapper slot. Each Provider hosts one Trigger+Content pair. Consumers needing multiple tooltips render multiple Providers.
3. `SegmentedControl` ships a custom `onKeyDownCapture` handler. Base UI's RadioGroup uses relaxed all-four-arrows navigation and disables Home/End. The handler enforces the WAI-ARIA radiogroup pattern (FR-025): strict-axis arrows, plus Home/End in both orientations.

Per-component commits _should_ make this easier to review than the line count suggests. Each component has its own commit so the diffs stay focused.