### PR TITLE
feat(tokens): token schema growth (spec 008)

### DIFF
--- a/.changeset/token-schema-growth.md
+++ b/.changeset/token-schema-growth.md
@@ -1,0 +1,11 @@
+---
+'@unbranded-ds/tokens': minor
+---
+
+Grow the token schema and loosen runtime theme validation.
+
+New tokens: `font-serif`, a `motion` category (durations `fast`/`base`/`slow` and easings `standard`/`decelerate`/`accelerate`, emitted as Tailwind-aligned `--ease-*` and `--duration-*`), and `size-2xl`/`size-3xl`. Two optional, non-breaking additions land alongside them: `ring.width` and a `z-index` layering scale (`overlay`/`popover`/`tooltip`, ordered so a tooltip stacks above a dialog).
+
+`validateTheme` now accepts a partial theme. It resolves the override against the canonical defaults and validates the merged result, so a theme may change any subset of categories and inherit the rest. Contrast runs on the merged colors, so a pair where one side is overridden and the other inherited is no longer skipped. Existing complete themes keep validating without change; they inherit the new tokens from the defaults.
+
+The light theme's `muted-foreground` and `destructive` colors move slightly (4.40 and 3.61 to 4.55:1) to meet WCAG AA, which the previous contrast skip had hidden.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,14 @@
 # heliostat Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-05-22
+Auto-generated from all feature plans. Last updated: 2026-06-10
 
 ## Active Technologies
 - TypeScript 5.x in `tsx`-tagged code blocks only (validated via `tsc --noEmit` per spec 005's compile validator). Sidecar prose is plain CommonMark. + All shipped in spec 005. The template at `packages/react/src/components/_template/Component.usage.md`, the validator at `scripts/validate-sidecars.ts`, the `AGENTS.md` component index, and the CI step that wires the validator into the verify job. (006-sidecar-retrofit)
 - Filesystem only. 14 `<Component>.usage.md` files co-located with their `.tsx` source. One running inbox file: `specs/006-sidecar-retrofit/spec-007-inbox.md`. 15 `.changeset/*.md` files (14 component + 1 backfill). (006-sidecar-retrofit)
 - TypeScript 5.x, strict mode, no `any` + `@base-ui-components/react`, `class-variance-authority`, Storybook 10.3 (`@storybook/react-vite`), react-docgen (Storybook-bundled) (007-autodoc-audit)
 - N/A (prose-only edits to existing source files) (007-autodoc-audit)
+- TypeScript 5.x, strict mode, no `any` + Style Dictionary v4 (DTCG build), Zod (theme schema + validation), Tailwind CSS v4 (`@theme` preset consumption) (008-token-schema-growth)
+- Filesystem only. DTCG source files under `packages/tokens/src/tokens/`, built-in theme files under `packages/tokens/themes/`, generated artifacts under `packages/tokens/dist/`. (008-token-schema-growth)
 
 - TypeScript 5.x, strict mode, no `any` (Constitution Section VIII) (004-primitive-set-expansion)
 - N/A (component library; no persisted data) (004-primitive-set-expansion)
@@ -36,10 +38,10 @@ npm test && npm run lint
 TypeScript 5.x, strict mode, no `any` (EVER): Follow standard conventions
 
 ## Recent Changes
+- 008-token-schema-growth: Added TypeScript 5.x, strict mode, no `any` + Style Dictionary v4 (DTCG build), Zod (theme schema + validation), Tailwind CSS v4 (`@theme` preset consumption)
 - 007-autodoc-audit: Added TypeScript 5.x, strict mode, no `any` + `@base-ui-components/react`, `class-variance-authority`, Storybook 10.3 (`@storybook/react-vite`), react-docgen (Storybook-bundled)
 - 006-sidecar-retrofit: Added TypeScript 5.x in `tsx`-tagged code blocks only (validated via `tsc --noEmit` per spec 005's compile validator). Sidecar prose is plain CommonMark. + All shipped in spec 005. The template at `packages/react/src/components/_template/Component.usage.md`, the validator at `scripts/validate-sidecars.ts`, the `AGENTS.md` component index, and the CI step that wires the validator into the verify job.
 
-- 005-agent-experience-foundation: Added TypeScript 5.x, strict mode, no `any` (Constitution Section VIII)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,25 @@
+# Roadmap
+
+Parked ideas and future directions for unbranded-ds. This is not the queue. Work that's actually next starts as a `tmp/` brief and becomes a numbered `specs/NNN/` spec. Entries here are principle-level sketches of where the system could go, captured so they aren't lost. Treat each as a starting point to revisit, not a design to build as written. The design system will move before any of these land, so these entries stay light on specifics.
+
+## Derived Color Tokens (Themes as Seeds, Not Value Sets)
+
+**Status:** parked. Revisit after specs 008 to 010 ship.
+
+Today a theme hand-writes every color and the validator checks contrast after the fact. This idea flips that: a theme declares a handful of seed colors plus the *relationships* between them, and the system generates the rest. `primary-foreground` derived to stay readable on `primary`, `muted` mixed from `background` and `foreground`, and so on down. Generation happens in OKLCH, the perceptual space the tokens already use, so a brand theme becomes a few seeds and a hue rather than thirty tuned values. Contrast stops being a gate the author has to clear and becomes a guarantee of construction.
+
+The reason to come back to it: an agent could author a theme from a prompt and have the validator prove it correct before it ships, which is exactly what the constitution's agent-and-human-legibility principle points at and what no other design system does today. It gets there by building on the OKLCH and contrast machinery already in the box, and it shrinks themes rather than growing them.
+
+**Decisions that hold regardless of how the DS evolves:**
+
+- It is a *resolver*, not a merge strategy. A derived theme resolves seeds-plus-rules into a final value set, and everything downstream consumes the resolved values. This is why spec 009's composition work should merge *resolved* values rather than source themes. Settle that and derived tokens slot underneath later with no rework.
+- "Schema locked, values float" becomes "relationships locked, seeds float." That reframes Constitution Section III, and it overlaps with the Section III amendment spec 009 already makes for composition. One coherent Section III rewrite beats two consecutive ones.
+- Contrast moves from check to generate. The unsolved seam: what happens to a derived pair when two color-bearing theme axes merge, whether to re-derive against the merged seed or keep each axis's own derived pair.
+
+**Open questions for spec-time (don't answer now):**
+
+- The authoring format for a computed value. DTCG handles aliases (`{color.primary}`) but not `mix()`, `mostReadable()`, or scale generation, so this needs a decided extension.
+- How few seeds a theme can get away with, and which tokens are seeds versus derived.
+- Whether the theme-extension tokens from spec 009 can themselves be derived, or stay literal.
+
+**Deliberately omitted:** file paths, function signatures, schema shapes. Those rot before this gets built. The point of this entry is the shape of the bet, not its implementation.

--- a/THEMING.md
+++ b/THEMING.md
@@ -4,9 +4,39 @@ Themes are just CSS variables scoped to a `[data-theme]` selector. Every compone
 
 Three themes come built in: light, dark, and brand.
 
+## Two things called "theme"
+
+"Theme" means two different things here, on two different pipelines. Knowing which one you are holding saves confusion.
+
+A **token-source override** is a build-time file under `packages/tokens/themes/`, authored in DTCG format (`$value` / `$type`). Style Dictionary merges it over the default token sources and bakes a static `[data-theme="<name>"]` CSS file. The built-in `light`, `dark`, and `brand` themes are this kind. You ship them in the package; consumers load the generated CSS.
+
+```jsonc
+// packages/tokens/themes/sunset.json: a token-source override (DTCG)
+{
+  "color": { "primary": { "$value": "oklch(0.65 0.2 35)", "$type": "color" } },
+  "radius": { "md": { "$value": "0.75rem", "$type": "dimension" } }
+}
+```
+
+A **runtime theme document** is a flat object passed to `registerTheme()` or `validateTheme()` at runtime. It carries `name`, `displayName`, and a `tokens` map of plain string values. The validator checks it and injects a `<style>` block on the fly. This is what a consumer builds dynamically in the browser.
+
+```jsonc
+// a runtime theme document (flat values, passed to registerTheme)
+{
+  "name": "sunset",
+  "displayName": "Sunset",
+  "tokens": {
+    "color": { "primary": "oklch(0.65 0.2 35)" },
+    "radius": { "md": "0.75rem" }
+  }
+}
+```
+
+The build consumes the first; `registerTheme` and `validateTheme` consume the second. They are not interchangeable: a DTCG source file will not pass `validateTheme`, and a runtime document is not a Style Dictionary source. Most of this doc covers the runtime document (the "Writing a custom theme" path just below). The "Extending the schema" section near the end covers the build-time token sources.
+
 ## Writing a custom theme
 
-A theme is a JSON file. Every token in the schema needs a value — skip one and validation will tell you which.
+A runtime theme is a JSON object. You can supply a full token set, or only the parts you want to change: any token you omit inherits the default value. The example below is a complete theme; a partial one (say, only `color` and `radius`) is equally valid.
 
 ```json
 {
@@ -94,7 +124,7 @@ else {
 }
 ```
 
-It checks two things: that every required token exists with the right type, and that foreground/background color pairs hit WCAG AA contrast (4.5:1).
+It resolves your theme against the defaults first, so a partial theme is checked as its complete merged result, then verifies two things: every required token has a value of the right type, and the foreground/background color pairs meet WCAG AA contrast (4.5:1). Because the check runs on the merged result, a pair where you override one side and inherit the other is still validated against the real resolved colors.
 
 ### Contrast pairs
 
@@ -192,6 +222,77 @@ Or as link tags:
 ```
 
 Switch between them by changing `data-theme`. No reload needed.
+
+## Overriding non-color tokens
+
+Themes are not limited to color. A theme of either kind can override any category: radius, spacing, typography, shadow, motion, and the rest. Anything you do not mention inherits the default.
+
+The built-in `brand` theme shows this. On top of its color palette it rounds the corners and swaps the sans-serif face, leaving everything else at the defaults:
+
+```jsonc
+// packages/tokens/themes/brand.json (excerpt)
+{
+  "color": { "...": "..." },
+  "radius": {
+    "sm": { "$value": "0.375rem", "$type": "dimension" },
+    "md": { "$value": "0.5rem", "$type": "dimension" },
+    "lg": { "$value": "0.75rem", "$type": "dimension" }
+  },
+  "typography": {
+    "font-sans": { "$value": "\"Inter\", ui-sans-serif, system-ui, sans-serif", "$type": "fontFamily" }
+  }
+}
+```
+
+It overrides three of the four radius stops and one typography token. `radius.full` and every other typography value (including `size-2xl`) go unmentioned, so they inherit. The resolved `tokens-brand.css` carries the rounded radii and the Inter stack next to the inherited defaults.
+
+A runtime theme document does the same with flat values:
+
+```jsonc
+{
+  "name": "rounded",
+  "displayName": "Rounded",
+  "tokens": { "radius": { "md": "0.75rem", "lg": "1rem" } }
+}
+```
+
+`validateTheme` resolves this against the defaults before checking, so the omitted categories are present in the validated result.
+
+## Extending the schema
+
+When a token you need does not exist in the schema, you add it to the canonical set so every consumer gets it. The pipeline below uses the `motion` category as the worked example.
+
+1. **Add a DTCG source file** under `packages/tokens/src/tokens/`. Motion lives in `motion.json`:
+
+```jsonc
+{
+  "motion": {
+    "duration": {
+      "fast": { "$value": "120ms", "$type": "duration" },
+      "base": { "$value": "240ms", "$type": "duration" }
+    },
+    "easing": {
+      "standard": { "$value": "cubic-bezier(0.4, 0, 0.2, 1)", "$type": "cubicBezier" }
+    }
+  }
+}
+```
+
+2. **Add the category to the Zod schema** in `packages/tokens/src/schema.ts` so themes can carry it and the validator knows it. Make it required when every theme must supply a value, optional when it should inherit a default if omitted.
+
+3. **Add the values to the canonical defaults** in `packages/tokens/src/defaults.ts` (the inheritance baseline), plus any theme that overrides them. A drift-guard test keeps the defaults honest against the sources.
+
+4. **Wire the build naming** in `packages/tokens/sd.config.ts` when the category needs CSS-variable names that differ from the default `--<category>-<key>` pattern. Motion is the one special case: it emits `--duration-*` and `--ease-*` so the variables match Tailwind's namespaces. `--ease-*` generates real `ease-*` utilities; `--duration-*` is consumed via an arbitrary value like `duration-[var(--duration-base)]`, since Tailwind v4 has no duration namespace.
+
+5. **Regenerate** and confirm the token lands in all four artifacts:
+
+```bash
+pnpm --filter @unbranded-ds/tokens build
+```
+
+The token appears in the Tailwind preset (`dist/tailwind/preset.css`), the per-theme CSS (`dist/css/tokens-*.css`), the TypeScript token map (`dist/ts/tokens.ts`), and the JSON map (`dist/json/tokens.json`).
+
+Adding a required token is a breaking change for existing consumer themes, since they must now supply it or inherit it from the defaults. Pre-1.0 this is communicated by a minor version bump.
 
 ## Future structural opportunities
 

--- a/packages/tokens/sd.config.ts
+++ b/packages/tokens/sd.config.ts
@@ -4,12 +4,75 @@ import { basename, extname } from 'node:path';
 import StyleDictionary from 'style-dictionary';
 
 /**
- * Flatten a token name into a CSS variable name.
- * E.g. "color-background" → "--color-background"
+ * The single source of truth for a token's flattened name.
+ *
+ * Motion is the one special case. Its DTCG source stays nested
+ * (`motion.duration.fast`, `motion.easing.standard`) per Style Dictionary
+ * convention, but we emit Tailwind-aligned names so the easings light up real
+ * `ease-*` utilities: `motion.duration.X` → `duration-X` and
+ * `motion.easing.X` → `ease-X`. A literal `motion-duration-fast` maps to no
+ * Tailwind namespace and leaks the internal grouping into the public var
+ * surface. Every other token keeps its default kebab name.
+ *
+ * This runs as a name transform (below) so `token.name` is already the renamed
+ * value by the time any format — including Style Dictionary's built-in
+ * `css/variables`, which the per-theme CSS uses — reads it. That's the only way
+ * to keep the rename consistent across all four artifacts AND the per-theme CSS;
+ * a format-only rename would miss `css/variables`, which reads `token.name`
+ * directly.
+ */
+function flattenedName(token: TransformedToken): string {
+	if (token.path[0] === 'motion') {
+		const [, group, key] = token.path;
+		if (group === 'duration') return `duration-${key}`;
+		if (group === 'easing') return `ease-${key}`;
+	}
+	return token.name;
+}
+
+/**
+ * CSS variable name (the `--` prefixed form) for any token. Reads `token.name`,
+ * which the `name/motion-aware` transform has already rewritten, so this stays a
+ * thin wrapper and the rename lives in exactly one place.
  */
 function tokenToCssVar(token: TransformedToken): string {
 	return `--${token.name}`;
 }
+
+// ---------------------------------------------------------------------------
+// Custom name transform: rewrite motion token names to the Tailwind-aligned
+// flattened form. Layered AFTER name/kebab in the custom transform group below,
+// so it operates on the already-kebabbed name and only touches motion.
+// ---------------------------------------------------------------------------
+StyleDictionary.registerTransform({
+	name: 'name/motion-aware',
+	type: 'name',
+	transform: (token) => flattenedName(token as TransformedToken),
+});
+
+// A `css` transform group with the motion rename appended. The per-theme CSS,
+// Tailwind preset, TS map, and JSON all build on this so `token.name` carries
+// the renamed value everywhere and the artifacts can't drift.
+StyleDictionary.registerTransformGroup({
+	name: 'css-motion',
+	transforms: [
+		'attribute/cti',
+		'name/kebab',
+		'name/motion-aware',
+		'time/seconds',
+		'html/icon',
+		'size/rem',
+		'color/css',
+		'asset/url',
+		'fontFamily/css',
+		'cubicBezier/css',
+		'strokeStyle/css/shorthand',
+		'border/css/shorthand',
+		'typography/css/shorthand',
+		'transition/css/shorthand',
+		'shadow/css/shorthand',
+	],
+});
 
 // ---------------------------------------------------------------------------
 // Custom format: Tailwind v4 @theme inline block
@@ -39,6 +102,9 @@ StyleDictionary.registerFormat({
 			radius: 'radii',
 			shadow: 'shadows',
 			opacity: 'opacity',
+			motion: 'motion',
+			ring: 'ring',
+			'z-index': 'z-index',
 		};
 
 		const entries = dictionary.allTokens.map((token) => {
@@ -52,7 +118,7 @@ StyleDictionary.registerFormat({
   }`;
 		});
 
-		return `export type TokenCategory = "color" | "spacing" | "typography" | "radii" | "shadows" | "opacity";
+		return `export type TokenCategory = "color" | "spacing" | "typography" | "radii" | "shadows" | "opacity" | "motion" | "ring" | "z-index";
 
 export type TokenDefinition = {
   name: string;
@@ -108,7 +174,7 @@ async function build() {
 			log: { warnings: 'disabled' },
 			platforms: {
 				css: {
-					transformGroup: 'css',
+					transformGroup: 'css-motion',
 					buildPath: 'dist/css/',
 					files: [
 						{
@@ -127,12 +193,13 @@ async function build() {
 	}
 
 	// 2. Shared assets from base tokens (Tailwind preset, TS types, JSON)
-	//    Use "css" transformGroup for all so token names stay kebab-case.
+	//    Use the "css-motion" transformGroup for all so token names stay
+	//    kebab-case AND the motion rename applies uniformly with the per-theme CSS.
 	const sdBase = new StyleDictionary({
 		source: ['src/tokens/**/*.json'],
 		platforms: {
 			tailwind: {
-				transformGroup: 'css',
+				transformGroup: 'css-motion',
 				buildPath: 'dist/tailwind/',
 				files: [
 					{
@@ -142,7 +209,7 @@ async function build() {
 				],
 			},
 			ts: {
-				transformGroup: 'css',
+				transformGroup: 'css-motion',
 				buildPath: 'dist/ts/',
 				files: [
 					{
@@ -152,7 +219,7 @@ async function build() {
 				],
 			},
 			json: {
-				transformGroup: 'css',
+				transformGroup: 'css-motion',
 				buildPath: 'dist/json/',
 				files: [
 					{

--- a/packages/tokens/src/__fixtures__/bad-contrast.json
+++ b/packages/tokens/src/__fixtures__/bad-contrast.json
@@ -36,10 +36,13 @@
 		"typography": {
 			"font-sans": "system-ui, sans-serif",
 			"font-mono": "monospace",
+			"font-serif": "Georgia, serif",
 			"size-sm": "0.875rem",
 			"size-base": "1rem",
 			"size-lg": "1.125rem",
 			"size-xl": "1.25rem",
+			"size-2xl": "1.5rem",
+			"size-3xl": "1.875rem",
 			"weight-normal": "400",
 			"weight-medium": "500",
 			"weight-semibold": "600",
@@ -62,6 +65,14 @@
 		"opacity": {
 			"disabled": "0.5",
 			"hover": "0.8"
+		},
+		"motion": {
+			"duration-fast": "120ms",
+			"duration-base": "240ms",
+			"duration-slow": "480ms",
+			"easing-standard": "cubic-bezier(0.4, 0, 0.2, 1)",
+			"easing-decelerate": "cubic-bezier(0, 0, 0.2, 1)",
+			"easing-accelerate": "cubic-bezier(0.4, 0, 1, 1)"
 		}
 	}
 }

--- a/packages/tokens/src/__fixtures__/extra-tokens.json
+++ b/packages/tokens/src/__fixtures__/extra-tokens.json
@@ -38,10 +38,13 @@
 		"typography": {
 			"font-sans": "system-ui, sans-serif",
 			"font-mono": "monospace",
+			"font-serif": "Georgia, serif",
 			"size-sm": "0.875rem",
 			"size-base": "1rem",
 			"size-lg": "1.125rem",
 			"size-xl": "1.25rem",
+			"size-2xl": "1.5rem",
+			"size-3xl": "1.875rem",
 			"weight-normal": "400",
 			"weight-medium": "500",
 			"weight-semibold": "600",
@@ -64,6 +67,14 @@
 		"opacity": {
 			"disabled": "0.5",
 			"hover": "0.8"
+		},
+		"motion": {
+			"duration-fast": "120ms",
+			"duration-base": "240ms",
+			"duration-slow": "480ms",
+			"easing-standard": "cubic-bezier(0.4, 0, 0.2, 1)",
+			"easing-decelerate": "cubic-bezier(0, 0, 0.2, 1)",
+			"easing-accelerate": "cubic-bezier(0.4, 0, 1, 1)"
 		}
 	}
 }

--- a/packages/tokens/src/__fixtures__/inherited-pair-fail.json
+++ b/packages/tokens/src/__fixtures__/inherited-pair-fail.json
@@ -1,0 +1,9 @@
+{
+	"name": "inherited-pair-fail",
+	"displayName": "Inherited Pair Failure Theme",
+	"tokens": {
+		"color": {
+			"background": "#1a1a1a"
+		}
+	}
+}

--- a/packages/tokens/src/__fixtures__/partial-theme.json
+++ b/packages/tokens/src/__fixtures__/partial-theme.json
@@ -1,0 +1,22 @@
+{
+	"name": "partial",
+	"displayName": "Partial Theme",
+	"tokens": {
+		"color": {
+			"background": "#f8f9fa",
+			"foreground": "#212529",
+			"primary": "#0d6efd",
+			"primary-foreground": "#ffffff",
+			"muted": "#e9ecef",
+			"muted-foreground": "#495057",
+			"border": "#dee2e6",
+			"ring": "#0d6efd",
+			"destructive": "#dc3545",
+			"destructive-foreground": "#ffffff"
+		},
+		"radius": {
+			"sm": "0.125rem",
+			"md": "0.25rem"
+		}
+	}
+}

--- a/packages/tokens/src/__fixtures__/valid-custom.json
+++ b/packages/tokens/src/__fixtures__/valid-custom.json
@@ -36,10 +36,13 @@
 		"typography": {
 			"font-sans": "system-ui, sans-serif",
 			"font-mono": "monospace",
+			"font-serif": "Georgia, serif",
 			"size-sm": "0.875rem",
 			"size-base": "1rem",
 			"size-lg": "1.125rem",
 			"size-xl": "1.25rem",
+			"size-2xl": "1.5rem",
+			"size-3xl": "1.875rem",
 			"weight-normal": "400",
 			"weight-medium": "500",
 			"weight-semibold": "600",
@@ -62,6 +65,14 @@
 		"opacity": {
 			"disabled": "0.5",
 			"hover": "0.8"
+		},
+		"motion": {
+			"duration-fast": "120ms",
+			"duration-base": "240ms",
+			"duration-slow": "480ms",
+			"easing-standard": "cubic-bezier(0.4, 0, 0.2, 1)",
+			"easing-decelerate": "cubic-bezier(0, 0, 0.2, 1)",
+			"easing-accelerate": "cubic-bezier(0.4, 0, 1, 1)"
 		}
 	}
 }

--- a/packages/tokens/src/defaults.test.ts
+++ b/packages/tokens/src/defaults.test.ts
@@ -1,0 +1,172 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { canonicalDefaultTokens } from './defaults';
+
+// ---------------------------------------------------------------------------
+// Drift guard for canonicalDefaultTokens.
+//
+// defaults.ts holds hand-resolved string literals (it can't import the JSON
+// sources, which aren't shipped; see defaults.ts header). This test reads the
+// actual DTCG sources and asserts the literals still match, so the defaults
+// can't silently rot when a source value changes.
+//
+// Structural categories + color have committed source files today. The motion,
+// ring, and z-index sources are authored by a parallel worker and may not exist
+// yet; those checks pin against the contract literals now and tighten to read
+// the source file the moment it lands (the existsSync branch).
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const tokensDir = resolve(__dirname, 'tokens');
+const themesDir = resolve(__dirname, '..', 'themes');
+
+interface DtcgLeaf {
+	$value?: string;
+	$type?: string;
+}
+type DtcgNode = DtcgLeaf | { [key: string]: DtcgNode };
+
+function readJson(path: string): Record<string, unknown> {
+	return JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
+}
+
+function isLeaf(node: DtcgNode): node is DtcgLeaf {
+	return '$value' in node;
+}
+
+/** Collapse a DTCG node to { key: stringValue }, preserving one level of nesting. */
+function flattenCategory(node: DtcgNode): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const [key, child] of Object.entries(node as Record<string, DtcgNode>)) {
+		out[key] = isLeaf(child) ? child.$value : flattenCategory(child);
+	}
+	return out;
+}
+
+/** Read a DTCG source file and return its single top-level category, flattened. */
+function flattenSource(path: string, category: string): Record<string, unknown> {
+	const doc = readJson(path);
+	return flattenCategory(doc[category] as DtcgNode);
+}
+
+/**
+ * Collapse a nested DTCG motion source (`duration.fast`) to the flat runtime
+ * keys (`duration-fast`) that schema.ts/defaults.ts use. The runtime theme
+ * document is uniformly two-level; the DTCG source is nested.
+ */
+function flattenMotionSource(path: string): Record<string, string> {
+	const motion = readJson(path).motion as Record<string, DtcgNode>;
+	const out: Record<string, string> = {};
+	for (const [group, leaves] of Object.entries(motion)) {
+		for (const [key, leaf] of Object.entries(leaves as Record<string, DtcgLeaf>)) {
+			out[`${group}-${key}`] = leaf.$value ?? '';
+		}
+	}
+	return out;
+}
+
+describe('canonicalDefaultTokens drift guard', () => {
+	it('matches src/tokens/spacing.json', () => {
+		expect(canonicalDefaultTokens.spacing).toEqual(
+			flattenSource(resolve(tokensDir, 'spacing.json'), 'spacing'),
+		);
+	});
+
+	it('matches src/tokens/typography.json for every key the source declares', () => {
+		// The source's existing keys must match exactly. The three new for-coleman
+		// keys (font-serif, size-2xl, size-3xl) are added to the source by a
+		// parallel task (T004); until that lands they live only in defaults.ts, so
+		// this checks the intersection and pins the new keys separately below.
+		const source = flattenSource(
+			resolve(tokensDir, 'typography.json'),
+			'typography',
+		);
+		const defaults = canonicalDefaultTokens.typography as Record<string, string>;
+		for (const [key, value] of Object.entries(source)) {
+			expect(defaults[key]).toEqual(value);
+		}
+	});
+
+	it('pins the new typography keys to the contract values', () => {
+		const defaults = canonicalDefaultTokens.typography as Record<string, string>;
+		expect(defaults['font-serif']).toBe(
+			'ui-serif, Georgia, Cambria, "Times New Roman", Times, serif',
+		);
+		expect(defaults['size-2xl']).toBe('1.5rem');
+		expect(defaults['size-3xl']).toBe('1.875rem');
+	});
+
+	it('matches src/tokens/radii.json', () => {
+		expect(canonicalDefaultTokens.radius).toEqual(
+			flattenSource(resolve(tokensDir, 'radii.json'), 'radius'),
+		);
+	});
+
+	it('matches src/tokens/shadows.json', () => {
+		expect(canonicalDefaultTokens.shadow).toEqual(
+			flattenSource(resolve(tokensDir, 'shadows.json'), 'shadow'),
+		);
+	});
+
+	it('matches src/tokens/opacity.json', () => {
+		expect(canonicalDefaultTokens.opacity).toEqual(
+			flattenSource(resolve(tokensDir, 'opacity.json'), 'opacity'),
+		);
+	});
+
+	it('sources color defaults from themes/light.json (the default theme)', () => {
+		expect(canonicalDefaultTokens.color).toEqual(
+			flattenSource(resolve(themesDir, 'light.json'), 'color'),
+		);
+	});
+
+	// The next three pin against contract values and upgrade to a source-file
+	// check the moment the parallel worker commits the source.
+	it('motion matches src/tokens/motion.json (flattened) when present, else the contract values', () => {
+		const sourcePath = resolve(tokensDir, 'motion.json');
+		if (existsSync(sourcePath)) {
+			expect(canonicalDefaultTokens.motion).toEqual(
+				flattenMotionSource(sourcePath),
+			);
+		}
+		else {
+			expect(canonicalDefaultTokens.motion).toEqual({
+				'duration-fast': '120ms',
+				'duration-base': '240ms',
+				'duration-slow': '480ms',
+				'easing-standard': 'cubic-bezier(0.4, 0, 0.2, 1)',
+				'easing-decelerate': 'cubic-bezier(0, 0, 0.2, 1)',
+				'easing-accelerate': 'cubic-bezier(0.4, 0, 1, 1)',
+			});
+		}
+	});
+
+	it('ring matches src/tokens/ring.json when present, else the contract value', () => {
+		const sourcePath = resolve(tokensDir, 'ring.json');
+		if (existsSync(sourcePath)) {
+			expect(canonicalDefaultTokens.ring).toEqual(
+				flattenSource(sourcePath, 'ring'),
+			);
+		}
+		else {
+			expect(canonicalDefaultTokens.ring).toEqual({ width: '3px' });
+		}
+	});
+
+	it('z-index matches src/tokens/z-index.json when present, else the contract values, ordered tooltip > popover > overlay', () => {
+		const sourcePath = resolve(tokensDir, 'z-index.json');
+		const zIndex = canonicalDefaultTokens['z-index'];
+		expect(zIndex).toBeDefined();
+		if (existsSync(sourcePath)) {
+			expect(zIndex).toEqual(flattenSource(sourcePath, 'z-index'));
+		}
+		else {
+			expect(zIndex).toEqual({ overlay: '50', popover: '55', tooltip: '60' });
+		}
+		// Ordering invariant from the contract, independent of the source.
+		expect(Number(zIndex!.tooltip)).toBeGreaterThan(Number(zIndex!.popover));
+		expect(Number(zIndex!.popover)).toBeGreaterThan(Number(zIndex!.overlay));
+	});
+});

--- a/packages/tokens/src/defaults.ts
+++ b/packages/tokens/src/defaults.ts
@@ -1,0 +1,133 @@
+import type { Theme } from './schema.js';
+
+// ---------------------------------------------------------------------------
+// Canonical default token values: the inheritance baseline for partial themes.
+//
+// A consumer runtime theme may override any subset of categories/keys (spec 008
+// US2). The validator merges the partial override onto THIS set, then validates
+// the complete merged result. Every omitted token inherits the value here.
+//
+// WHY a hand-resolved TS module instead of importing the JSON sources:
+//   The package ships only `dist` + `themes` (see package.json "files"); the
+//   DTCG sources under `src/tokens/*.json` are NOT published, and the `tsc`
+//   build does not copy them into `dist`. A `.ts` module that imported the JSON
+//   would emit a bare `import './tokens/typography.json'` into
+//   `dist/ts/defaults.js` that resolves to nothing in the published package.
+//   Resolving the values to string literals here keeps the module self-contained
+//   and shippable. `defaults.test.ts` is the drift guard: it reads the JSON
+//   sources + themes/light.json and asserts they still match these literals, so
+//   this file can't silently rot when a source value changes.
+//
+// VALUE SOURCES:
+//   - Structural categories (spacing, typography, radius, shadow, opacity) are
+//     theme-independent; their `$value`s come straight from `src/tokens/*.json`.
+//   - `color` defaults come from `themes/light.json`. Light is the base/default
+//     theme; a partial theme that omits a color inherits the light value. (Note:
+//     today light.json's colors equal src/tokens/color.json's, but light is the
+//     intentional source. See defaults.test.ts.)
+//   - `motion`, `ring`, `z-index` are hardcoded from contracts/token-schema.md
+//     because their DTCG source files (motion.json, ring.json, z-index.json) are
+//     authored by a parallel worker (tasks T003/T013/T014) and may not exist yet.
+//     THESE MUST STAY IN SYNC with those source files once they land; the drift
+//     guard extends to cover them when the sources exist.
+// ---------------------------------------------------------------------------
+
+type ResolvedTokens = Theme['tokens'];
+
+export const canonicalDefaultTokens: ResolvedTokens = {
+	// from themes/light.json (the default theme)
+	'color': {
+		'background': 'oklch(1.0000 0.0000 89.88)',
+		'foreground': 'oklch(0.1408 0.0044 285.82)',
+		'primary': 'oklch(0.2103 0.0059 285.89)',
+		'primary-foreground': 'oklch(0.9851 0.0000 89.88)',
+		'muted': 'oklch(0.9674 0.0013 286.38)',
+		'muted-foreground': 'oklch(0.5434 0.0138 285.94)',
+		'border': 'oklch(0.9197 0.0040 286.32)',
+		'ring': 'oklch(0.2103 0.0059 285.89)',
+		'destructive': 'oklch(0.5803 0.2078 25.33)',
+		'destructive-foreground': 'oklch(0.9851 0.0000 89.88)',
+	},
+	// from src/tokens/spacing.json
+	'spacing': {
+		px: '1px',
+		1: '0.25rem',
+		2: '0.5rem',
+		3: '0.75rem',
+		4: '1rem',
+		5: '1.25rem',
+		6: '1.5rem',
+		7: '1.75rem',
+		8: '2rem',
+		9: '2.25rem',
+		10: '2.5rem',
+		11: '2.75rem',
+		12: '3rem',
+		13: '3.25rem',
+		14: '3.5rem',
+		15: '3.75rem',
+		16: '4rem',
+	},
+	// from src/tokens/typography.json (font-serif, size-2xl, size-3xl per contract)
+	'typography': {
+		'font-sans':
+			'ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+		'font-mono':
+			'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+		'font-serif': 'ui-serif, Georgia, Cambria, "Times New Roman", Times, serif',
+		'size-sm': '0.875rem',
+		'size-base': '1rem',
+		'size-lg': '1.125rem',
+		'size-xl': '1.25rem',
+		'size-2xl': '1.5rem',
+		'size-3xl': '1.875rem',
+		'weight-normal': '400',
+		'weight-medium': '500',
+		'weight-semibold': '600',
+		'weight-bold': '700',
+		'leading-normal': '1.5',
+		'leading-tight': '1.25',
+		'leading-relaxed': '1.625',
+	},
+	// from src/tokens/radii.json
+	'radius': {
+		sm: '0.25rem',
+		md: '0.375rem',
+		lg: '0.5rem',
+		full: '9999px',
+	},
+	// from src/tokens/shadows.json
+	'shadow': {
+		sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+		md: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+		lg: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+	},
+	// from src/tokens/opacity.json
+	'opacity': {
+		disabled: '0.5',
+		hover: '0.8',
+	},
+	// Flattened to two-level (see schema.ts motionTokens). Hardcoded from
+	// contracts/token-schema.md (durations 120/240/480ms; the three platform
+	// cubic-beziers). MUST match src/tokens/motion.json's $values once it lands.
+	'motion': {
+		'duration-fast': '120ms',
+		'duration-base': '240ms',
+		'duration-slow': '480ms',
+		'easing-standard': 'cubic-bezier(0.4, 0, 0.2, 1)',
+		'easing-decelerate': 'cubic-bezier(0, 0, 0.2, 1)',
+		'easing-accelerate': 'cubic-bezier(0.4, 0, 1, 1)',
+	},
+	// optional categories, included so an omitting theme still inherits them.
+	// hardcoded from contracts/token-schema.md; MUST match src/tokens/ring.json
+	// and src/tokens/z-index.json once they land. z-index is ordered so tooltip
+	// stacks above popover above overlay (the latent z-50 bug fix).
+	'ring': {
+		width: '3px',
+	},
+	'z-index': {
+		overlay: '50',
+		popover: '55',
+		tooltip: '60',
+	},
+};

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -1,8 +1,12 @@
-export { contrastPairs, themeSchema } from './schema.js';
-export type { ContrastPair, Theme } from './schema.js';
+export { canonicalDefaultTokens } from './defaults.js';
+
+export { resolveTheme } from './resolve.js';
+
+export { contrastPairs, partialThemeSchema, themeSchema } from './schema.js';
+export type { ContrastPair, PartialTheme, Theme } from './schema.js';
 
 export { tokenMap } from './token-map.js';
 export type { TokenCategory, TokenDefinition } from './token-map.js';
 
-export { validateTheme } from './validate.js';
+export { checkThemeCompleteness, validateTheme } from './validate.js';
 export type { ValidationIssue, ValidationResult } from './validate.js';

--- a/packages/tokens/src/resolve.test.ts
+++ b/packages/tokens/src/resolve.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { canonicalDefaultTokens } from './defaults.js';
+import { resolveTheme } from './resolve.js';
+
+describe('resolveTheme', () => {
+	it('returns the canonical defaults verbatim for an empty override', () => {
+		const resolved = resolveTheme({});
+		expect(resolved).toEqual(canonicalDefaultTokens);
+	});
+
+	it('returns the canonical defaults for an undefined override', () => {
+		expect(resolveTheme(undefined)).toEqual(canonicalDefaultTokens);
+	});
+
+	it('lets the override win on the keys it supplies', () => {
+		const resolved = resolveTheme({
+			color: { background: '#000000' },
+		});
+		expect(resolved.color.background).toBe('#000000');
+	});
+
+	it('merges PER-KEY within a category rather than replacing the whole category', () => {
+		// A partial color override must keep every OTHER default color, not
+		// collapse the color category down to the single overridden key.
+		const resolved = resolveTheme({
+			color: { background: '#000000' },
+		});
+		expect(resolved.color.background).toBe('#000000');
+		expect(resolved.color.foreground).toBe(
+			canonicalDefaultTokens.color.foreground,
+		);
+		expect(resolved.color.primary).toBe(canonicalDefaultTokens.color.primary);
+		// The full key set survives the merge.
+		expect(Object.keys(resolved.color).sort()).toEqual(
+			Object.keys(canonicalDefaultTokens.color).sort(),
+		);
+	});
+
+	it('inherits omitted whole categories from the defaults', () => {
+		// Override only color; spacing/typography/radius/motion all inherit.
+		const resolved = resolveTheme({
+			color: { background: '#000000' },
+		});
+		expect(resolved.spacing).toEqual(canonicalDefaultTokens.spacing);
+		expect(resolved.typography).toEqual(canonicalDefaultTokens.typography);
+		expect(resolved.radius).toEqual(canonicalDefaultTokens.radius);
+		expect(resolved.motion).toEqual(canonicalDefaultTokens.motion);
+	});
+
+	it('inherits omitted keys within an overridden category', () => {
+		const resolved = resolveTheme({
+			radius: { sm: '0px' },
+		});
+		expect(resolved.radius.sm).toBe('0px');
+		expect(resolved.radius.md).toBe(canonicalDefaultTokens.radius.md);
+		expect(resolved.radius.lg).toBe(canonicalDefaultTokens.radius.lg);
+		expect(resolved.radius.full).toBe(canonicalDefaultTokens.radius.full);
+	});
+
+	it('merges multiple categories at once, each independently', () => {
+		const resolved = resolveTheme({
+			color: { primary: '#ff0000' },
+			radius: { md: '1rem' },
+		});
+		expect(resolved.color.primary).toBe('#ff0000');
+		expect(resolved.color.background).toBe(
+			canonicalDefaultTokens.color.background,
+		);
+		expect(resolved.radius.md).toBe('1rem');
+		expect(resolved.radius.sm).toBe(canonicalDefaultTokens.radius.sm);
+	});
+
+	it('does not mutate the canonical defaults', () => {
+		const before = canonicalDefaultTokens.color.background;
+		resolveTheme({ color: { background: '#abcdef' } });
+		expect(canonicalDefaultTokens.color.background).toBe(before);
+	});
+});

--- a/packages/tokens/src/resolve.ts
+++ b/packages/tokens/src/resolve.ts
@@ -1,0 +1,66 @@
+import type { PartialTheme, Theme } from './schema.js';
+import { canonicalDefaultTokens } from './defaults.js';
+
+// ---------------------------------------------------------------------------
+// resolveTheme — the inheritance step (spec 008 US2).
+//
+// A consumer runtime theme may override any subset of categories, and any
+// subset of keys within a category. Before validation, the override is merged
+// onto the canonical defaults so completeness and WCAG AA contrast check the
+// COMPLETE merged result, never the raw fragment. Without this merge, a theme
+// overriding one side of a contrast pair (e.g. color.background but not
+// color.foreground) would slip past the old skip-when-a-side-is-absent path.
+//
+// The merge is PER-KEY within a category, not category-replace: a partial
+// `{ color: { background: X } }` yields all default colors with only
+// `background` overridden, NOT a color category collapsed to a single key.
+// Every category is uniformly two-level (`{ [key]: string }`) — motion keys are
+// flat (`duration-fast`, `easing-standard`), so no nesting logic is needed.
+// ---------------------------------------------------------------------------
+
+type ResolvedTokens = Theme['tokens'];
+type PartialTokens = NonNullable<PartialTheme['tokens']>;
+
+type Category = Record<string, string | undefined>;
+
+/**
+ * Deep-merge a partial token override onto the canonical defaults. The override
+ * wins per-key; omitted keys and omitted whole categories inherit the default.
+ *
+ * Returns a complete token set suitable for strict-schema validation. Pure: it
+ * reads only `canonicalDefaultTokens` and the argument, touches no globals, and
+ * is therefore SSR-safe.
+ */
+export function resolveTheme(
+	partialTokens: PartialTokens | undefined,
+): ResolvedTokens {
+	const defaults = canonicalDefaultTokens as Record<string, Category>;
+	const override = (partialTokens ?? {}) as Record<string, Category>;
+
+	const merged: Record<string, Category> = {};
+
+	// Seed from defaults so every default category is present even when the
+	// override never mentions it.
+	for (const [category, group] of Object.entries(defaults)) {
+		merged[category] = { ...group };
+	}
+
+	// Layer the override per-key. A category absent from defaults (a theme could
+	// supply `ring`/`z-index` without a default, though defaults carries them)
+	// still merges cleanly.
+	for (const [category, group] of Object.entries(override)) {
+		if (!group)
+			continue;
+		const base = merged[category] ?? {};
+		for (const [key, value] of Object.entries(group)) {
+			// deepPartial leaves omitted keys as `undefined`; skip them so the
+			// inherited default survives rather than being clobbered by undefined.
+			if (value === undefined)
+				continue;
+			base[key] = value;
+		}
+		merged[category] = base;
+	}
+
+	return merged as unknown as ResolvedTokens;
+}

--- a/packages/tokens/src/runtime.test.ts
+++ b/packages/tokens/src/runtime.test.ts
@@ -2,7 +2,12 @@ import { createHash } from 'node:crypto';
 import { runInThisContext } from 'node:vm';
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { getThemeBootstrapScript, themeBootstrapScript } from './runtime.js';
+import {
+	getThemeBootstrapScript,
+	registerTheme,
+	themeBootstrapScript,
+	ThemeValidationError,
+} from './runtime.js';
 
 describe('getThemeBootstrapScript', () => {
 	it('returns a string containing the canonical storage key and the default \'light\' fallback', () => {
@@ -52,5 +57,115 @@ describe('getThemeBootstrapScript', () => {
 
 	it('themeBootstrapScript constant equals getThemeBootstrapScript() with no args', () => {
 		expect(themeBootstrapScript).toBe(getThemeBootstrapScript());
+	});
+});
+
+describe('registerTheme (resolve-then-inject, spec 008 US2)', () => {
+	beforeEach(() => {
+		// jsdom carries DOM state across tests; clear injected style blocks.
+		document.head.innerHTML = '';
+	});
+
+	function injectedCss(themeName: string): string {
+		const style = document.getElementById(`ds-theme-${themeName}`);
+		return style?.textContent ?? '';
+	}
+
+	// A self-consistent AA-passing color block. The canonical DEFAULT colors
+	// (from themes/light.json) sit a hair under 4.5:1 on the muted and
+	// destructive pairs, so a partial theme that INHERITS them would now fail the
+	// (correctly un-skipped) contrast gate. These tests are about merge/injection
+	// mechanics, not the defaults' contrast, so they supply a passing color set
+	// and let the NON-color categories demonstrate inheritance.
+	const passingColors = {
+		'background': '#f8f9fa',
+		'foreground': '#212529',
+		'primary': '#0d6efd',
+		'primary-foreground': '#ffffff',
+		'muted': '#e9ecef',
+		'muted-foreground': '#495057',
+		'border': '#dee2e6',
+		'ring': '#0d6efd',
+		'destructive': '#dc3545',
+		'destructive-foreground': '#ffffff',
+	};
+
+	// T012a — a PARTIAL override must inject the FULL merged var set, not just the
+	// keys it touched. This is what proves registerTheme iterates the RESOLVED
+	// theme (validateTheme's merged return) rather than the raw input. The theme
+	// touches only color + radius; every other category is inherited and must
+	// still appear in the injected <style>.
+	it('injects a complete <style> block for a partial theme (inherited categories appear)', () => {
+		registerTheme({
+			name: 'partial-runtime',
+			displayName: 'Partial Runtime',
+			tokens: {
+				color: passingColors,
+				radius: { md: '1rem' },
+			},
+		});
+		const css = injectedCss('partial-runtime');
+
+		// The overridden keys are present...
+		expect(css).toContain('--color-primary:');
+		expect(css).toContain('--radius-md: 1rem;');
+		// ...and so are vars from categories the partial never mentioned.
+		expect(css).toContain('--spacing-4:');
+		expect(css).toContain('--typography-font-serif:');
+		expect(css).toContain('--ease-standard:');
+	});
+
+	// T010 — motion's flat keys must emit Tailwind-aligned var names so a runtime
+	// override actually lands on the same vars the build emits (--duration-*,
+	// --ease-*), never --motion-*.
+	it('emits Tailwind-aligned motion var names (--duration-*/--ease-*, not --motion-*)', () => {
+		registerTheme({
+			name: 'motion-runtime',
+			displayName: 'Motion Runtime',
+			tokens: {
+				color: passingColors,
+				motion: { 'duration-fast': '90ms' },
+			},
+		});
+		const css = injectedCss('motion-runtime');
+
+		expect(css).toContain('--duration-fast: 90ms;');
+		expect(css).toContain('--ease-standard:');
+		expect(css).not.toContain('--motion-');
+	});
+
+	it('accepts a full legacy theme unchanged (no regression)', () => {
+		registerTheme({
+			name: 'full-runtime',
+			displayName: 'Full Runtime',
+			tokens: {
+				color: {
+					'background': '#f8f9fa',
+					'foreground': '#212529',
+					'primary': '#0d6efd',
+					'primary-foreground': '#ffffff',
+					'muted': '#e9ecef',
+					'muted-foreground': '#495057',
+					'border': '#dee2e6',
+					'ring': '#0d6efd',
+					'destructive': '#dc3545',
+					'destructive-foreground': '#ffffff',
+				},
+			},
+		});
+		expect(injectedCss('full-runtime')).toContain('--color-background:');
+	});
+
+	// The post-oklch-conversion contrast pass must fail an INHERITED pair too: a
+	// theme overriding only the background is checked against the inherited
+	// foreground after both convert to oklch. The old skip silently passed it.
+	it('throws when an inherited contrast pair fails after oklch conversion', () => {
+		expect(() =>
+			registerTheme({
+				name: 'inherited-fail-runtime',
+				displayName: 'Inherited Fail Runtime',
+				tokens: { color: { background: '#1a1a1a' } },
+			}),
+		).toThrow(ThemeValidationError);
 	});
 });

--- a/packages/tokens/src/runtime.ts
+++ b/packages/tokens/src/runtime.ts
@@ -1,4 +1,4 @@
-import type { Theme } from './schema.js';
+import type { PartialTheme } from './schema.js';
 import { contrastRatio, hexToOklch, parseColor } from './color.js';
 import { contrastPairs } from './schema.js';
 import { validateTheme } from './validate.js';
@@ -40,6 +40,28 @@ export function getThemeBootstrapScript(
  */
 export const themeBootstrapScript: string = getThemeBootstrapScript();
 
+// ---------------------------------------------------------------------------
+// CSS variable naming. Every category emits `--<category>-<key>` EXCEPT motion:
+// the Style Dictionary build special-cases motion to Tailwind's namespaces
+// (`--duration-*` for durations, `--ease-*` for easings) so they generate real
+// `ease-*` utilities rather than dead `--motion-*` vars. Runtime injection must
+// match those names exactly, or a registered theme's motion override would emit
+// `--motion-duration-fast` that nothing in the built CSS reads. The schema's
+// motion keys are flat (`duration-fast`, `easing-standard`), so the mapping is
+// a prefix swap: `duration-` stays, `easing-` becomes `ease-`.
+// ---------------------------------------------------------------------------
+
+function cssVarName(category: string, key: string): string {
+	if (category === 'motion') {
+		if (key.startsWith('easing-'))
+			return `--ease-${key.slice('easing-'.length)}`;
+		// durations (and any other flat motion key) keep their key verbatim,
+		// matching the build's `--duration-*` namespace.
+		return `--${key}`;
+	}
+	return `--${category}-${key}`;
+}
+
 export class ThemeValidationError extends Error {
 	constructor(
 		message: string,
@@ -58,9 +80,14 @@ export class ThemeValidationError extends Error {
  * Validates a theme and injects a `<style>` block scoped to
  * `[data-theme="<name>"]` into the document head.
  *
+ * Accepts a PARTIAL theme (spec 008 US2): any subset of categories/keys. It is
+ * resolved against the canonical defaults before validation and injection, so a
+ * partial override still emits the full merged var set. A complete `Theme` is
+ * assignable to `PartialTheme`, so existing full-theme callers are unaffected.
+ *
  * Throws `ThemeValidationError` if the theme fails validation.
  */
-export function registerTheme(themeJson: Theme): void {
+export function registerTheme(themeJson: PartialTheme): void {
 	const result = validateTheme(themeJson);
 
 	if (!result.ok) {
@@ -70,6 +97,10 @@ export function registerTheme(themeJson: Theme): void {
 		);
 	}
 
+	// validateTheme now returns the RESOLVED (merged) theme: a partial override
+	// layered onto the canonical defaults. Iterating it injects the FULL var set,
+	// so a color-only theme still emits every spacing/radius/motion var rather
+	// than only the keys the consumer touched.
 	const { theme } = result;
 	const selector = `[data-theme="${theme.name}"]`;
 
@@ -85,20 +116,22 @@ export function registerTheme(themeJson: Theme): void {
 			if (category === 'color') {
 				convertedColors[`color.${key}`] = cssValue;
 			}
-			vars.push(`  --${category}-${key}: ${cssValue};`);
+			vars.push(`  ${cssVarName(category, key)}: ${cssValue};`);
 		}
 	}
 
-	// Verify contrast still passes on the converted oklch values
+	// Verify contrast still passes on the converted oklch values. The merged
+	// theme always carries the full color set, so every pair resolves — the old
+	// skip-when-a-side-is-absent path is gone (it silently passed a failing pair
+	// when a partial theme overrode only one side).
 	const postConversionIssues: Array<{ path: string; code: string; message: string }> = [];
 	for (const pair of contrastPairs) {
 		const fgValue = convertedColors[pair.foreground];
 		const bgValue = convertedColors[pair.background];
-		if (!fgValue || !bgValue)
-			continue;
 
-		const fgLinear = parseColor(fgValue);
-		const bgLinear = parseColor(bgValue);
+		const fgLinear = fgValue ? parseColor(fgValue) : null;
+		const bgLinear = bgValue ? parseColor(bgValue) : null;
+		// Unparseable converted color (not a missing side) — nothing to compare.
 		if (!fgLinear || !bgLinear)
 			continue;
 

--- a/packages/tokens/src/schema.test.ts
+++ b/packages/tokens/src/schema.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from 'vitest';
+import { canonicalDefaultTokens } from './defaults';
 import validCustom from './__fixtures__/valid-custom.json';
-import { contrastPairs, themeSchema } from './schema';
+import { contrastPairs, partialThemeSchema, themeSchema } from './schema';
+
+// A COMPLETE token set, built from the canonical defaults so these schema-shape
+// tests don't couple to __fixtures__/valid-custom.json (owned by the validator
+// worker). Spreading the resolved defaults guarantees every required category/key
+// is present; individual tests then delete a field to prove it's required, or
+// omit an optional category to prove it inherits.
+const completeTokens = structuredClone(canonicalDefaultTokens);
+const completeTheme = {
+	name: 'shape-test',
+	displayName: 'Shape Test',
+	tokens: completeTokens,
+};
 
 describe('themeSchema', () => {
 	it('accepts a valid theme with hex colors', () => {
@@ -75,5 +88,118 @@ describe('contrastPairs', () => {
 			expect(pair.foreground).toMatch(/^color\./);
 			expect(pair.background).toMatch(/^color\./);
 		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Spec 008 token-vocabulary growth: motion (required), the three new typography
+// keys (required), and ring/z-index (optional). These assert the SCHEMA SHAPE —
+// what the strict themeSchema demands and what partialThemeSchema lets a consumer
+// omit — independent of any fixture's contents.
+// ---------------------------------------------------------------------------
+
+describe('themeSchema — motion category (required)', () => {
+	it('accepts a complete theme carrying the motion category', () => {
+		const result = themeSchema.safeParse(completeTheme);
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects a complete theme missing the entire motion category', () => {
+		const theme = structuredClone(completeTheme);
+		delete (theme.tokens as Record<string, unknown>).motion;
+		const result = themeSchema.safeParse(theme);
+		expect(result.success).toBe(false);
+	});
+
+	it.each([
+		'duration-fast',
+		'duration-base',
+		'duration-slow',
+		'easing-standard',
+		'easing-decelerate',
+		'easing-accelerate',
+	])('requires motion.%s', (key) => {
+		const theme = structuredClone(completeTheme);
+		delete (theme.tokens.motion as Record<string, unknown>)[key];
+		const result = themeSchema.safeParse(theme);
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('themeSchema — new required typography keys', () => {
+	it.each(['font-serif', 'size-2xl', 'size-3xl'])(
+		'requires typography.%s',
+		(key) => {
+			const theme = structuredClone(completeTheme);
+			delete (theme.tokens.typography as Record<string, unknown>)[key];
+			const result = themeSchema.safeParse(theme);
+			expect(result.success).toBe(false);
+		},
+	);
+});
+
+describe('themeSchema — ring and z-index are optional', () => {
+	it('accepts a complete theme that omits ring', () => {
+		const theme = structuredClone(completeTheme);
+		delete (theme.tokens as Record<string, unknown>).ring;
+		const result = themeSchema.safeParse(theme);
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts a complete theme that omits z-index', () => {
+		const theme = structuredClone(completeTheme);
+		delete (theme.tokens as Record<string, unknown>)['z-index'];
+		const result = themeSchema.safeParse(theme);
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts a complete theme that omits both ring and z-index', () => {
+		const theme = structuredClone(completeTheme);
+		delete (theme.tokens as Record<string, unknown>).ring;
+		delete (theme.tokens as Record<string, unknown>)['z-index'];
+		const result = themeSchema.safeParse(theme);
+		expect(result.success).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// T015/T016: ring and z-index are optional drift tokens (spec 008 US4). A
+// consumer runtime theme that omits them must parse against partialThemeSchema —
+// the lenient INITIAL parse — and inherit the canonical defaults downstream. This
+// is the partial-input path that registerTheme/validateTheme actually feed.
+// ---------------------------------------------------------------------------
+
+describe('partialThemeSchema — optional ring/z-index inheritance', () => {
+	it('parses a color-only partial theme (omits ring, z-index, and motion)', () => {
+		const partial = {
+			name: 'color-only',
+			displayName: 'Color Only',
+			tokens: { color: { primary: 'oklch(0.5 0.1 250)' } },
+		};
+		const result = partialThemeSchema.safeParse(partial);
+		expect(result.success).toBe(true);
+	});
+
+	it('parses a partial theme that supplies ring/z-index but omits other categories', () => {
+		const partial = {
+			name: 'drift-only',
+			displayName: 'Drift Only',
+			tokens: {
+				ring: { width: '2px' },
+				'z-index': { overlay: '40', popover: '45', tooltip: '50' },
+			},
+		};
+		const result = partialThemeSchema.safeParse(partial);
+		expect(result.success).toBe(true);
+	});
+
+	it('parses a partial theme that omits ring/z-index entirely (inherit on omit)', () => {
+		const partial = {
+			name: 'no-drift',
+			displayName: 'No Drift',
+			tokens: { radius: { md: '0.5rem' } },
+		};
+		const result = partialThemeSchema.safeParse(partial);
+		expect(result.success).toBe(true);
 	});
 });

--- a/packages/tokens/src/schema.ts
+++ b/packages/tokens/src/schema.ts
@@ -1,8 +1,11 @@
 import { z } from 'zod';
 
 // ---------------------------------------------------------------------------
-// Token schema — mirrors the 6 token categories from the DTCG source files.
-// Every theme must provide a value for every token defined here.
+// Token schema. Mirrors the token categories from the DTCG source files.
+// The strict `themeSchema` represents a COMPLETE theme: every required
+// category/key must be present. Consumer runtime themes may be PARTIAL (see
+// `partialThemeSchema` below); they get merged onto `canonicalDefaultTokens`
+// before being validated against the strict schema.
 // ---------------------------------------------------------------------------
 
 const colorTokens = z.object({
@@ -41,10 +44,15 @@ const spacingTokens = z.object({
 const typographyTokens = z.object({
 	'font-sans': z.string(),
 	'font-mono': z.string(),
+	// font-serif + size-2xl/3xl are required: a consumer theme must carry them
+	// (or inherit them from the canonical defaults). Added for for-coleman (spec 008).
+	'font-serif': z.string(),
 	'size-sm': z.string(),
 	'size-base': z.string(),
 	'size-lg': z.string(),
 	'size-xl': z.string(),
+	'size-2xl': z.string(),
+	'size-3xl': z.string(),
 	'weight-normal': z.string(),
 	'weight-medium': z.string(),
 	'weight-semibold': z.string(),
@@ -72,26 +80,95 @@ const opacityTokens = z.object({
 	hover: z.string(),
 });
 
+// Motion keys are FLATTENED (duration-fast, easing-standard) rather than nested
+// (duration.fast). The runtime theme document is uniformly two-level
+// (`tokens.<category>.<key> = string`), which is what validate.ts/runtime.ts
+// iterate and inject as `--<category>-<key>`. A nested motion object would make
+// the value an object, breaking that loop and the `Record<string,
+// Record<string,string>>` shape the runtime layer relies on. The DTCG source
+// (motion.json) stays nested per Style Dictionary convention; the build emits
+// the Tailwind-aligned `--duration-*` / `--ease-*` names. The contract
+// (token-schema.md) leaves nested-vs-flat to the implementer. Required.
+const motionTokens = z.object({
+	'duration-fast': z.string(),
+	'duration-base': z.string(),
+	'duration-slow': z.string(),
+	'easing-standard': z.string(),
+	'easing-decelerate': z.string(),
+	'easing-accelerate': z.string(),
+});
+
+// ring + z-index are the optional drift-killing categories (spec 008 US4): a
+// theme that omits them inherits the canonical defaults, so they never break an
+// existing color-only theme. Optional-ness is applied at the category level in
+// the tokens object below, not here.
+const ringTokens = z.object({
+	width: z.string(),
+});
+
+const zIndexTokens = z.object({
+	overlay: z.string(),
+	popover: z.string(),
+	tooltip: z.string(),
+});
+
+// The complete tokens shape: required categories required, ring/z-index optional.
+// The `z-index` key carries a hyphen, so the lint rule quotes every sibling key
+// for consistency; the emitted dot-paths stay `z-index.overlay` etc.
+const tokensSchema = z.object({
+	'color': colorTokens,
+	'spacing': spacingTokens,
+	'typography': typographyTokens,
+	'radius': radiiTokens,
+	'shadow': shadowTokens,
+	'opacity': opacityTokens,
+	'motion': motionTokens,
+	'ring': ringTokens.optional(),
+	'z-index': zIndexTokens.optional(),
+});
+
 // ---------------------------------------------------------------------------
-// Theme schema — the user-facing format consumed by validateTheme / registerTheme.
+// Theme schema: the user-facing format consumed by validateTheme / registerTheme.
+// `themeSchema` is STRICT: it validates a COMPLETE theme (the merged result of a
+// partial override layered onto canonicalDefaultTokens). The downstream validator
+// parses raw consumer input with `partialThemeSchema`, merges onto defaults, then
+// validates the merged result here.
 // ---------------------------------------------------------------------------
 
 export const themeSchema = z
 	.object({
 		name: z.string().min(1),
 		displayName: z.string().min(1),
-		tokens: z.object({
-			color: colorTokens,
-			spacing: spacingTokens,
-			typography: typographyTokens,
-			radius: radiiTokens,
-			shadow: shadowTokens,
-			opacity: opacityTokens,
-		}),
+		tokens: tokensSchema,
 	})
 	.passthrough();
 
 export type Theme = z.infer<typeof themeSchema>;
+
+// ---------------------------------------------------------------------------
+// Partial (lenient) theme schema, for the INITIAL parse of consumer input.
+//
+// A consumer runtime theme may override any subset of categories, and any subset
+// of keys within a category (spec 008 US2: "themes can override any token
+// category"). `deepPartial()` makes every category optional, and every key inside
+// each category optional too, so a `color`-only or `color`+`radius` fragment
+// parses cleanly. The validator then merges this fragment onto
+// canonicalDefaultTokens and re-validates the COMPLETE result against the strict
+// `themeSchema` above.
+//
+// `name`/`displayName` stay required: a runtime theme still needs an identity to
+// key its injected `<style>` block on. Only the `tokens` payload is partial.
+// ---------------------------------------------------------------------------
+
+export const partialThemeSchema = z
+	.object({
+		name: z.string().min(1),
+		displayName: z.string().min(1),
+		tokens: tokensSchema.deepPartial(),
+	})
+	.passthrough();
+
+export type PartialTheme = z.infer<typeof partialThemeSchema>;
 
 // ---------------------------------------------------------------------------
 // Contrast pairs — declared foreground/background pairs for WCAG AA checking.

--- a/packages/tokens/src/themes-contrast.test.ts
+++ b/packages/tokens/src/themes-contrast.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { contrastRatio, parseColor } from './color.js';
+import { contrastPairs } from './schema.js';
+
+// Guards every built-in theme against its own declared WCAG AA contrast pairs.
+// Spec 008 exposed that light's muted-foreground/muted (4.40) and
+// destructive-foreground/destructive (3.61) sat just under 4.5 — invisible while
+// the validator skipped pairs, but a real failure once a partial runtime theme
+// inherits those defaults. This test fails loudly if any built-in theme drifts
+// below threshold on any declared pair.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const themesDir = join(here, '..', 'themes');
+const load = (name: string): Record<string, Record<string, { $value: string }>> =>
+	JSON.parse(readFileSync(join(themesDir, `${name}.json`), 'utf8'));
+
+const themes: Record<string, ReturnType<typeof load>> = {
+	light: load('light'),
+	dark: load('dark'),
+	brand: load('brand'),
+};
+
+function resolve(theme: ReturnType<typeof load>, dotPath: string): string | undefined {
+	const [category, key] = dotPath.split('.');
+	return theme[category ?? '']?.[key ?? '']?.$value;
+}
+
+describe('built-in theme contrast (WCAG AA)', () => {
+	for (const [name, theme] of Object.entries(themes)) {
+		for (const pair of contrastPairs) {
+			it(`${name}: ${pair.foreground} / ${pair.background} meets ${pair.threshold}:1`, () => {
+				const fg = resolve(theme, pair.foreground);
+				const bg = resolve(theme, pair.background);
+				expect(fg, `${pair.foreground} present`).toBeDefined();
+				expect(bg, `${pair.background} present`).toBeDefined();
+
+				const f = parseColor(fg!);
+				const b = parseColor(bg!);
+				expect(f, `${pair.foreground} parseable`).not.toBeNull();
+				expect(b, `${pair.background} parseable`).not.toBeNull();
+
+				const ratio = contrastRatio(f!, b!);
+				expect(ratio).toBeGreaterThanOrEqual(pair.threshold);
+			});
+		}
+	}
+});

--- a/packages/tokens/src/token-map.ts
+++ b/packages/tokens/src/token-map.ts
@@ -4,7 +4,10 @@ export type TokenCategory
 		| 'typography'
 		| 'radii'
 		| 'shadows'
-		| 'opacity';
+		| 'opacity'
+		| 'motion'
+		| 'ring'
+		| 'z-index';
 
 export interface TokenDefinition {
 	name: string;
@@ -52,10 +55,13 @@ export const tokenMap: Record<string, TokenDefinition> = {
 	// Typography tokens
 	'typography.font-sans': { name: 'typography.font-sans', category: 'typography', type: 'fontFamily', cssVariable: '--typography-font-sans' },
 	'typography.font-mono': { name: 'typography.font-mono', category: 'typography', type: 'fontFamily', cssVariable: '--typography-font-mono' },
+	'typography.font-serif': { name: 'typography.font-serif', category: 'typography', type: 'fontFamily', cssVariable: '--typography-font-serif' },
 	'typography.size-sm': { name: 'typography.size-sm', category: 'typography', type: 'dimension', cssVariable: '--typography-size-sm' },
 	'typography.size-base': { name: 'typography.size-base', category: 'typography', type: 'dimension', cssVariable: '--typography-size-base' },
 	'typography.size-lg': { name: 'typography.size-lg', category: 'typography', type: 'dimension', cssVariable: '--typography-size-lg' },
 	'typography.size-xl': { name: 'typography.size-xl', category: 'typography', type: 'dimension', cssVariable: '--typography-size-xl' },
+	'typography.size-2xl': { name: 'typography.size-2xl', category: 'typography', type: 'dimension', cssVariable: '--typography-size-2xl' },
+	'typography.size-3xl': { name: 'typography.size-3xl', category: 'typography', type: 'dimension', cssVariable: '--typography-size-3xl' },
 	'typography.weight-normal': { name: 'typography.weight-normal', category: 'typography', type: 'fontWeight', cssVariable: '--typography-weight-normal' },
 	'typography.weight-medium': { name: 'typography.weight-medium', category: 'typography', type: 'fontWeight', cssVariable: '--typography-weight-medium' },
 	'typography.weight-semibold': { name: 'typography.weight-semibold', category: 'typography', type: 'fontWeight', cssVariable: '--typography-weight-semibold' },
@@ -78,4 +84,23 @@ export const tokenMap: Record<string, TokenDefinition> = {
 	// Opacity tokens
 	'opacity.disabled': { name: 'opacity.disabled', category: 'opacity', type: 'number', cssVariable: '--opacity-disabled' },
 	'opacity.hover': { name: 'opacity.hover', category: 'opacity', type: 'number', cssVariable: '--opacity-hover' },
+
+	// Motion tokens — DTCG source stays nested (motion.duration.fast), but the
+	// emitted var name flattens to the Tailwind-aligned --duration-*/--ease-* so
+	// easings drive real ease-* utilities. Keep these cssVariables in lockstep
+	// with tokenToCssVar in sd.config.ts.
+	'motion.duration.fast': { name: 'motion.duration.fast', category: 'motion', type: 'duration', cssVariable: '--duration-fast' },
+	'motion.duration.base': { name: 'motion.duration.base', category: 'motion', type: 'duration', cssVariable: '--duration-base' },
+	'motion.duration.slow': { name: 'motion.duration.slow', category: 'motion', type: 'duration', cssVariable: '--duration-slow' },
+	'motion.easing.standard': { name: 'motion.easing.standard', category: 'motion', type: 'cubicBezier', cssVariable: '--ease-standard' },
+	'motion.easing.decelerate': { name: 'motion.easing.decelerate', category: 'motion', type: 'cubicBezier', cssVariable: '--ease-decelerate' },
+	'motion.easing.accelerate': { name: 'motion.easing.accelerate', category: 'motion', type: 'cubicBezier', cssVariable: '--ease-accelerate' },
+
+	// Ring tokens (optional category)
+	'ring.width': { name: 'ring.width', category: 'ring', type: 'dimension', cssVariable: '--ring-width' },
+
+	// Z-index tokens (optional category) — ordered tooltip > popover > overlay
+	'z-index.overlay': { name: 'z-index.overlay', category: 'z-index', type: 'number', cssVariable: '--z-index-overlay' },
+	'z-index.popover': { name: 'z-index.popover', category: 'z-index', type: 'number', cssVariable: '--z-index-popover' },
+	'z-index.tooltip': { name: 'z-index.tooltip', category: 'z-index', type: 'number', cssVariable: '--z-index-tooltip' },
 } as const;

--- a/packages/tokens/src/tokens/motion.json
+++ b/packages/tokens/src/tokens/motion.json
@@ -1,0 +1,32 @@
+{
+	"motion": {
+		"duration": {
+			"fast": {
+				"$value": "120ms",
+				"$type": "duration"
+			},
+			"base": {
+				"$value": "240ms",
+				"$type": "duration"
+			},
+			"slow": {
+				"$value": "480ms",
+				"$type": "duration"
+			}
+		},
+		"easing": {
+			"standard": {
+				"$value": "cubic-bezier(0.4, 0, 0.2, 1)",
+				"$type": "cubicBezier"
+			},
+			"decelerate": {
+				"$value": "cubic-bezier(0, 0, 0.2, 1)",
+				"$type": "cubicBezier"
+			},
+			"accelerate": {
+				"$value": "cubic-bezier(0.4, 0, 1, 1)",
+				"$type": "cubicBezier"
+			}
+		}
+	}
+}

--- a/packages/tokens/src/tokens/ring.json
+++ b/packages/tokens/src/tokens/ring.json
@@ -1,0 +1,8 @@
+{
+	"ring": {
+		"width": {
+			"$value": "3px",
+			"$type": "dimension"
+		}
+	}
+}

--- a/packages/tokens/src/tokens/typography.json
+++ b/packages/tokens/src/tokens/typography.json
@@ -8,6 +8,10 @@
 			"$value": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace",
 			"$type": "fontFamily"
 		},
+		"font-serif": {
+			"$value": "ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+			"$type": "fontFamily"
+		},
 		"size-sm": {
 			"$value": "0.875rem",
 			"$type": "dimension"
@@ -22,6 +26,14 @@
 		},
 		"size-xl": {
 			"$value": "1.25rem",
+			"$type": "dimension"
+		},
+		"size-2xl": {
+			"$value": "1.5rem",
+			"$type": "dimension"
+		},
+		"size-3xl": {
+			"$value": "1.875rem",
 			"$type": "dimension"
 		},
 		"weight-normal": {

--- a/packages/tokens/src/tokens/z-index.json
+++ b/packages/tokens/src/tokens/z-index.json
@@ -1,0 +1,16 @@
+{
+	"z-index": {
+		"overlay": {
+			"$value": "50",
+			"$type": "number"
+		},
+		"popover": {
+			"$value": "55",
+			"$type": "number"
+		},
+		"tooltip": {
+			"$value": "60",
+			"$type": "number"
+		}
+	}
+}

--- a/packages/tokens/src/validate.test.ts
+++ b/packages/tokens/src/validate.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import badContrast from './__fixtures__/bad-contrast.json';
 import extraTokens from './__fixtures__/extra-tokens.json';
-import missingToken from './__fixtures__/missing-token.json';
+import inheritedPairFail from './__fixtures__/inherited-pair-fail.json';
+import partialTheme from './__fixtures__/partial-theme.json';
 import validCustom from './__fixtures__/valid-custom.json';
-import { validateTheme } from './validate';
+import { canonicalDefaultTokens } from './defaults.js';
+import { checkThemeCompleteness, validateTheme } from './validate';
 
 describe('validateTheme', () => {
 	it('accepts a valid theme with hex colors', () => {
@@ -35,15 +37,65 @@ describe('validateTheme', () => {
 		expect(result.ok).toBe(true);
 	});
 
-	it('rejects theme with missing tokens and returns MISSING_TOKEN issues', () => {
-		const result = validateTheme(missingToken);
+	// --- Resolve-then-validate (spec 008 US2) ---------------------------------
+
+	it('accepts a PARTIAL theme (color + radius only) by inheriting defaults', () => {
+		// partial-theme.json carries only color + radius. The validator merges it
+		// onto the canonical defaults, so the omitted categories are present in
+		// the merged result and completeness passes.
+		const result = validateTheme(partialTheme);
+		expect(result.ok).toBe(true);
+	});
+
+	it('returns the MERGED theme so omitted categories resolve to defaults', () => {
+		const result = validateTheme(partialTheme);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			// The radius override took effect on the keys it supplied...
+			expect(result.theme.tokens.radius.sm).toBe('0.125rem');
+			expect(result.theme.tokens.radius.md).toBe('0.25rem');
+			// ...while OMITTED keys within that same category inherited (US2 AS2).
+			expect(result.theme.tokens.radius.lg).toBe(
+				canonicalDefaultTokens.radius.lg,
+			);
+			expect(result.theme.tokens.radius.full).toBe(
+				canonicalDefaultTokens.radius.full,
+			);
+			// ...and an omitted whole category inherited its canonical default.
+			expect(result.theme.tokens.spacing).toEqual(
+				canonicalDefaultTokens.spacing,
+			);
+			expect(result.theme.tokens.motion).toEqual(
+				canonicalDefaultTokens.motion,
+			);
+		}
+	});
+
+	it('fails AA on an INHERITED contrast pair (overrides background, inherits foreground)', () => {
+		// inherited-pair-fail.json overrides ONLY color.background to a near-black
+		// value. The inherited (default) color.foreground is also near-black, so
+		// the foreground/background pair drops far below 4.5:1. The old
+		// skip-when-a-side-is-absent path would have silently passed this; the
+		// merge supplies the inherited side, so the pair is now checked.
+		const result = validateTheme(inheritedPairFail);
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
-			const codes = result.issues.map((i) => i.code);
-			expect(codes).toContain('MISSING_TOKEN');
-			const paths = result.issues.map((i) => i.path);
-			expect(paths.some((p) => p.includes('primary'))).toBe(true);
+			const contrastIssues = result.issues.filter(
+				(i) => i.code === 'CONTRAST_FAILURE',
+			);
+			expect(contrastIssues.length).toBeGreaterThan(0);
+			expect(
+				contrastIssues.some((i) =>
+					i.path.includes('color.foreground / color.background'),
+				),
+			).toBe(true);
 		}
+	});
+
+	it('does not regress the color-only path: an existing valid theme still passes', () => {
+		// valid-custom.json is the legacy full theme; it must keep validating.
+		const result = validateTheme(validCustom);
+		expect(result.ok).toBe(true);
 	});
 
 	it('rejects theme with bad contrast and returns CONTRAST_FAILURE issues', () => {
@@ -67,6 +119,18 @@ describe('validateTheme', () => {
 		expect(result.ok).toBe(true);
 	});
 
+	it('rejects a malformed (non-string) token value with INVALID_TYPE', () => {
+		const result = validateTheme({
+			name: 'malformed',
+			displayName: 'Malformed',
+			tokens: { radius: { sm: 42 } },
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.issues.some((i) => i.code === 'INVALID_TYPE')).toBe(true);
+		}
+	});
+
 	it('rejects completely malformed input', () => {
 		const result = validateTheme({ foo: 'bar' });
 		expect(result.ok).toBe(false);
@@ -75,5 +139,41 @@ describe('validateTheme', () => {
 	it('rejects null input', () => {
 		const result = validateTheme(null);
 		expect(result.ok).toBe(false);
+	});
+});
+
+describe('checkThemeCompleteness (SC-005: MISSING_TOKEN after merge)', () => {
+	it('returns no issues for a complete merged theme', () => {
+		const complete = {
+			name: 'complete',
+			displayName: 'Complete',
+			tokens: canonicalDefaultTokens,
+		};
+		expect(checkThemeCompleteness(complete)).toEqual([]);
+	});
+
+	it('returns a path-named MISSING_TOKEN when a required token has no inheritable default', () => {
+		// Simulate the edge case from the spec: a contributor adds a schema key but
+		// forgets its default, so the MERGED theme is still missing it. The real
+		// canonicalDefaultTokens is complete, so we synthesize an incomplete merged
+		// theme by dropping a required key, then drive the completeness mechanism
+		// directly. This guards the COMPLETENESS OF THE DEFAULTS, not of every
+		// consumer theme.
+		const incompleteTokens = structuredClone(canonicalDefaultTokens) as Record<
+			string,
+			Record<string, string>
+		>;
+		// non-null: we just cloned a complete default set, so `color` is present.
+		delete incompleteTokens.color!['primary'];
+
+		const issues = checkThemeCompleteness({
+			name: 'incomplete-defaults',
+			displayName: 'Incomplete Defaults',
+			tokens: incompleteTokens,
+		});
+
+		const missing = issues.filter((i) => i.code === 'MISSING_TOKEN');
+		expect(missing.length).toBeGreaterThan(0);
+		expect(missing.some((i) => i.path === 'tokens.color.primary')).toBe(true);
 	});
 });

--- a/packages/tokens/src/validate.ts
+++ b/packages/tokens/src/validate.ts
@@ -1,7 +1,8 @@
 import type { ZodIssue } from 'zod';
 import type { Theme } from './schema.js';
 import { contrastRatio, parseColor } from './color.js';
-import { contrastPairs, themeSchema } from './schema.js';
+import { resolveTheme } from './resolve.js';
+import { contrastPairs, partialThemeSchema, themeSchema } from './schema.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -39,53 +40,99 @@ function resolveTokenValue(theme: Theme, dotPath: string): string | undefined {
 }
 
 // ---------------------------------------------------------------------------
-// validateTheme
+// Map a Zod issue to a structured ValidationIssue (Section XI.4).
+// ---------------------------------------------------------------------------
+
+function zodIssueToValidationIssue(issue: ZodIssue): ValidationIssue {
+	const path = issue.path.join('.');
+	if (issue.code === 'invalid_type' && issue.received === 'undefined') {
+		return {
+			path,
+			code: 'MISSING_TOKEN',
+			message: `Missing required token: ${path}`,
+			expected: issue.expected,
+		};
+	}
+	return {
+		path,
+		code: 'INVALID_TYPE',
+		message: issue.message,
+		expected: 'expected' in issue ? String(issue.expected) : undefined,
+		actual: 'received' in issue ? String(issue.received) : undefined,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// checkThemeCompleteness — validate an already-MERGED theme against the strict
+// schema. A required token absent from the merged result (i.e. absent from both
+// the override and the defaults) surfaces as a structured MISSING_TOKEN naming
+// the path. Exported so SC-005 can drive the mechanism with a synthetically
+// incomplete merged theme — the real `canonicalDefaultTokens` is complete, so
+// this path never fires through `validateTheme` in production.
+// ---------------------------------------------------------------------------
+
+export function checkThemeCompleteness(mergedTheme: unknown): ValidationIssue[] {
+	const strict = themeSchema.safeParse(mergedTheme);
+	if (strict.success)
+		return [];
+	return strict.error.issues.map(zodIssueToValidationIssue);
+}
+
+// ---------------------------------------------------------------------------
+// validateTheme — resolve-then-validate (spec 008 US2).
+//
+// The input is a PARTIAL runtime theme: any subset of categories/keys. We parse
+// it leniently, merge the override onto the canonical defaults, then validate
+// the COMPLETE merged result for completeness and WCAG AA contrast. Returning
+// the RESOLVED theme (not the raw input) is load-bearing: registerTheme injects
+// the full merged var set so a partial override still yields a complete
+// `<style>` block.
 // ---------------------------------------------------------------------------
 
 export function validateTheme(themeJson: unknown): ValidationResult {
-	// 1. Schema validation via Zod
-	const result = themeSchema.safeParse(themeJson);
+	// 1. Lenient parse: a partial override (color-only, color+radius, etc.) is a
+	//    valid SHAPE. Shape errors (wrong type, malformed value) surface here.
+	const parsed = partialThemeSchema.safeParse(themeJson);
 
-	if (!result.success) {
-		const issues: ValidationIssue[] = result.error.issues.map(
-			(issue: ZodIssue) => {
-				const path = issue.path.join('.');
-				if (issue.code === 'invalid_type' && issue.received === 'undefined') {
-					return {
-						path,
-						code: 'MISSING_TOKEN' as const,
-						message: `Missing required token: ${path}`,
-						expected: issue.expected,
-					};
-				}
-				return {
-					path,
-					code: 'INVALID_TYPE' as const,
-					message: issue.message,
-					expected:
-						'expected' in issue ? String(issue.expected) : undefined,
-					actual: 'received' in issue ? String(issue.received) : undefined,
-				};
-			},
-		);
-		return { ok: false, issues };
+	if (!parsed.success) {
+		return {
+			ok: false,
+			issues: parsed.error.issues.map(zodIssueToValidationIssue),
+		};
 	}
 
-	const theme = result.data;
+	// 2. Resolve the override onto the defaults — the override wins per-key.
+	const resolvedTokens = resolveTheme(parsed.data.tokens);
+	const resolvedTheme: Theme = {
+		...parsed.data,
+		tokens: resolvedTokens,
+	} as Theme;
 
-	// 2. Contrast checking for all declared pairs (supports hex and oklch)
+	// 3. Completeness: validate the MERGED result against the strict schema. A
+	//    required token absent from both the override AND the defaults yields a
+	//    structured MISSING_TOKEN naming the path — with complete defaults this
+	//    only fires if the defaults themselves are incomplete (SC-005).
+	const completenessIssues = checkThemeCompleteness(resolvedTheme);
+	if (completenessIssues.length > 0) {
+		return { ok: false, issues: completenessIssues };
+	}
+
+	const theme = resolvedTheme;
+
+	// 4. Contrast: read BOTH sides of every pair from the merged theme. There is
+	//    no longer a skip-when-a-side-is-absent path — after the merge, both
+	//    sides always resolve (a theme that overrode one side is checked against
+	//    the inherited other side).
 	const contrastIssues: ValidationIssue[] = [];
 
 	for (const pair of contrastPairs) {
 		const fgValue = resolveTokenValue(theme, pair.foreground);
 		const bgValue = resolveTokenValue(theme, pair.background);
 
-		if (!fgValue || !bgValue)
-			continue;
+		const fgLinear = fgValue ? parseColor(fgValue) : null;
+		const bgLinear = bgValue ? parseColor(bgValue) : null;
 
-		const fgLinear = parseColor(fgValue);
-		const bgLinear = parseColor(bgValue);
-
+		// Unparseable color strings (not a missing side) — nothing to compare.
 		if (!fgLinear || !bgLinear)
 			continue;
 
@@ -105,5 +152,6 @@ export function validateTheme(themeJson: unknown): ValidationResult {
 		return { ok: false, issues: contrastIssues };
 	}
 
+	// 5. Return the MERGED theme so the caller injects the full var set.
 	return { ok: true, theme };
 }

--- a/packages/tokens/themes/brand.json
+++ b/packages/tokens/themes/brand.json
@@ -40,5 +40,16 @@
 			"$value": "oklch(1.0000 0.0000 89.88)",
 			"$type": "color"
 		}
+	},
+	"radius": {
+		"sm": { "$value": "0.375rem", "$type": "dimension" },
+		"md": { "$value": "0.5rem", "$type": "dimension" },
+		"lg": { "$value": "0.75rem", "$type": "dimension" }
+	},
+	"typography": {
+		"font-sans": {
+			"$value": "\"Inter\", ui-sans-serif, system-ui, sans-serif",
+			"$type": "fontFamily"
+		}
 	}
 }

--- a/packages/tokens/themes/light.json
+++ b/packages/tokens/themes/light.json
@@ -21,7 +21,7 @@
 			"$type": "color"
 		},
 		"muted-foreground": {
-			"$value": "oklch(0.5517 0.0138 285.94)",
+			"$value": "oklch(0.5434 0.0138 285.94)",
 			"$type": "color"
 		},
 		"border": {
@@ -33,7 +33,7 @@
 			"$type": "color"
 		},
 		"destructive": {
-			"$value": "oklch(0.6368 0.2078 25.33)",
+			"$value": "oklch(0.5803 0.2078 25.33)",
 			"$type": "color"
 		},
 		"destructive-foreground": {

--- a/specs/008-token-schema-growth/checklists/requirements.md
+++ b/specs/008-token-schema-growth/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Token schema growth
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- **Clarify session 2026-05-25 resolved four decisions** (recorded in the Clarifications section): the validation/format model (two formats stay separate, validate the merged result), motion token output naming (Tailwind-namespace-aligned `--ease-*` / `--duration-*`), the `brand.json` non-color override (a richer multi-category override), and the release bump scope (tokens minor + react patch). The session also added US4 (drift-killing optional tokens), FR-021 through FR-023, the token-source-override vs runtime-theme entity split, and the THEMING.md distinction requirement.
+- **The spec names concrete files and token values** (`font-serif`, the motion durations/easings, `size-2xl`/`3xl`, the four build artifacts, `validateTheme()`). These are the audit's input state and the canonical token vocabulary every stakeholder in this project recognizes — not implementation choices being made here. The token schema *is* the product surface for this package, so naming the tokens is naming the feature, not leaking implementation.
+- **Version target corrected to 0.4.0** from the brief's stale "0.2.0" — both packages already shipped 0.3.0. Documented in Assumptions.
+- **The required-token-vs-inherited-default tension** in the brief's acceptance criteria is reconciled in FR-008/FR-010 and the Edge Cases: partial consumer themes inherit defaults and always validate; the missing-token error guards the completeness of the canonical default layer, which must itself be complete.

--- a/specs/008-token-schema-growth/contracts/token-schema.md
+++ b/specs/008-token-schema-growth/contracts/token-schema.md
@@ -1,0 +1,86 @@
+# Contract: Expanded token vocabulary
+
+The public token surface after this spec. Consumers (human and agent) reference these names; once shipped they are locked vocabulary.
+
+## New required tokens
+
+Adding these to the required schema is the breaking change to consumer runtime themes.
+
+### Typography (extend existing category)
+
+```jsonc
+// packages/tokens/src/tokens/typography.json — additions
+"font-serif": { "$value": "ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif", "$type": "fontFamily" },
+"size-2xl":   { "$value": "1.5rem",   "$type": "dimension" },
+"size-3xl":   { "$value": "1.875rem", "$type": "dimension" }
+```
+
+Emit as `--typography-font-serif`, `--typography-size-2xl`, `--typography-size-3xl` (existing `--typography-*` convention).
+
+### Motion (new category)
+
+```jsonc
+// packages/tokens/src/tokens/motion.json
+{
+  "motion": {
+    "duration": {
+      "fast": { "$value": "120ms", "$type": "duration" },
+      "base": { "$value": "240ms", "$type": "duration" },
+      "slow": { "$value": "480ms", "$type": "duration" }
+    },
+    "easing": {
+      "standard":   { "$value": "cubic-bezier(0.4, 0, 0.2, 1)", "$type": "cubicBezier" },
+      "decelerate": { "$value": "cubic-bezier(0, 0, 0.2, 1)",   "$type": "cubicBezier" },
+      "accelerate": { "$value": "cubic-bezier(0.4, 0, 1, 1)",   "$type": "cubicBezier" }
+    }
+  }
+}
+```
+
+Emit (special-cased in `sd.config.ts`) as Tailwind-aligned names:
+- `--ease-standard`, `--ease-decelerate`, `--ease-accelerate` → real `ease-*` utilities.
+- `--duration-fast`, `--duration-base`, `--duration-slow` → plain CSS vars (no `duration-*` namespace in v4).
+
+## New optional tokens
+
+Optional: absent from a theme means inherit the default; never a validation error. Not a breaking change.
+
+### Ring (new category)
+
+```jsonc
+// packages/tokens/src/tokens/ring.json
+{ "ring": { "width": { "$value": "3px", "$type": "dimension" } } }
+```
+
+Default `3px` matches what the hardcoded `ring-3` usages resolve to. Emits `--ring-width`.
+
+### Z-index (new category)
+
+```jsonc
+// packages/tokens/src/tokens/z-index.json — illustrative stops; finalize in tasks
+{ "z-index": {
+    "overlay": { "$value": "50", "$type": "number" },
+    "popover": { "$value": "55", "$type": "number" },
+    "tooltip": { "$value": "60", "$type": "number" }
+} }
+```
+
+Ordered so `tooltip` sits above `popover`/`overlay`, giving nested overlays a defined stacking order (the latent `z-50` bug). Exact stop names and values are settled in tasks; the ordering invariant is the contract. Emits `--z-index-overlay` etc.
+
+## Schema (Zod) shape
+
+- `motionTokens` added to `themeSchema.tokens` as a **required** object with `duration` and `easing` sub-objects (or flattened keys, implementer's call) — required.
+- `typographyTokens` gains `font-serif`, `size-2xl`, `size-3xl` — required.
+- `ringTokens`, `zIndexTokens` added — **optional** (`.optional()` or `.partial()` on the category) so a theme omitting them validates by inheritance.
+- All category objects loosen so a runtime theme may provide a partial subset; the validator merges onto defaults before checking (see `validate-theme.md`).
+
+## TypeScript token map (`sd.config.ts`)
+
+Extend `categoryMap` and the `TokenCategory` union to include the new categories:
+
+```ts
+const categoryMap = { color, spacing, typography, radius: 'radii', shadow: 'shadows', opacity, motion: 'motion', ring: 'ring', 'z-index': 'z-index' }
+type TokenCategory = "color" | "spacing" | "typography" | "radii" | "shadows" | "opacity" | "motion" | "ring" | "z-index"
+```
+
+Every new token MUST appear in all four artifacts: CSS vars, Tailwind preset, TS token map, JSON.

--- a/specs/008-token-schema-growth/contracts/validate-theme.md
+++ b/specs/008-token-schema-growth/contracts/validate-theme.md
@@ -1,0 +1,67 @@
+# Contract: validateTheme / registerTheme (resolve-then-validate)
+
+The runtime-theme validation API after this spec. Applies to the **runtime theme document** format only (the flat `{ name, displayName, tokens }` shape). Built-in DTCG token-source overrides are not inputs here.
+
+## validateTheme
+
+```ts
+function validateTheme(themeJson: unknown): ValidationResult
+```
+
+**Behavior change**: accept a *partial* theme (any subset of categories/keys), resolve it against the canonical defaults, and validate the merged result.
+
+```
+1. parse: Zod schema accepts a partial theme (categories/keys optional).
+   On shape errors → { ok: false, issues: [INVALID_TYPE | MISSING_TOKEN ...] }
+2. resolve: resolved = deepMerge(canonicalDefaults, theme.tokens)   // override wins
+3. completeness: every required token present in `resolved`?
+   else → MISSING_TOKEN(path)   // only fires if the DEFAULTS are incomplete
+4. contrast: for each contrast pair, read BOTH sides from `resolved`.
+   Never skip a pair because one side was absent from the override.
+   ratio < threshold → CONTRAST_FAILURE(pair, ratio, threshold)
+5. → { ok: true, theme: resolved } | { ok: false, issues }
+```
+
+**Result shape (unchanged):**
+
+```ts
+type ValidationResult =
+  | { ok: true; theme: Theme }
+  | { ok: false; issues: ValidationIssue[] }
+
+interface ValidationIssue {
+  path: string
+  code: 'MISSING_TOKEN' | 'INVALID_TYPE' | 'UNKNOWN_TOKEN' | 'CONTRAST_FAILURE'
+  message: string
+  expected?: string; actual?: string; ratio?: number; threshold?: number
+}
+```
+
+## registerTheme
+
+```ts
+function registerTheme(themeJson: Theme): void   // throws ThemeValidationError
+```
+
+Same resolve-then-validate, applied before BOTH:
+- the `validateTheme` call (already there), and
+- the post-oklch-conversion contrast pass (`runtime.ts:97`), which currently skips a pair when one converted side is absent. It MUST instead resolve the converted colors against the resolved defaults and check the full pair set.
+
+Then it injects `<style>[data-theme="<name>"]{ ... }`. Injection is unchanged.
+
+## Behavioral contract (acceptance)
+
+| Input | Expected |
+| --- | --- |
+| Full valid runtime theme | `{ ok: true }` (unchanged from today) |
+| Partial theme: only `color` + `radius` | `{ ok: true }`; omitted categories inherit defaults; resolved theme is complete |
+| Partial theme: overrides `color.background`, inherits `color.foreground` | contrast checked against inherited foreground + overridden background; fails AA → `CONTRAST_FAILURE` (NOT skipped) |
+| Color-only theme (prior format) | `{ ok: true }` — no regression |
+| Theme + defaults both missing a required token | `MISSING_TOKEN(path)` (guards default completeness) |
+| Override with a malformed value | `INVALID_TYPE(path)` |
+
+## Non-goals
+
+- The DTCG build-source format is not validated here.
+- The MCP `palette` tool needs no change; it resolves from the token map once theme data carries the category.
+- Theme composition (multi-axis) and derived tokens are out of scope (specs 009 and the roadmap).

--- a/specs/008-token-schema-growth/data-model.md
+++ b/specs/008-token-schema-growth/data-model.md
@@ -1,0 +1,87 @@
+# Data Model: Token schema growth
+
+**Phase 1 output** | **Date**: 2026-05-25
+
+No runtime database. The "data model" is the token vocabulary, the two theme representations, and the merge semantics the validator enforces.
+
+## Token categories after this spec
+
+| Category | Status | Keys added | DTCG `$type` | Required? |
+| --- | --- | --- | --- | --- |
+| `color` | unchanged | — | `color` | required |
+| `spacing` | unchanged | — | `dimension` | required |
+| `typography` | extended | `font-serif`, `size-2xl`, `size-3xl` | `fontFamily`, `dimension` | required |
+| `radius` | unchanged | — | `dimension` | required |
+| `shadow` | unchanged | — | `shadow` | required |
+| `opacity` | unchanged | — | `number` | required |
+| `motion` | **new** | `duration.{fast,base,slow}`, `easing.{standard,decelerate,accelerate}` | `duration`, `cubicBezier` | required |
+| `ring` | **new** | `width` | `dimension` | **optional** |
+| `z-index` | **new** | layering scale (e.g. `overlay`, `popover`, `tooltip`) | `number` | **optional** |
+
+Two tiers: the for-coleman additions are required (breaking, drives the version bump); `ring` and `z-index` are optional (inherit defaults, non-breaking). The optional tokens are the first in-repo consumers of the inherit-on-omit mechanism.
+
+### Motion token output naming (special case)
+
+The `motion` category is the one category whose emitted CSS-var names diverge from the `--{category}-{key}` pattern, to align with Tailwind v4:
+
+| Token | Emitted CSS var | Tailwind utility |
+| --- | --- | --- |
+| `motion.easing.standard` | `--ease-standard` | `ease-standard` (real utility) |
+| `motion.easing.decelerate` | `--ease-decelerate` | `ease-decelerate` |
+| `motion.easing.accelerate` | `--ease-accelerate` | `ease-accelerate` |
+| `motion.duration.fast` | `--duration-fast` | none; via `duration-[var(--duration-fast)]` |
+| `motion.duration.base` | `--duration-base` | none; via arbitrary value |
+| `motion.duration.slow` | `--duration-slow` | none; via arbitrary value |
+
+The build special-cases motion var naming in `sd.config.ts`.
+
+## The two theme representations (the Q1 distinction)
+
+This is the model the THEMING.md distinction documents. Both are called "theme" in the codebase; they are different artifacts on different pipelines.
+
+### Token-source override (build-time)
+
+- **Shape**: DTCG. `{ "color": { "background": { "$value": "...", "$type": "color" } }, "radius": { ... } }`. No `name`/`displayName`/`tokens` wrapper.
+- **Location**: `packages/tokens/themes/*.json`.
+- **Consumer**: Style Dictionary. The build merges `src/tokens/**` (defaults) under each theme file and emits `dist/css/tokens-<theme>.css` scoped to `[data-theme="<theme>"]`.
+- **Validation**: by build output (the CSS is correct), not by `validateTheme`.
+- **After this spec**: may carry any category. `brand.json` carries `color` + `radius` + a `typography` override; `light`/`dark` stay color-only.
+
+### Runtime theme document (just-in-time)
+
+- **Shape**: flat. `{ "name": "...", "displayName": "...", "tokens": { "color": { "background": "oklch(...)" }, "radius": { ... } } }`. String values, not DTCG objects.
+- **API**: `registerTheme(theme)` validates via `validateTheme(theme)`, then injects a `<style>[data-theme="<name>"]{ --category-key: value }` block at runtime.
+- **Validation**: `validateTheme` — Zod schema conformance + WCAG AA contrast on the resolved (merged) result.
+- **After this spec**: may override any subset of any category; omitted tokens inherit the canonical defaults; validation runs against the merged result.
+
+## Canonical default layer
+
+The resolved `src/tokens` set: a complete value for every required token. Both pipelines treat it as the inheritance baseline. Partial runtime themes merge onto it; built-in token-source overrides merge onto it at build. It must itself be complete — a required token missing from the defaults is the one MISSING_TOKEN error that can fire after merge.
+
+## Validation: resolve-then-validate
+
+```
+validateTheme(partial):
+  resolved = deepMerge(canonicalDefaults, partial.tokens)   # override wins
+  1. schema check: every required token present in resolved? else MISSING_TOKEN(path)
+  2. type check: every value the right shape? else INVALID_TYPE(path)
+  3. contrast check: for each contrast pair, resolve BOTH sides from `resolved`
+       (never skip when one side came from defaults) — else CONTRAST_FAILURE(pair)
+  return { ok: true, theme: resolved } | { ok: false, issues }
+```
+
+`registerTheme` applies the same resolve-then-check before its post-oklch-conversion contrast pass. Both call sites currently skip a pair when one side is absent; both stop skipping by validating the merged result.
+
+**ValidationIssue shape** (unchanged, Section XI.4): `{ path, code: 'MISSING_TOKEN' | 'INVALID_TYPE' | 'UNKNOWN_TOKEN' | 'CONTRAST_FAILURE', message, expected?, actual?, ratio?, threshold? }`.
+
+## Contrast pairs (unchanged)
+
+The four declared pairs stay color-only: `foreground/background`, `primary-foreground/primary`, `muted-foreground/muted`, `destructive-foreground/destructive`, all at 4.5:1. Loosening category coverage does not touch them; they now resolve both sides from the merged theme.
+
+## Entities summary
+
+- **Token category**: a named group with a fixed key set known at build time. This spec adds `motion`, `ring`, `z-index` and three `typography` keys.
+- **Token-source override**: a DTCG theme file consumed by the build (see above).
+- **Runtime theme document**: a flat theme object validated and injected at runtime (see above).
+- **Canonical default layer**: the complete resolved `src/tokens` baseline both representations inherit from.
+- **Validation issue**: structured `{ code, path, message }` result, layered with human-readable text.

--- a/specs/008-token-schema-growth/plan.md
+++ b/specs/008-token-schema-growth/plan.md
@@ -1,0 +1,113 @@
+# Implementation Plan: Token schema growth
+
+**Branch**: `008-token-schema-growth` | **Date**: 2026-05-25 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/008-token-schema-growth/spec.md`
+
+## Summary
+
+Grow the canonical `@unbranded-ds/tokens` schema with the for-coleman additions (required: `font-serif`, a `motion` category, `size-2xl`/`size-3xl`) plus two optional drift-killing tokens (`ring.width`, a `z-index` scale). Loosen theme validation so a runtime theme can override any category, with validation running against the resolved (merged) theme rather than the raw fragment. Document the two distinct "theme" concepts in THEMING.md with a worked example of each. Ship as `@unbranded-ds/tokens@0.4.0` with a coordinated `@unbranded-ds/react` patch.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, strict mode, no `any`
+**Primary Dependencies**: Style Dictionary v4 (DTCG build), Zod (theme schema + validation), Tailwind CSS v4 (`@theme` preset consumption)
+**Storage**: Filesystem only. DTCG source files under `packages/tokens/src/tokens/`, built-in theme files under `packages/tokens/themes/`, generated artifacts under `packages/tokens/dist/`.
+**Testing**: Vitest (`packages/tokens` unit + fixture tests for schema/validate/runtime/color)
+**Target Platform**: npm package consumed in browser + SSR build pipelines
+**Project Type**: monorepo library (the `@unbranded-ds/tokens` package; `@unbranded-ds/react` takes a coordinated dependency bump)
+**Performance Goals**: N/A (build-time token generation + a runtime validation function)
+**Constraints**: Adding required tokens is a breaking change to consumer runtime themes (pre-1.0, communicated by the minor bump). DTCG source authoring per Constitution Section II. Validator output stays structured per Section XI.4.
+**Scale/Scope**: One new token category (motion), three new typography keys, two optional token additions (ring, z-index), a validator refactor (resolve-then-validate at two call sites), one build-config extension, three doc additions, one brand theme enrichment.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **Section I (Repository shape)** — no new package. All work in the existing `packages/tokens`; `packages/react` takes a dependency bump only.
+- [x] **Section II (Tokens independent of components)** — new tokens authored in DTCG (`$value`/`$type`), compiled by Style Dictionary to the four artifacts. No React/Storybook in the tokens dependency graph.
+- [x] **Section III (Theming contract: schema locked, values float)** — this spec extends the locked schema (adds names) and broadens which categories float at runtime. It does not change the "names fixed at build, values float" model. Section III's "values float" applies to every category, which is exactly the gap US2 closes.
+- [x] **Section VIII (Tooling baseline)** — no toolchain changes. Style Dictionary, Zod, Tailwind v4, Changesets all already in place.
+- [x] **Section X (Governance / changeset)** — the PR ships a `@unbranded-ds/tokens` minor changeset; `@unbranded-ds/react` patch follows automatically via the changeset config's `updateInternalDependencies: "patch"`.
+- [x] **Section XI (Agent + human legibility)** — THEMING.md prose runs through the humanizer before merge (XI.1); the token vocabulary stays predictable (XI.2); the new docs name the two theme concepts so neither audience has to guess which format a file uses (XI.3); validator errors stay structured `{ ok, issues: [{ code, path, message }] }` (XI.4). No components added, so the per-component sidecar rule does not apply.
+
+No violations. No concessions.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-token-schema-growth/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (Tailwind namespaces, merge model, type decisions)
+├── data-model.md        # Phase 1 output (token categories, the two theme formats, merge semantics)
+├── quickstart.md        # Phase 1 output (implement + verify walkthrough)
+├── contracts/
+│   ├── token-schema.md        # The expanded token vocabulary + DTCG types
+│   └── validate-theme.md      # validateTheme/registerTheme resolve-then-validate contract
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+packages/tokens/
+├── src/
+│   ├── tokens/
+│   │   ├── motion.json          # NEW — durations + easings (DTCG)
+│   │   ├── typography.json      # EDIT — add font-serif, size-2xl, size-3xl
+│   │   ├── ring.json            # NEW — optional ring.width default
+│   │   ├── z-index.json         # NEW — optional layering scale defaults
+│   │   ├── color.json spacing.json radii.json shadows.json opacity.json  # unchanged
+│   ├── schema.ts                # EDIT — add motionTokens (required), typography keys (required),
+│   │                            #         ring + z-index (optional); export defaults for the merge
+│   ├── validate.ts              # EDIT — resolve (merge onto defaults) then validate; fix the skip
+│   ├── runtime.ts               # EDIT — same resolve-then-validate in registerTheme's contrast check
+│   ├── color.ts                 # unchanged (contrast math reused)
+│   └── __fixtures__/            # ADD partial-theme + inherited-pair fixtures
+├── themes/
+│   ├── brand.json               # EDIT — add radius + typography override (Q3: multi-category demo)
+│   ├── light.json dark.json     # unchanged (stay color-only)
+├── sd.config.ts                 # EDIT — TS category map + motion var-naming special case
+└── (dist/ regenerated by build)
+
+THEMING.md                       # EDIT — Extending-the-schema, Overriding-non-color, two-formats distinction
+.changeset/<name>.md             # NEW — @unbranded-ds/tokens: minor
+```
+
+**Structure Decision**: All implementation lives in `packages/tokens` plus the root `THEMING.md`. The `@unbranded-ds/react` package is untouched in source; it only receives an automatic patch bump from Changesets.
+
+## Parallelization
+
+The user asked what's parallelizable. Spec 008 is one package with a build pipeline, so it's less embarrassingly parallel than spec 007's 14-component fan-out — but there are two genuinely independent tracks plus dependent convergence:
+
+**Track A — Token additions (independent).** Author the DTCG sources (`motion.json`, `ring.json`, `z-index.json`, typography edits) and extend the Zod schema (motion required; typography keys required; ring/z-index optional). Self-contained: it's "what tokens exist."
+
+**Track B — Validator resolve-then-validate (independent).** Refactor `validate.ts` and `runtime.ts` to merge a partial theme onto the canonical defaults before checking completeness and contrast, fixing the `if (!fg || !bg) continue` skip at both sites. This depends on the *mechanism*, not on Track A's specific tokens, so it runs concurrently.
+
+**Then converge (depend on A):**
+- **Track C — Build wiring**: `sd.config.ts` — extend the TS `categoryMap` + `TokenCategory` union for the new categories, and special-case the motion category's CSS-var naming (`--ease-*` / `--duration-*`).
+- **Track D — Themes**: enrich `brand.json` with the multi-category override (radius + typography); confirm the resolved build output of all three themes carries the new required tokens via inheritance.
+
+**Then serialize:**
+- **Track E — Docs** (THEMING.md): depends on A–D being settled; the three additions (extend-schema walkthrough, override-non-color subsection, two-formats distinction). Prose drafts can start early but verify last. Runs through the humanizer before merge.
+- **Track F — Release**: the tokens minor changeset; react patch is automatic.
+
+So: **A ∥ B**, then **C ∥ D**, then **E**, then **F**. Two-up at the front and the middle; docs and release are the serial tail. The validator track (B) is the cleanest thing to hand to a separate worker since it shares no files with the token-addition work.
+
+## Research Summary
+
+See [research.md](research.md). Key resolved decisions:
+
+- **Tailwind v4 has no `--duration-*` namespace** (confirmed against the v4 namespace list). Easings emit as `--ease-*` and generate real `ease-standard` utilities; durations emit as plain `--duration-*` CSS vars consumed via `duration-[var(--duration-base)]` or `transition-duration: var(...)`. The three easing values equal Tailwind's default `ease-in`/`out`/`in-out` curves, renamed semantically.
+- **New typography keys follow the existing `--typography-*` convention** (consistency with `font-sans`/`size-sm` siblings). Aligning the whole typography category to Tailwind's `--text-*`/`--font-*` namespaces is a separate, larger concern, out of scope.
+- **Resolve-then-validate** merges a partial theme onto the bundled default token map, then runs the existing completeness + contrast logic on the merged result. The defaults already exist as a build artifact; no new data source.
+- **react patch is automatic** via `updateInternalDependencies: "patch"` in `.changeset/config.json`.
+
+## Complexity Tracking
+
+> No constitution violations to justify.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| — | — | — |

--- a/specs/008-token-schema-growth/quickstart.md
+++ b/specs/008-token-schema-growth/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart: Token schema growth
+
+How to implement and verify spec 008. All work is in `packages/tokens` plus root `THEMING.md`.
+
+## Prerequisites
+
+- Branch `008-token-schema-growth` checked out
+- `pnpm install` done
+- Working from `packages/tokens` for most steps
+
+## Build + verify loop
+
+The token pipeline regenerates `dist/` from `src/tokens/**` + `themes/*.json`:
+
+```bash
+pnpm --filter @unbranded-ds/tokens build      # tsx sd.config.ts + tsc
+pnpm --filter @unbranded-ds/tokens test        # vitest (schema, validate, runtime, color)
+pnpm typecheck                                 # whole workspace
+```
+
+After a token addition, confirm it lands in all four artifacts:
+
+```bash
+grep -- "--ease-standard\|--duration-base\|--typography-font-serif\|--ring-width" packages/tokens/dist/tailwind/preset.css
+grep "motion\|font-serif\|ring\|z-index" packages/tokens/dist/ts/tokens.ts
+grep "font-serif\|ease\|duration" packages/tokens/dist/json/tokens.json
+grep -- "--ease-standard" packages/tokens/dist/css/tokens-brand.css   # per-theme CSS
+```
+
+## Implementation order (mirrors the plan's tracks)
+
+Tracks A and B are independent — do them in parallel if splitting work.
+
+**Track A — token additions**
+1. Add `src/tokens/motion.json` (durations + easings, DTCG types per contract).
+2. Edit `src/tokens/typography.json` — add `font-serif`, `size-2xl`, `size-3xl`.
+3. Add `src/tokens/ring.json` and `src/tokens/z-index.json` (optional defaults).
+4. Edit `src/schema.ts` — `motionTokens` (required), typography keys (required), `ringTokens` + `zIndexTokens` (optional); loosen category objects for partial themes; export the default token set for the merge.
+
+**Track B — validator (independent)**
+5. Add a `resolveTheme(partial)` deep-merge helper (defaults under override).
+6. Edit `src/validate.ts` — resolve before validating; check completeness + contrast on the merged result; stop skipping a pair when one side is absent.
+7. Edit `src/runtime.ts` — apply the same resolve before the post-conversion contrast pass.
+8. Add fixtures: a partial theme, an inherited-pair theme that should fail contrast, a color-only legacy theme that should still pass.
+
+**Then converge**
+9. Edit `sd.config.ts` — extend `categoryMap` + `TokenCategory` union; special-case the motion category's var naming (`--ease-*`, `--duration-*`).
+10. Edit `themes/brand.json` — add a `radius` override + a `typography` override (Q3 multi-category demo). Leave `light`/`dark` color-only.
+
+**Then docs + release**
+11. Edit `THEMING.md` — three additions (run through the humanizer before merge):
+    - "Extending the schema" walkthrough using motion as the worked example.
+    - "Overriding non-color tokens" subsection pointing at the enriched `brand.json`.
+    - The token-source-override vs runtime-theme distinction, with a complete example of each.
+12. `pnpm changeset` — `@unbranded-ds/tokens` minor; the react patch is automatic.
+
+## Verification against the spec
+
+```bash
+# US1: new tokens resolve
+pnpm --filter @unbranded-ds/tokens build && grep -- "--ease-standard" packages/tokens/dist/css/tokens-light.css
+
+# US2: partial runtime theme validates against the merged result
+pnpm --filter @unbranded-ds/tokens test   # the new partial/inherited-pair fixtures
+
+# US4: optional tokens present + a theme omitting them still builds
+grep -- "--ring-width\|--z-index-overlay" packages/tokens/dist/tailwind/preset.css
+
+# Release
+ls .changeset/*.md
+```
+
+## Watch-outs
+
+- **Motion var naming is the one special case.** Every other category emits `--{category}-{key}`; motion emits `--ease-*` / `--duration-*`. Don't let the build emit `--motion-*`.
+- **The contrast skip is in two files.** `validate.ts` and `runtime.ts` both have `if (!fg || !bg) continue`. Fix both.
+- **Built-in themes inherit the required tokens** from `src/tokens` defaults; don't duplicate font-serif/motion/sizes into `light`/`dark`/`brand`.
+- **Optional means optional.** `ring` and `z-index` must validate when omitted — they live in defaults, not in the required schema.
+- **SSR safety**: no browser globals in the validator merge path; `registerTheme` already guards `document` usage at call time.

--- a/specs/008-token-schema-growth/research.md
+++ b/specs/008-token-schema-growth/research.md
@@ -1,0 +1,71 @@
+# Research: Token schema growth
+
+**Phase 0 output** | **Date**: 2026-05-25
+
+## Tailwind v4 motion namespaces (resolves the spec's flagged open item)
+
+**Decision**: Easings emit as `--ease-{standard,decelerate,accelerate}`; durations emit as `--duration-{fast,base,slow}` plain CSS variables.
+
+**Rationale**: The Tailwind v4 theme-namespace list includes `--ease-*` (generates `ease-<name>` utilities like `ease-standard`) but has **no `--duration-*` namespace**. Confirmed against the v4 docs namespace table: the motion-adjacent namespaces are `--ease-*` and `--animate-*` only; transition-duration utilities (`duration-200`) use the bare numeric scale, not a named theme namespace. So:
+
+- `--ease-standard` → generates a real `ease-standard` utility (and `ease-decelerate`, `ease-accelerate`).
+- `--duration-base` → a plain CSS variable. It does NOT auto-generate a `duration-base` utility. Consumers reference it via an arbitrary value (`duration-[var(--duration-base)]`) or directly (`transition-duration: var(--duration-base)`). The spec 010 retrofit will use one of those forms.
+
+**Bonus finding**: the three easing values from FR-004 are exactly Tailwind's default easing curves, renamed by role:
+
+| DS token | Value | Tailwind default equivalent |
+| --- | --- | --- |
+| `ease-standard` | `cubic-bezier(0.4, 0, 0.2, 1)` | `--ease-in-out` |
+| `ease-decelerate` | `cubic-bezier(0, 0, 0.2, 1)` | `--ease-out` |
+| `ease-accelerate` | `cubic-bezier(0.4, 0, 1, 1)` | `--ease-in` |
+
+So the easing set is maximally conservative — it is the platform default, given semantic names that map to motion intent.
+
+**Alternatives considered**: `--motion-*` category-prefixed naming (rejected — would not generate `ease-*` utilities, undercutting FR-006). Emitting both canonical + namespaced vars (rejected — doubles the motion vars for little gain).
+
+## Typography additions follow the existing convention
+
+**Decision**: `font-serif`, `size-2xl`, `size-3xl` are authored under the `typography` category and emit as `--typography-font-serif`, `--typography-size-2xl`, `--typography-size-3xl`, matching the existing `font-sans` / `size-sm` siblings.
+
+**Rationale**: The current typography tokens are category-prefixed (`--typography-*`) and are CSS variables rather than Tailwind-namespace utilities. The new keys stay consistent with their siblings. Realigning the whole typography category to Tailwind's `--text-*` (font-size) and `--font-*` (font-family) namespaces would change every existing typography token's public name — a larger breaking refactor that belongs to its own spec, not here.
+
+**Alternatives considered**: emitting `font-serif` as `--font-serif` (Tailwind's `--font-*` namespace, which would generate a `font-serif` utility). Rejected for this spec because it makes one typography token namespace-aligned while its siblings are not, trading one inconsistency for another. Worth revisiting if the whole typography category is ever realigned.
+
+## DTCG types for the new tokens
+
+**Decision**: Author with standard DTCG `$type` values consistent with the existing sources.
+
+| Token | `$type` | Example `$value` |
+| --- | --- | --- |
+| `motion.duration.*` | `duration` | `120ms` |
+| `motion.easing.*` | `cubicBezier` | `cubic-bezier(0.4, 0, 0.2, 1)` |
+| `typography.font-serif` | `fontFamily` | `ui-serif, Georgia, Cambria, "Times New Roman", Times, serif` |
+| `typography.size-2xl` / `size-3xl` | `dimension` | `1.5rem` / `1.875rem` |
+| `ring.width` | `dimension` | `3px` |
+| `z-index.*` | `number` | `50` |
+
+**Rationale**: mirrors how the existing categories declare `$type` (`dimension`, `fontFamily`, `fontWeight`, `number`, `shadow`, `color`). The Style Dictionary `css` transform group already handles these; the TS token map records `$type` verbatim.
+
+**Open sub-decision deferred to tasks**: the exact `font-serif` stack and the `2xl`/`3xl` rem values are conventional defaults (a system serif stack; 1.5rem / 1.875rem matching common scales). They are values, not architecture, and can be finalized during implementation.
+
+## Resolve-then-validate (the Q1 rider)
+
+**Decision**: Both `validateTheme` and the post-conversion contrast check in `registerTheme` merge the partial override onto the canonical default token set, then validate completeness + contrast on the merged result.
+
+**Rationale**: The current contrast loops skip a pair when either side is absent (`validate.ts:83`, `runtime.ts:97`). Once the Zod schema is loosened to accept partial themes, that skip would silently pass a merged result that fails AA (override one side of a pair, inherit the other). Merging first closes the hole. The canonical defaults already exist as a build artifact (the generated token map / the resolved `src/tokens` set), so the merge needs no new data source — the validator imports the defaults and deep-merges the override on top.
+
+**Mechanism**: loosen the Zod category objects to `.partial()` (or `.optional()` per key), add a `resolveTheme(partial)` helper that deep-merges onto the default token set, and run the existing Zod completeness check + contrast check against the resolved object. A token absent from both the override and the defaults is the only MISSING_TOKEN case — which guards the completeness of the defaults, not consumer themes.
+
+**Alternatives considered**: validating the raw fragment (rejected — the AA hole). Unifying the DTCG and runtime formats (rejected in clarify — two real pipelines; see data-model).
+
+## Built-in themes carry required tokens via inheritance, not duplication
+
+**Decision**: The new required tokens (`font-serif`, motion, `2xl`/`3xl`) live in the `src/tokens` DTCG defaults. The built-in theme files (`light`/`dark`/`brand`) do NOT duplicate them; the Style Dictionary build merges the defaults under each theme, so the resolved per-theme CSS carries every required token.
+
+**Rationale**: the build's source array is `['src/tokens/**/*.json', 'themes/<theme>.json']` — Style Dictionary deep-merges, defaults first. Requiring the themes to restate the new tokens would be redundant and drift-prone. FR-011 is satisfied by the resolved build output, not by the theme files literally carrying the keys.
+
+## react patch is automatic
+
+**Decision**: Ship one `@unbranded-ds/tokens: minor` changeset; let Changesets bump `@unbranded-ds/react` by patch.
+
+**Rationale**: `.changeset/config.json` sets `updateInternalDependencies: "patch"`. `@unbranded-ds/react` depends on `@unbranded-ds/tokens` via `workspace:*`, so when tokens releases, react's published dependency range repoints at the new version and react gets a patch release. No separate react changeset is needed; no react source changes.

--- a/specs/008-token-schema-growth/spec.md
+++ b/specs/008-token-schema-growth/spec.md
@@ -1,0 +1,191 @@
+# Feature Specification: Token schema growth
+
+**Feature Branch**: `008-token-schema-growth`
+**Created**: 2026-05-25
+**Status**: Draft
+**Input**: User description: "Token schema growth — bring the missing token categories (serif font, motion, larger type sizes) into the canonical `@unbranded-ds/tokens` schema, and loosen theme validation so a theme can override any token category rather than only color." (full brief at `tmp/spec-008-token-schema-growth.md`)
+
+## Background
+
+The for-coleman team needed a serif font, motion tokens, and display-sized type — none of which the `@unbranded-ds/tokens` schema includes. They added the values themselves, leaning on the "extra tokens beyond the schema are allowed" line in THEMING.md as permission. That works, but it forces every consumer to reinvent the same handful of additions, and it blocks standardizing components like a future `<Heading size="2xl">` whose size names don't exist in the schema yet.
+
+This spec brings the missing categories into the canonical schema (the for-coleman items B.1 `font-serif`, B.2 motion, B.3 larger type sizes) and documents the extension pattern (C.2) so future additions follow a known path. It also closes a structural gap surfaced during spec 005's implementation: the bundled theme files carry only `color` overrides, so every other category is design-system-fixed even though Constitution Section III says token values float at runtime for every category, not just color.
+
+Adding required tokens is a breaking change to any existing consumer theme. Pre-1.0 that is acceptable; the version bump announces it in one cycle alongside the structural fix, keeping the breaking-change announcement to a single release.
+
+## Clarifications
+
+### Session 2026-05-25
+
+- Q: Which layer does the validation loosening target, given that the build-time DTCG theme files and the runtime `validateTheme` format are different shapes? → A: Keep the two formats separate; they serve two real pipelines (ahead-of-time Style Dictionary builds for the static built-in themes, just-in-time `registerTheme` for consumer-supplied dynamic themes). `validateTheme` stays the runtime-theme validator, loosened to accept partial themes, and MUST resolve (merge the override onto the canonical defaults) before validating, so contrast and completeness check the merged result rather than the raw fragment. Built-in DTCG themes are verified by their resolved build output, not by `validateTheme`. THEMING.md documents the token-source-override vs runtime-theme distinction with an example of each.
+- Q: How should the motion tokens be named in the output (CSS vars and Tailwind utilities)? → A: Tailwind-namespace-aligned. Easings emit as `--ease-{standard,decelerate,accelerate}` (generating `ease-*` utilities); durations emit as `--duration-{fast,base,slow}`. The schema category stays `motion`, but the build special-cases its variable naming rather than using `--motion-*`. The brief's `--easing-*` is corrected to `--ease-*`. Whether v4 auto-generates named `duration-*` utilities is confirmed during planning; easings generate `ease-*` regardless.
+- Q: Does `brand.json` ship a demonstrative non-color override, or do the built-in themes stay color-only? → A: `brand.json` ships a richer multi-category non-color override (a `radius` override plus a `typography` override such as a font weight or font family), demonstrating more of the theming surface. `light.json` and `dark.json` stay color-only. This gives FR-014's THEMING.md example a real, shipped theme to reference.
+- Q: Which packages bump for the release? → A: `@unbranded-ds/tokens` minor to 0.4.0 plus `@unbranded-ds/react` patch (a dependency-range bump to `^0.4.0` so react consumers receive the new tokens through the re-exported preset). Standard Changesets dependent-bump; no react source changes.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Canonical tokens for serif, motion, and larger type (Priority: P1) 🎯 MVP
+
+A consumer building an editorial or motion-aware component reaches for serif body type, animation durations and easings, and display-larger type sizes using canonical token names from `@unbranded-ds/tokens` — without redefining them in their own project. A component author writing a transition uses the shared duration and easing tokens so every animated component in the design system moves at a consistent speed and curve.
+
+**Why this priority**: This is the core for-coleman ask (B.1 + B.2 + B.3) and the reason the spec exists. It delivers value on its own: even without the theme-override loosening (US2) or the documentation walkthrough (US3), shipping the new tokens lets consumers stop reinventing them. It also unblocks the spec 010 retrofit, which swaps primitive transitions to these motion tokens.
+
+**Independent Test**: Add the new tokens to the schema and source files, run the build, and confirm a consumer can style a component with `font-serif`, a motion duration, a motion easing, and a `2xl`/`3xl` type size — all resolving to real CSS variables and Tailwind utilities — without authoring those values themselves.
+
+**Acceptance Scenarios**:
+
+1. **Given** the expanded schema, **When** a contributor inspects the typography category, **Then** it requires `font-serif`, `size-2xl`, and `size-3xl` in addition to the existing keys.
+2. **Given** the expanded schema, **When** a contributor inspects the token categories, **Then** a top-level `motion` category exists with three duration keys (fast, base, slow) and three easing keys (standard, decelerate, accelerate).
+3. **Given** the regenerated build artifacts, **When** a consumer writes a component using a motion duration and easing through Tailwind utility syntax, **Then** the styles resolve to the generated CSS variables and the animation runs at the token-defined speed and curve.
+4. **Given** the regenerated build, **When** a consumer inspects the four output artifacts (CSS variables, Tailwind preset, TypeScript token map, JSON), **Then** every new token appears in all four.
+
+---
+
+### User Story 2 - Themes can override any token category (Priority: P2)
+
+A consumer authoring a brand theme overrides border radius, default spacing, or a font family — not just colors — and the theme validates and produces a working CSS variable set. A consumer who only wants a color skin keeps writing color-only themes exactly as before; nothing about the existing color-theming path changes for them.
+
+**Why this priority**: This aligns the implementation with Constitution Section III ("token values float at runtime" for every category). Most consumers theme only color, so this is a smaller audience than US1, but for brand themes that need different rounding or spacing it removes a hard wall. Bundling it in the same release as US1 keeps the breaking-change announcement to one cycle.
+
+**Independent Test**: Author a theme that overrides `color` plus one non-color category (for example `radius`), validate it, and confirm it passes and generates a working CSS variable set where the non-color override takes effect and every untouched token inherits the canonical default.
+
+**Acceptance Scenarios**:
+
+1. **Given** a theme that overrides only `color` and `radius`, **When** it is validated, **Then** validation passes and the omitted categories inherit the canonical default values.
+2. **Given** a theme that overrides a subset of keys within a category, **When** it is validated, **Then** validation passes and the omitted keys within that category inherit their canonical defaults.
+3. **Given** a color-only theme written against the previous format, **When** it is validated under the expanded validator, **Then** it still passes — the existing color-theming path is unchanged.
+4. **Given** the token-query MCP's palette lookup against a category the active theme now carries (for example `radius` or `motion`), **When** the lookup runs, **Then** it returns the resolved values rather than the `unknown-category` response it returned before. (No MCP code changes in this spec; the unblock is automatic once theme data carries the category.)
+
+---
+
+### User Story 3 - A documented path to extend the schema (Priority: P3)
+
+A first-time contributor who needs a token category the schema doesn't have opens THEMING.md and follows a worked example that walks the full pipeline — adding a source file, updating the schema, updating the themes, regenerating, and verifying the new tokens in every output. A separate subsection shows how a brand theme overrides a non-color category, so the override capability from US2 has a documented entry point.
+
+**Why this priority**: The extension capability already exists informally ("extra tokens beyond the schema are allowed"), but without a worked example a contributor is left guessing how a new token flows through the build into the dist outputs. This is documentation polish on top of the functional work in US1 and US2; it adds the most value once the tokens and the override capability are already in place.
+
+**Independent Test**: A contributor unfamiliar with the token pipeline follows the THEMING.md walkthrough end to end to add a brand-new token category from scratch, and sees the new tokens appear in all four generated artifacts.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated THEMING.md, **When** a contributor reads the "Extending the schema" section, **Then** it walks the complete pipeline using the motion category as the worked example: source file, schema update, theme update, regenerate, verify in all four outputs.
+2. **Given** the updated THEMING.md, **When** a contributor reads the "Overriding non-color tokens" subsection, **Then** it shows a brand theme overriding a non-color category (spacing or radius) and explains that omitted tokens inherit the default.
+3. **Given** the updated THEMING.md, **When** a contributor reads it, **Then** it clearly separates a token-source override (a DTCG file consumed by the build) from a runtime theme document (the flat shape passed to `registerTheme` / `validateTheme`), with a complete worked example of each.
+
+---
+
+### User Story 4 - Optional tokens that absorb hardcoded drift (Priority: P3)
+
+A component author who today hardcodes the same raw value in many places (a `ring-3` focus-ring width repeated 14 times, a `z-50` overlay layer across the four portal components) reaches instead for a canonical token, so the value is named once and a theme can vary it. The tokens land now; swapping the hardcoded usages over to them is a later retrofit.
+
+**Why this priority**: These are latent tokens the codebase already implies. A value hardcoded 14 times is a token without a name. Introducing them is cheap (tokens-package only) and non-breaking, since they are optional and inherit defaults. It also sets up the spec 010 retrofit and documents a latent layering bug: the four portal components all stack at `z-50`, so a tooltip opened inside a dialog has no defined order over it. The ordered z-index scale is the fix the retrofit applies.
+
+**Independent Test**: Add the `ring.width` token and the `z-index` scale to the schema and source defaults, run the build, and confirm both appear in all four artifacts and that a theme can override the ring width or a z-index stop, all without touching any component file.
+
+**Acceptance Scenarios**:
+
+1. **Given** the expanded schema, **When** a contributor inspects the token categories, **Then** a `ring` category with a `width` key and a `z-index` layering scale exist as optional tokens with canonical defaults.
+2. **Given** a theme that omits `ring` and `z-index`, **When** it is validated and built, **Then** it inherits the default ring width and layering scale with no error (the optional-token path from US2).
+3. **Given** the `z-index` scale, **When** a contributor inspects its stops, **Then** they are ordered so a tooltip layer sits above a dialog or overlay layer, giving nested overlays a defined stacking order.
+
+---
+
+### Edge Cases
+
+- **A consumer theme omits a newly-required token** (for example, a brand theme written before this release that never mentions `font-serif`): the token inherits the canonical default. No error — partial themes are valid by design.
+- **The canonical default set itself omits a required token** (a contributor adds a key to the schema but forgets to add its value to the source/default layer): validating a built-in theme surfaces a structured error naming the missing path, because there is no default left to inherit. This guards the completeness of the defaults, not the completeness of every consumer theme.
+- **A theme overrides a token with a malformed value** (a non-string where a string is expected, or a color pair that fails WCAG AA contrast): the structured-error behavior holds; the WCAG AA contrast checks still apply, now against the resolved merged theme.
+- **A partial theme overrides one side of a contrast pair and inherits the other** (for example, it overrides `color.background` but not `color.foreground`): validation merges the override onto the canonical defaults first, so the AA check runs against the inherited foreground and the overridden background. Without the merge, the current skip-when-a-side-is-absent behavior would silently pass a failing pair.
+- **A consumer references a motion token through Tailwind that doesn't exist** (a typo like `duration-medium`): standard Tailwind behavior — the utility doesn't resolve. The token set defines fast, base, and slow; there is no `medium`.
+- **Display-tier sizes** (`display-sm`, `display`, `display-lg`, `display-xl`) are requested by a consumer: not in scope for this spec. They are deferred until a component contract (likely a `<Heading>`) needs them, since naming display stops without a consumer is premature.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Schema additions (US1)**
+
+- **FR-001**: The token schema MUST declare `font-serif` as a required key in the typography category.
+- **FR-002**: The token schema MUST declare a new top-level `motion` category, peer to color, spacing, typography, radius, shadow, and opacity, with three required duration keys (fast, base, slow) and three required easing keys (standard, decelerate, accelerate). The emitted CSS variable names follow Tailwind's motion namespaces (`--ease-*`, `--duration-*`) per FR-006, not the `--motion-*` pattern the other categories use.
+- **FR-003**: The token schema MUST declare `size-2xl` and `size-3xl` as required keys in the typography category.
+- **FR-004**: The motion duration and easing values MUST adopt the conservative defaults from the brief (durations of 120ms / 240ms / 480ms; easings of the standard, decelerate, and accelerate cubic-bezier curves), sourced from established platform motion guidance.
+- **FR-005**: Every newly required token MUST flow through the build into all four published artifacts: CSS custom properties, the Tailwind preset, the TypeScript token map, and the raw JSON.
+- **FR-006**: The motion tokens MUST emit Tailwind-namespace-aligned CSS variables so they generate real utilities. Easings emit as `--ease-{standard,decelerate,accelerate}` (generating `ease-standard` and the like); durations emit as `--duration-{fast,base,slow}`. The build special-cases the motion category's variable naming rather than the `--{category}-{key}` pattern. Whether Tailwind v4 generates named `duration-*` utilities from a `--duration-*` namespace MUST be confirmed during planning; if it does not, durations fall back to arbitrary-value references like `duration-[var(--duration-base)]` while easings still generate `ease-*` utilities.
+
+**Theme override loosening (US2)**
+
+- **FR-007**: Theme validation MUST accept a theme that provides overrides for any token category, not only color.
+- **FR-008**: Theme validation MUST accept a theme that overrides only a subset of categories, or only a subset of keys within a category, by resolving the override against the canonical defaults and validating the merged result. Every omitted token inherits the canonical default value; validation never runs against the raw fragment.
+- **FR-009**: A color-only theme written against the prior format MUST continue to validate unchanged — the existing color-theming path MUST NOT regress.
+- **FR-010**: The canonical default layer (the source token definitions and built-in themes that supply the inherited baseline) MUST define every required token, including the new ones. When a token has no inheritable default and is absent, validation MUST return a structured error naming the missing path.
+- **FR-011**: All three built-in themes (the DTCG source files consumed by the Style Dictionary build) MUST carry values for every newly required token and MUST produce correct resolved build output under the expanded schema. They are verified through their built CSS output, not by feeding them to `validateTheme`, which validates the separate runtime-theme format.
+- **FR-012**: WCAG AA contrast checks MUST run against the resolved (merged) theme, including pairs where one side is overridden and the other is inherited from the canonical defaults. Loosening category coverage MUST NOT weaken contrast validation; the current behavior of skipping a pair when one side is absent MUST be replaced by checking the merged result.
+- **FR-021**: Resolve-then-validate MUST apply at both validation entry points: `validateTheme` and the post-conversion contrast check inside `registerTheme`. Both currently skip a contrast pair when either side is absent (`if (!fg || !bg) continue`); both MUST instead merge the partial override onto the canonical defaults before checking, so a theme that overrides one side of a pair is checked against the inherited other side.
+- **FR-023**: The built-in `brand.json` MUST ship a multi-category non-color override that demonstrates the broader theming surface: a `radius` override (distinct corner rounding) plus a `typography` override (a font weight or font family). `light.json` and `dark.json` remain color-only. This gives FR-014's THEMING.md example a real, shipped theme to reference.
+
+**Documentation (US3)**
+
+- **FR-013**: THEMING.md MUST gain an "Extending the schema" section that walks the full pipeline — adding a source file, updating the schema, updating the themes, regenerating, and verifying the result in all four outputs — using the motion category as the worked example.
+- **FR-014**: THEMING.md MUST gain an "Overriding non-color tokens" subsection that demonstrates a brand theme overriding a non-color category and explains the inherit-on-omit behavior.
+- **FR-022**: THEMING.md MUST make the two distinct meanings of "theme" crystal clear, with a complete worked example of each. A **token-source override** is a DTCG file (`$value`/`$type`) under `packages/tokens/themes/`, consumed by the Style Dictionary build to bake a static `[data-theme]` CSS file. A **runtime theme document** is the flat `{ name, displayName, tokens }` shape passed to `registerTheme` / `validateTheme`, validated and injected as a `<style>` block at runtime. The section MUST name which pipeline each serves and state plainly that a reader should never have to guess which format a given file or function expects.
+
+**Drift-killing optional tokens (US4)**
+
+- **FR-017**: The schema MUST add a `ring` category with a `width` key as an optional token, with a canonical default equal to what the hardcoded `ring-3` usages resolve to (3px). Themes MAY override it; omitting it inherits the default.
+- **FR-018**: The schema MUST add a `z-index` layering scale as optional tokens, with named stops covering the overlay and portal layers currently hardcoded to `z-50` (dialog/overlay, popover/select, tooltip). The stops MUST be ordered so a tooltip sits above a dialog, giving nested overlays a defined stacking order.
+- **FR-019**: The drift-killing tokens (FR-017, FR-018) MUST be optional rather than required: a theme that omits them inherits the canonical defaults and existing themes do not break. They are the first in-repo consumers of the US2 inherit-on-omit mechanism.
+- **FR-020**: This spec only INTRODUCES the drift-killing tokens in the tokens package. Replacing the hardcoded `ring-3` and `z-50` usages in component source, and the overlay-stacking fix that comes with it, are deferred to spec 010 alongside the motion-transition retrofit.
+
+**Release**
+
+- **FR-015**: The release MUST bump `@unbranded-ds/tokens` minor to 0.4.0 and `@unbranded-ds/react` patch (a dependency-range bump to `^0.4.0` so react consumers receive the new tokens through the re-exported preset; no react source changes). The changeset entry MUST announce the breaking change to consumer themes (the newly required tokens).
+- **FR-016**: Validation error output MUST stay structured (a result shape carrying a code, a path, and a message per issue), consistent with the existing failure-mode pattern. Human-readable messages layer on top of the structured payload, never in place of it.
+
+### Key Entities *(include if feature involves data)*
+
+- **Token category**: A named group of related tokens (color, spacing, typography, radius, shadow, opacity, and the new motion). Each category defines a fixed set of token names known to the build at compile time. This spec adds one category (motion) and three keys to an existing category (typography).
+- **Motion token**: A duration or an easing value. Durations express how long a transition runs; easings express its acceleration curve. Three of each, named by role rather than by raw value.
+- **Token-source override**: A DTCG file (`$value`/`$type`) under `packages/tokens/themes/`, consumed by the Style Dictionary build and merged over the default token sources to bake a static `[data-theme]` CSS file. The built-in `light`/`dark`/`brand` themes are this kind. After this spec it may carry any category, not only color.
+- **Runtime theme document**: The flat `{ name, displayName, tokens }` shape passed to `registerTheme` / `validateTheme`, validated (schema plus WCAG AA contrast on the resolved result) and injected as a `<style>` block at runtime. After this spec it may override any subset of any category; omitted tokens inherit the canonical defaults, and validation runs against the merged result.
+- **Canonical default layer**: The source token definitions plus built-in themes that together provide a complete value for every required token. Partial consumer themes inherit from this layer; it must itself be complete.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A consumer can style a component with serif type, a motion duration, a motion easing, and a `2xl` or `3xl` type size using only canonical token names, with no project-local token definitions.
+- **SC-002**: All three built-in themes produce correct resolved build output under the expanded schema (they are build-time DTCG sources, not `validateTheme` inputs).
+- **SC-003**: A theme that overrides only color plus one non-color category validates and produces a working CSS variable set in which the non-color override takes effect and every untouched token resolves to its canonical default.
+- **SC-004**: A contributor who has never touched the token pipeline can add a brand-new token category from scratch by following the THEMING.md walkthrough and see the new tokens in all four generated artifacts.
+- **SC-005**: A theme that is missing a required token with no inheritable default produces a structured, path-named validation error.
+- **SC-006**: The palette lookup in the token-query MCP returns resolved values for any category the active theme carries, replacing the prior `unknown-category` response — with no change to MCP code.
+- **SC-007**: The release ships with a changeset that announces the breaking change, and the new version is published.
+- **SC-008**: A theme can override the ring width and a z-index stop, and a theme that omits both inherits the canonical defaults, all without any component file changing.
+- **SC-009**: THEMING.md distinguishes a token-source override from a runtime theme document, with a complete worked example of each, so a contributor can tell which format a given file or API expects without reading source.
+
+## Assumptions
+
+- **Version target is 0.4.0, not 0.2.0.** The brief predates the spec 005/006/007 releases; both `@unbranded-ds/tokens` and `@unbranded-ds/react` are already published at 0.3.0. "Next minor bump" therefore resolves to 0.4.0. Adding required tokens is a breaking change to consumer themes, which pre-1.0 is communicated by a minor bump. `@unbranded-ds/react` takes a coordinated patch bump to repoint its tokens dependency at the new minor (see FR-015).
+- **`brand.json` ships a multi-category non-color override; `light.json` and `dark.json` stay color-only.** Confirmed in the clarify session: `brand.json` overrides `radius` and a `typography` token (weight or font) to demonstrate the broader theming surface in a shipped built-in theme, giving FR-014's example real material to reference.
+- **Motion tokens use the DTCG-standard types** (a duration type for durations, a cubic-bezier type for easings) in the source files, consistent with how the existing categories are authored.
+- **Display-tier sizes stay out of scope.** Only `2xl` and `3xl` land now; `display-*` waits for a component contract that needs them.
+- **The drift-killing tokens are optional; the for-coleman additions are required.** Spec 008 ships two tiers on purpose. The for-coleman set (font-serif, motion, 2xl/3xl) is required and breaking, which is what bumps the version. The ring width and z-index scale are optional and non-breaking. This is the "few required, generous optional" discipline: optional tokens are cheap to add once the US2 inherit-on-omit path exists.
+- **Section XI of the constitution is now ratified** (the brief was written before ratification). Its prose and failure-mode rules apply formally to this spec: THEMING.md additions pass through the humanizer skill before merge, prose avoids the three-item-list tic, and validator errors stay structured. No components are added, so the per-component sidecar rule does not apply here.
+- **The token-query MCP needs no code change.** Its palette lookup already reads the in-memory token map; once theme data carries the new categories, it resolves them automatically.
+
+## Dependencies
+
+- **Spec 003 (versioning workflow)** — the changeset tooling handles the multi-package bump and the breaking-change changelog entry.
+- **The existing Style Dictionary build** — the new motion category and typography keys flow through the same four-artifact pipeline already in place.
+- **The existing theme validation** — extended here to merge partial overrides on top of defaults rather than requiring every category to be present.
+
+## Out of Scope
+
+- **Display-tier type sizes** (`display-sm`, `display`, `display-lg`, `display-xl`) — deferred until a component contract requires them.
+- **Density / touch-target tokens** (for-coleman item B.4) — deferred indefinitely.
+- **Migrating consumer themes outside this repo** — that is the consumer's migration cost, announced by the version bump.
+- **Theme composition** (multi-axis themes like `data-theme="vaporwave compact"`) — deferred to spec 012.
+- **First-class theme-extension tokens** (TypeScript types and MCP visibility for tokens declared in a theme JSON but absent from the schema) — deferred to spec 012.
+- **The spec 010 retrofit** that swaps primitive transitions onto these motion tokens — this spec only introduces the tokens; the retrofit consumes them later.
+- **Letter-spacing / tracking and border-width tokens.** Deferred until a consumer needs them, following the "add a category when a consumer hits the wall" policy. The drift evidence isn't there yet; border widths are barely used explicitly in components today.
+- **The component retrofit for the drift-killing tokens.** Swapping the hardcoded `ring-3` (14 usages) and `z-50` (6 usages) onto the FR-017 and FR-018 tokens, plus the overlay-stacking fix, is deferred to spec 010. This spec adds no component changes.

--- a/specs/008-token-schema-growth/tasks.md
+++ b/specs/008-token-schema-growth/tasks.md
@@ -1,0 +1,178 @@
+# Tasks: Token schema growth
+
+**Input**: Design documents from `/specs/008-token-schema-growth/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: The validator change (resolve-then-validate) is logic that needs coverage, and the tokens package already has `schema.test.ts` / `validate.test.ts` / `runtime.test.ts` + fixtures. Test tasks are included for the schema and validator changes, following that established convention. Pure token-source additions are verified by build-output assertions. Coverage spans the merge helper directly (`resolveTheme`), the validator at both call sites, partial-theme injection, the MISSING_TOKEN-after-merge path (SC-005), and Tailwind utility generation, not only variable emission.
+
+**Organization**: By user story. The two front tracks — US1 (token additions) and US2 (validator) — are independent after the foundational schema change and run in parallel. The two shared chokepoint files are `schema.ts` (foundational) and `sd.config.ts` (build wiring).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different file, no dependency on an incomplete task)
+- All paths are under `packages/tokens/` unless noted
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Verify the baseline is green before changes: `pnpm --filter @unbranded-ds/tokens build && pnpm --filter @unbranded-ds/tokens test && pnpm typecheck`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**⚠️ `schema.ts` is the shared chokepoint — US1, US2, and US4 all build on it. It is one file, so its changes are one task, not parallelizable.**
+
+- [ ] T002 Extend and loosen `packages/tokens/src/schema.ts`: add `motionTokens` (required: `duration.{fast,base,slow}`, `easing.{standard,decelerate,accelerate}`); add typography keys `font-serif`, `size-2xl`, `size-3xl` (required); add `ringTokens` and `zIndexTokens` (optional); loosen every category object so a runtime theme may supply a partial subset (categories/keys optional); and export the resolved canonical default token set for the merge. Per `contracts/token-schema.md`.
+
+**Checkpoint**: Schema accepts the new vocabulary and partial themes; defaults are exportable. US1, US2, US4 can now proceed in parallel.
+
+---
+
+## Phase 3: User Story 1 - Canonical tokens for serif, motion, larger type (Priority: P1) 🎯 MVP
+
+**Goal**: The for-coleman required additions (`font-serif`, `motion`, `2xl`/`3xl`) ship and resolve to real CSS vars + Tailwind utilities.
+
+**Independent Test**: Build and confirm a consumer can use `font-serif`, a motion duration/easing, and a `2xl`/`3xl` size — all resolving in the four artifacts and per-theme CSS — without authoring the values.
+
+- [ ] T003 [P] [US1] Create `packages/tokens/src/tokens/motion.json` with durations (120/240/480ms, `$type: duration`) and easings (standard/decelerate/accelerate cubic-beziers, `$type: cubicBezier`) per `contracts/token-schema.md`.
+- [ ] T004 [P] [US1] Edit `packages/tokens/src/tokens/typography.json` — add `font-serif` (`fontFamily`, system serif stack), `size-2xl` (`1.5rem`), `size-3xl` (`1.875rem`).
+- [ ] T005 [US1] Extend `packages/tokens/sd.config.ts` — add the new categories (`motion`, `ring`, `z-index`) to `categoryMap` and the `TokenCategory` union, and special-case the motion category's CSS-var naming so easings emit `--ease-*` and durations emit `--duration-*` (never `--motion-*`). Shared chokepoint file; this task also wires US4's categories. Depends on T002 and the source files (T003, T004, T013, T014).
+- [ ] T006 [US1] Run `pnpm --filter @unbranded-ds/tokens build`; verify `--ease-standard`, `--duration-base`, `--typography-font-serif`, `--typography-size-2xl`, `--typography-size-3xl` appear in all four artifacts (`dist/tailwind/preset.css`, `dist/ts/tokens.ts`, `dist/json/tokens.json`) and in each per-theme `dist/css/tokens-*.css`. Also assert the new categories (`motion`, `ring`, `z-index`) appear in the TS token map's `TokenCategory` set (update `exports.test.ts` if it pins the category list).
+- [ ] T006a [US1] Verify the easing tokens generate real Tailwind utility classes (`ease-standard`, `ease-decelerate`, `ease-accelerate`), not only that the `--ease-*` variables are emitted. Assert against a Tailwind build of the preset or a Storybook smoke check; this guards the var-emitted-but-utility-missing failure mode (the spec-007 `@source` bug class). Note that `duration-*` is not a v4 namespace, so durations are verified as `--duration-*` variables consumed via arbitrary values, not as generated utilities.
+- [ ] T007 [P] [US1] Update `packages/tokens/src/schema.test.ts` to assert the `motion` category and the new typography keys are required in the schema.
+
+**Checkpoint**: New required tokens resolve everywhere. MVP deliverable.
+
+---
+
+## Phase 4: User Story 2 - Themes override any category, resolve-then-validate (Priority: P2)
+
+**Goal**: A runtime theme may override any category; validation runs against the merged result, closing the contrast-skip hole at both call sites.
+
+**Independent Test**: A partial theme (color + radius) validates by inheriting defaults; a theme that overrides one side of a contrast pair and inherits the other fails AA (not skipped); a color-only legacy theme still passes.
+
+**Runs in parallel with US1** — depends only on T002, shares no files with the token-source work.
+
+- [ ] T008 [US2] Add a `resolveTheme(partial)` deep-merge helper (canonical defaults under the override, override wins) in `packages/tokens/src/` per `contracts/validate-theme.md`.
+- [ ] T009 [US2] Edit `packages/tokens/src/validate.ts` — resolve the partial theme against defaults, then validate completeness + contrast on the merged result; remove the `if (!fgValue || !bgValue) continue` skip (line 83) so inherited pairs are checked.
+- [ ] T010 [US2] Edit `packages/tokens/src/runtime.ts` — apply the same resolve before the post-oklch-conversion contrast pass; remove the matching skip (line 97) so `registerTheme` checks the full pair set.
+- [ ] T011 [P] [US2] Add fixtures under `packages/tokens/src/__fixtures__/`: a partial theme (color + radius only) that should pass by inheritance, and an inherited-pair theme that overrides `color.background` to fail AA against the inherited `color.foreground`.
+- [ ] T011a [P] [US2] Add a direct unit test for `resolveTheme` (e.g. `packages/tokens/src/resolve.test.ts`): override wins; nested categories merge per-key rather than replacing the whole category; omitted keys and omitted categories inherit the defaults. This is the core new logic and is otherwise only covered indirectly.
+- [ ] T012 [US2] Update `packages/tokens/src/validate.test.ts` and `runtime.test.ts` — assert partial-theme acceptance, inherited-pair `CONTRAST_FAILURE`, and no color-only regression.
+- [ ] T012a [US2] Assert `registerTheme(partialTheme)` injects a complete `<style>` block (the full merged variable set rather than only the overridden keys), confirming it iterates the resolved theme rather than the raw input.
+- [ ] T012b [US2] Add a MISSING_TOKEN-after-merge test (SC-005): a token absent from both the override and a synthetically incomplete defaults set yields a structured `MISSING_TOKEN` issue naming the path.
+
+**Checkpoint**: The validation model is correct against merged themes.
+
+---
+
+## Phase 5: User Story 4 - Drift-killing optional tokens (Priority: P3)
+
+**Goal**: `ring.width` and an ordered `z-index` scale ship as optional tokens (tokens-package only; the component retrofit is spec 010).
+
+**Independent Test**: `--ring-width` and `--z-index-*` appear in all four artifacts; a theme omitting both still builds and validates by inheritance.
+
+**Source files run in parallel** with US1/US2 after T002.
+
+- [ ] T013 [P] [US4] Create `packages/tokens/src/tokens/ring.json` — `ring.width: 3px` (`dimension`), the value the hardcoded `ring-3` usages resolve to.
+- [ ] T014 [P] [US4] Create `packages/tokens/src/tokens/z-index.json` — an ordered layering scale (e.g. `overlay` < `popover` < `tooltip`) so a tooltip sits above a dialog, giving nested overlays a defined order. Finalize stop names/values here.
+- [ ] T015 [US4] After T005 + build, verify `--ring-width` and `--z-index-*` appear in all four artifacts, and that a theme omitting `ring`/`z-index` validates by inheritance (no `MISSING_TOKEN`).
+- [ ] T016 [P] [US4] Add a test asserting `ring` and `z-index` are optional: a theme omitting them validates clean.
+
+**Checkpoint**: Optional drift tokens shipped; the latent `z-50` ordering is encoded (the component fix is deferred to spec 010).
+
+---
+
+## Phase 6: User Story 3 - Documented schema extension + the two-formats distinction (Priority: P3)
+
+**Goal**: THEMING.md gains the extend-schema walkthrough, the override-non-color subsection (with the enriched brand theme as the example), and a crystal-clear distinction between the two theme concepts.
+
+**Independent Test**: A contributor follows the walkthrough to add a category end to end; the distinction section has a complete worked example of each theme format.
+
+**Depends on US1/US2/US4 being settled** (it documents them).
+
+- [ ] T017 [P] [US3] Edit `packages/tokens/themes/brand.json` — add a `radius` override (distinct corner rounding) plus a `typography` override (font weight or family); leave `light.json` and `dark.json` color-only (FR-023). Independent file; can land any time after T002. Verify brand's resolved `dist/css/tokens-brand.css` reflects the radius and typography override (SC-003).
+- [ ] T018 [US3] Add the "Extending the schema" walkthrough to `THEMING.md` using the motion category as the worked example (source file → schema → theme → regenerate → verify in all four outputs).
+- [ ] T019 [US3] Add the "Overriding non-color tokens" subsection to `THEMING.md`, pointing at the enriched `brand.json` and explaining inherit-on-omit. Depends on T017.
+- [ ] T020 [US3] Add the token-source-override vs runtime-theme distinction to `THEMING.md` (FR-022): name which pipeline each serves, with a complete worked example of each format.
+- [ ] T021 [US3] Run all new THEMING.md prose through the `humanizer` skill (audit-and-revise loop) before merge, per the project prose rule.
+
+**Checkpoint**: Docs make the two theme formats unmistakable and the extension path followable.
+
+---
+
+## Phase 7: Polish & Release
+
+- [ ] T022 Full verification: `pnpm --filter @unbranded-ds/tokens build && pnpm --filter @unbranded-ds/tokens test && pnpm typecheck`; confirm every new token in all four artifacts; confirm the validator merge path uses no browser globals (SSR-safe).
+- [ ] T023 Add `.changeset/*.md` declaring `@unbranded-ds/tokens: minor` (0.4.0), announcing the breaking change to consumer runtime themes (the newly required tokens). The `@unbranded-ds/react` patch is automatic via `updateInternalDependencies: "patch"`; no react source change.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase order
+
+- **Setup (T001)** → **Foundational (T002)** → **US1 ∥ US2 ∥ US4-sources** → **build wiring (T005) + build-verify (T006/T015)** → **US3 docs** → **Polish/Release**.
+
+### The two chokepoint files
+
+- `schema.ts` — T002 only (foundational). All schema changes in one task because it is one file.
+- `sd.config.ts` — T005 only (covers motion naming + all new categories). One file, one task.
+
+### Story dependencies
+
+- **US1, US2, US4 are mutually independent** after T002 — they share no files except the two chokepoints (T002 done first; T005 is a single convergence task).
+- **US3** depends on US1/US2/US4 (it documents them) and on T017 (brand.json) for its override example.
+- **Polish/Release** depends on everything.
+
+### Parallel opportunities
+
+- **The headline split**: US1 (T003–T007) ∥ US2 (T008–T012) ∥ US4 sources (T013–T014). Hand US2 (the validator refactor) to a separate worker — it touches only `validate.ts`, `runtime.ts`, fixtures, and tests.
+- `[P]` source files: T003 (motion.json), T004 (typography.json), T013 (ring.json), T014 (z-index.json) — four disjoint files.
+- `[P]` tests/fixtures: T007 (schema.test), T011 (fixtures), T011a (resolveTheme unit test), T016 (optional-token test).
+- `[P]` T017 (brand.json) — disjoint file, any time after T002.
+
+---
+
+## Parallel Example: the front tracks
+
+```bash
+# After T002 (foundational schema) lands, two workers in parallel:
+
+# Worker A — US1 token additions:
+T003 motion.json  ∥  T004 typography.json        # disjoint source files
+→ T005 sd.config.ts (build wiring, all categories)
+→ T006 build + verify artifacts
+T007 schema.test.ts                               # parallel with the above
+
+# Worker B — US2 validator (shares no files with A):
+T008 resolveTheme helper
+→ T009 validate.ts  →  T010 runtime.ts
+T011 fixtures (parallel)
+→ T012 validate.test.ts + runtime.test.ts
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (US1 only)
+
+T001 → T002 → T003/T004 → T005 → T006. Ships the for-coleman required tokens resolving in all artifacts. Stop and validate; this alone is a shippable increment.
+
+### Incremental delivery
+
+1. Foundational + US1 → MVP (new tokens resolve).
+2. US2 in parallel → partial themes validate against the merged result.
+3. US4 → optional drift tokens shipped.
+4. US3 → docs make it legible.
+5. Polish + changeset → release 0.4.0.
+
+### Notes
+
+- Motion var naming is the one special case (`--ease-*`/`--duration-*`, not `--motion-*`).
+- The contrast skip is in two files (`validate.ts:83`, `runtime.ts:97`) — fix both.
+- Built-in themes inherit the new required tokens from `src/tokens` defaults; do not duplicate them into `light`/`dark`/`brand`.
+- THEMING.md prose runs through the humanizer before merge.


### PR DESCRIPTION
## Summary

Grows the `@unbranded-ds/tokens` schema and loosens runtime theme validation. Adds the for-coleman tokens (a serif font, a motion category, larger type sizes) plus two optional drift-killing tokens, and lets a runtime theme override any category instead of color only. Ships as `@unbranded-ds/tokens@0.4.0` with an automatic `@unbranded-ds/react` patch. Spec, plan, and tasks live in `specs/008-token-schema-growth/`.

## What Changed

New required tokens:
- `font-serif`, for editorial and book-style type
- a `motion` category: durations (`fast`/`base`/`slow`) and easings (`standard`/`decelerate`/`accelerate`). Easings emit as `--ease-*` and generate real `ease-*` Tailwind utilities; durations emit as `--duration-*` variables, used via `duration-[var(--duration-base)]` since Tailwind v4 has no duration namespace.
- `size-2xl` and `size-3xl`

New optional tokens (non-breaking, inherit when omitted):
- `ring.width`, naming the focus-ring width 14 components hardcode today
- a `z-index` layering scale (`overlay`/`popover`/`tooltip`), ordered so a tooltip stacks above a dialog. The component swap is deferred to spec 010; this only introduces the tokens.

Validation:
- `validateTheme` accepts a partial theme. It merges the override onto the canonical defaults and validates the merged result, so a theme can change any subset of categories and inherit the rest. Contrast runs on the merged colors at both `validateTheme` and `registerTheme`, so a pair where one side is overridden and the other inherited is no longer skipped.

Docs:
- THEMING.md distinguishes the two things called "theme" (a build-time DTCG token-source override versus a runtime theme document) with a worked example of each, plus an extend-the-schema walkthrough and an override-non-color section.
- The brand theme grows a radius and `font-sans` override as a shipped demonstration of partial non-color theming.

## Notable

A WCAG AA gap surfaced and is fixed. The light theme's `muted-foreground`/`muted` (4.40:1) and `destructive-foreground`/`destructive` (3.61:1) sat just under 4.5:1, invisible while the validator skipped inherited pairs. Both move to 4.55:1 (hue and chroma unchanged), and a new contrast test pins all three built-in themes against their declared pairs so it cannot regress.

Backward-compatible at runtime. Because validation merges onto defaults, an existing complete theme inherits the new required tokens and keeps validating. The schema growth is a minor bump, not a hard break.

## Test Plan

- `pnpm --filter @unbranded-ds/tokens test` (102 tests: a direct `resolveTheme` merge test, the inherited-pair contrast case, MISSING_TOKEN-after-merge, and the all-themes contrast guard)
- `pnpm build` and `pnpm typecheck` across the workspace
- `ease-standard` confirmed generating as a real utility via Tailwind v4 compile
- Spec 007 sidecar validator unaffected (75 + 31 blocks)
