### PR TITLE
docs: capture workshop and planning output from gitignored tmp/

### DIFF
--- a/docs/workshops/2026-05-15/TODO.md
+++ b/docs/workshops/2026-05-15/TODO.md
@@ -1,0 +1,288 @@
+# unbranded-ds DX feedback
+
+Lightweight evidence-based feedback collected while integrating `@unbranded-ds/tokens@0.1.0` and `@unbranded-ds/react@0.1.0` into for-coleman. Goal: help the monorepo become as kickass as possible for downstream consumers.
+
+Format: each item names the gap, why it matters, and a concrete suggested resolution. Items are ordered by how often a real consumer hits them.
+
+---
+
+## A. Components to port FROM for-coleman INTO unbranded-ds
+
+These were built locally in for-coleman because they didn't exist upstream. Every one is generic — no museum coupling — and several DS-driven projects would build them again. Direct candidates for the upstream `@unbranded-ds/react` package.
+
+### A.1 `<VariableText>` — variable-font axis primitive
+
+- **Why**: Variable fonts are everywhere now. A primitive that maps a 0..1 progress value to `font-variation-settings` is missing infrastructure for anyone doing scroll-tied typography, kinetic type, or animated emphasis.
+- **What it does**: Accepts `axis` (e.g., `'wght' | 'ital' | 'slnt'`), `range` (`[from, to]`), `progress` (`0..1`), and an optional polymorphic `as` prop. Renders children with the computed `font-variation-settings`. Snaps to `range[1]` on `prefers-reduced-motion`. Mirrors `wght` to `font-weight` so non-variable fallbacks degrade gracefully.
+- **Suggested location**: `packages/react/src/components/VariableText/`.
+- **Reference implementation**: see `components/scene/variable-text.tsx` in for-coleman. ~70 lines, zero deps beyond `framer-motion`'s `useReducedMotion` (or roll your own if you'd rather not depend on framer-motion).
+
+### A.2 `<ThemeToggle>` — ternary segmented control (light/auto/dark)
+
+- **Why**: Every DS-driven app rebuilds this. The pattern is well-defined (localStorage persistence + system fallback + live media-query listener for the auto state) but each consumer reimplements. Shipping the canonical version means consumers can drop it in.
+- **What it does**: Three-state segmented control. Persists to `localStorage` (key `'theme'`). When in `auto`, listens to `prefers-color-scheme` changes mid-session. Sets `data-theme` on `document.documentElement`. Accessible: semantic `<fieldset>` + radio inputs, visually-hidden but keyboard-navigable.
+- **Suggested location**: `packages/react/src/components/ThemeToggle/`.
+- **Reference**: `components/theme-toggle.tsx` in for-coleman. ~100 lines + ~40 lines of CSS.
+
+### A.3 `themeBootstrapScript` — FOUC-prevention helper
+
+- **Why**: Every consumer needs this exact pattern: an inline script in `<head>` that reads the saved theme from localStorage and sets `data-theme` on `<html>` before the first paint. Without it, dark-mode users see a light-flash on every reload. Re-deriving the script from scratch is error-prone (e.g., forgetting to handle blocked localStorage).
+- **What it does**: Exports a stringified IIFE that consumers inline via `<script dangerouslySetInnerHTML={{ __html: themeBootstrapScript }} />`.
+- **Suggested location**: `@unbranded-ds/tokens/runtime` (since it pairs with the theme system, not the React components). Single named export.
+- **Reference**: the `THEME_BOOTSTRAP` constant in `app/layout.tsx` in for-coleman. ~10 lines.
+
+### A.4 Visually-hidden utility (sr-only)
+
+- **Why**: Already on the upstream gap list informally; making it formal closes the loop. Every accessible app needs ARIA-only text.
+- **Options**:
+  1. Tailwind utility in the preset.css (`@theme inline { /* … */ }`) that emits `.sr-only` with the canonical clip-path pattern.
+  2. A `<VisuallyHidden>` component (Radix-style, polymorphic).
+  3. Both — the utility for static markup, the component for prop-driven cases.
+- **Suggested location**: utility in `@unbranded-ds/tokens/dist/tailwind/preset.css`. Component in `@unbranded-ds/react`.
+- **Reference**: the `.sr-only` class in for-coleman's `globals.css`. ~10 lines.
+
+---
+
+## B. Token schema additions
+
+Real gaps in `@unbranded-ds/tokens@0.1.0`'s schema that downstream consumers will all hit.
+
+### B.1 `font-serif` typography token
+
+The schema declares `font-sans` and `font-mono` but not `font-serif`. Editorial / curatorial / museum / book-style sites need serif body type. for-coleman added it via `--typography-font-serif` and treated unbranded-ds's "extra tokens beyond the schema are allowed" line as permission, but it should be in the canonical schema. One-line addition.
+
+### B.2 Motion tokens (durations + easings)
+
+The schema has zero motion tokens. Real apps need:
+
+```
+--duration-fast:     120ms
+--duration-base:     240ms
+--duration-slow:     480ms
+
+--easing-standard:   cubic-bezier(0.4, 0, 0.2, 1)
+--easing-decelerate: cubic-bezier(0, 0, 0.2, 1)
+--easing-accelerate: cubic-bezier(0.4, 0, 1, 1)
+```
+
+Material Design and iOS HIG both define this set. Without it, every consumer rolls their own.
+
+### B.3 Type scale beyond `xl`
+
+Schema currently stops at `size-xl` (1.25rem). Editorial sites need display sizes — `2xl`, `3xl`, `display-sm`, `display`, `display-lg`, `display-xl`. Even if the values are stylistic and per-project, naming the scale stops in the schema means components like `<Heading size="display-lg">` can be standard.
+
+### B.4 (Maybe) density / touch-target tokens
+
+`--touch-target` (default 44pt) is something every interactive component needs to honor. Apple HIG defines 44pt minimum; tablet kiosk apps want bigger. Could ship as an opt-in module. Lower priority than B.1–B.3.
+
+---
+
+## C. Documentation gaps
+
+The package has a strong README and a solid THEMING.md. These are the gaps a first-time consumer hits.
+
+### C.1 Tailwind preset import path isn't visible from the README
+
+To wire the tokens into Tailwind v4, the consumer needs:
+
+```css
+@import 'tailwindcss';
+@import '@unbranded-ds/tokens/dist/tailwind/preset.css';
+```
+
+The `dist/tailwind/preset.css` path is discoverable only by reading `package.json`'s `exports` field. Add a "Quickstart with Tailwind v4" section to the tokens README showing the exact import line. Same for the CSS-only (no Tailwind) path: `@unbranded-ds/tokens/dist/css/tokens-light.css` + `tokens-dark.css`.
+
+### C.2 No example of extending the schema
+
+THEMING.md says "extra tokens beyond the schema are allowed; forward compatible by design." Excellent. But there's no example showing:
+
+- How to add a new token type (e.g., `motion`) and have it flow through Style Dictionary into the dist outputs.
+- How to add a new value in an existing type (e.g., adding `size-2xl`) and surface it as a Tailwind utility.
+- How a downstream theme JSON can carry extra tokens that won't be in `@unbranded-ds`'s validation schema.
+
+Even a single end-to-end example covering one of these would unblock consumers.
+
+### C.3 FOUC-prevention pattern isn't documented
+
+THEMING.md covers "applying themes at runtime" but doesn't show the inline-script-in-head pattern that every consumer needs. Add a "Preventing flash-of-wrong-theme" section. Pairs with A.3 above.
+
+### C.4 `validateTheme()` invocation context
+
+The runtime exports `validateTheme()`. Unclear where consumers should call it:
+
+- In a build script (CI)?
+- In a Vitest test as part of the project's test suite?
+- At runtime when a theme is registered?
+
+Add a recipe under "Validating your custom themes" showing the recommended pattern. for-coleman's `tests/unit/design-tokens.spec.ts` does WCAG contrast checks at test time but never calls `validateTheme` — partly because the integration pattern wasn't obvious.
+
+### C.5 Per-component prop tables
+
+`@unbranded-ds/react` ships 9 components but consumers can't see the prop surface without reading the `.d.ts` files or running Storybook locally. Two paths:
+
+1. Publish the Storybook to a public URL (Chromatic was mentioned in the CI; if a URL exists, link it from the React package README).
+2. Add a barebones per-component table to `packages/react/README.md`: name → variants → notable props → quick example.
+
+Storybook is the better source of truth long-term; a README table is the cheap unblocker right now.
+
+### C.6 `publishConfig.access` reminder
+
+When for-coleman first installed `@unbranded-ds/tokens@0.1.0`, the package returned 404 from anonymous npm queries — published as private despite `publishConfig.access: 'public'` being in package.json. The fix was `npm access set status=public @unbranded-ds/tokens`. Worth a one-line callout in the contributor README: "if you fork and publish under your own scope, double-check access after `pnpm publish`."
+
+---
+
+## D. Missing primitives (the gap list)
+
+Components for-coleman needed but `@unbranded-ds/react` doesn't ship yet. Each is generic (not museum-specific). Listed roughly by demand frequency.
+
+| Primitive                 | Demand | Notes                                                                                                                                                                                  |
+| ------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Slider / Range**        | High   | Scenes 5/6/7 need it (tempo, jungle tempo, chop velocity). Standard ARIA-compliant range input. Base UI has `Slider`; thin shadcn-style wrapper would mirror your existing components. |
+| **Tooltip**               | High   | Citation hover, control labels. Base UI has `Tooltip`.                                                                                                                                 |
+| **Toast / Status region** | High   | BYOA load-result announcements (ARIA live region).                                                                                                                                     |
+| **Skip link**             | High   | Keyboard a11y requirement. Hidden until focused, jumps to main content.                                                                                                                |
+| **Segmented control**     | Med    | Theme toggle (A.2 above). If `<ThemeToggle>` lands as a specific component, a generic `<SegmentedControl>` is the underlying primitive.                                                |
+| **VisuallyHidden**        | Med    | A.4 above. Either utility class or component.                                                                                                                                          |
+| **Form**                  | Med    | Wrapping `<Input>` + `<Label>` + error message in an accessible pattern. Base UI has `Form`.                                                                                           |
+
+---
+
+## E. Examples & templates
+
+### E.1 `examples/nextjs-15-app-router/` directory
+
+A minimal, copy-paste-able starter showing `@unbranded-ds/tokens` + `@unbranded-ds/react` wired up in a Next.js 15 App Router project with:
+
+- Tailwind v4 preset import
+- Theme bootstrap script in `app/layout.tsx`
+- A `ThemeToggle` (once A.2 lands)
+- `next/font/local` for self-hosted fonts that override the schema's font tokens
+
+for-coleman currently IS this example, but it's a real project rather than a minimal template. Even a stripped-down version under `examples/` would unblock new consumers significantly.
+
+### E.2 MCP-for-agents documentation
+
+The README mentions the Storybook speaks MCP so agents can see what's in there. As an agent-built project, for-coleman didn't actually wire this up — partly because the consumer-side path wasn't obvious. A "How agents use unbranded-ds" doc would explain:
+
+- What MCP endpoint to point an agent at
+- What queries it supports
+- A worked example (e.g., "Claude Code, scaffold a component using the Card primitive")
+
+---
+
+## F. Misc observations
+
+- **Token naming**: the schema uses `--typography-font-sans` (long form). Many DS use shorter `--font-sans`. Mostly preference; the long form is more discoverable but longer to type. Worth a note in the README explaining the rationale.
+- **`oklch` vs `hex`**: the live tokens are oklch. The schema accepts hex. The conversion happens at registration time. Worth mentioning: contrast math is more accurate against the linearized sRGB derived from oklch than from hex (perceptually-uniform luminance). for-coleman's contrast audit (see `tests/unit/design-tokens.spec.ts`) is a possible model for downstream WCAG validation.
+
+---
+
+## G. Build & distribution
+
+Decisions about how the packages are exposed to consumers' build pipelines. These determine the first ten minutes of a consumer's experience. The single biggest opportunity in this whole document is G.1 — it's the first thing every Tailwind+React consumer hits.
+
+### G.1 Bundle Tailwind wiring into `@unbranded-ds/react/preset.css`
+
+**What a consumer hits today.** To use `@unbranded-ds/react` components in a Tailwind v4 app, the consumer's `globals.css` needs _two_ statements with _different syntax_ and _inscrutable paths_:
+
+```css
+@import 'tailwindcss';
+@import '@unbranded-ds/tokens/dist/tailwind/preset.css';
+@source "../node_modules/@unbranded-ds/react";
+```
+
+That's three lines, two of which leak internal package layout (`dist/tailwind/`, `node_modules/`), and a mixed-syntax pair (`@import` vs `@source`) that the consumer has to know is _one_ concern (tell-Tailwind-about-the-DS).
+
+**Why the obvious-seeming fix is wrong.** The intuitive move is to put `@source "../@unbranded-ds/react"` into `@unbranded-ds/tokens/dist/tailwind/preset.css` so the consumer only needs one `@import`. But `@unbranded-ds/tokens` is intentionally framework-agnostic — Vue, Svelte, vanilla-HTML, and native-mobile consumers all pull from it. Teaching the tokens package to scan a specific React package leaks framework concern into the wrong layer. A non-React consumer would be paying the cost of a `@source` rule that doesn't apply to them.
+
+**The right layering.** `@source` belongs in the package whose files need scanning. That's `@unbranded-ds/react`. The React package owns the Tailwind-scanning concern for its own dist; tokens stays agnostic.
+
+**Recommended pattern — what to ship:**
+
+1. Add a clean export alias in `@unbranded-ds/tokens/package.json` so the path is package-name-only, no `dist/` leakage:
+
+   ```json
+   "exports": {
+     ".": { "types": "./dist/ts/index.d.ts", "import": "./dist/ts/index.js" },
+     "./runtime": { "types": "./dist/ts/runtime.d.ts", "import": "./dist/ts/runtime.js" },
+     "./preset.css": "./dist/tailwind/preset.css"
+   }
+   ```
+
+2. Ship a new file `@unbranded-ds/react/dist/preset.css` that internally wraps the tokens preset and adds the React-specific source scan:
+
+   ```css
+   /* @unbranded-ds/react/dist/preset.css */
+   @import '@unbranded-ds/tokens/preset.css';
+   @source "../@unbranded-ds/react";
+   ```
+
+   The `@source` path is relative to the file it sits in. Inside `node_modules/@unbranded-ds/react/dist/preset.css`, `../@unbranded-ds/react` resolves to `node_modules/@unbranded-ds/react`, which is what we want Tailwind to scan.
+
+3. Add a matching export alias in `@unbranded-ds/react/package.json`:
+
+   ```json
+   "exports": {
+     ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
+     "./preset.css": "./dist/preset.css"
+   }
+   ```
+
+**What the consumer writes after this lands:**
+
+```css
+@import 'tailwindcss';
+@import '@unbranded-ds/react/preset.css';
+```
+
+Two lines, both clean package-name paths. One for Tailwind itself, one for the DS layer (tokens + scanning, fully wired). The two-step structure mirrors the consumer's mental model — "I'm using Tailwind, and I'm using this design system on top."
+
+A Vue/Svelte/vanilla consumer who only wants tokens gets the same shape:
+
+```css
+@import 'tailwindcss';
+@import '@unbranded-ds/tokens/preset.css';
+```
+
+**Why not collapse to one line by importing Tailwind from inside the DS preset?** Tempting, but couples the DS to a specific Tailwind major. If the consumer upgrades or pins Tailwind to a version the DS preset didn't expect, breakage with confusing errors. Letting the consumer own their `@import 'tailwindcss'` line is the conventional, correct boundary. Two clean lines beats one fragile line.
+
+**Why this preserves consumer overrides (critical — do not break).** The `@theme` block in `tokens/preset.css` is _registration-only_. It says "the Tailwind utility name `color-background` resolves to whatever the CSS variable `--color-background` is set to" — it does NOT set `--color-background` to a default value. Default values live in _separate_ files (`tokens/dist/css/tokens-{light,dark}.css`, generated from `themes/{light,dark}.json`). Consumers compose:
+
+- **Register only** (override everything): `@import '@unbranded-ds/react/preset.css'` + consumer's own `:root { --color-background: ... }` declarations. This is what for-coleman does — we replace the whole palette with museum-specific oklch values. The `@theme` block gives us the Tailwind utility names (`bg-primary`, etc.); our cascade-later declarations provide the values they resolve to.
+- **Register + defaults** (consume the design system as designed): the consumer adds `@import '@unbranded-ds/tokens/themes/light.css'` (and dark) below the preset import to bring in the upstream's default values. Then optionally adds their own overrides below those.
+
+The DS-side rule: **never bundle values into `preset.css`**. If a future change inlines `tokens-light.css` into `preset.css` "for convenience," it would force the upstream's default palette onto every consumer, and overrides would have to fight a same-specificity ancestor declaration. The registration-only design is what makes for-coleman's full palette swap possible with a single `:root { ... }` block. Keep them separate.
+
+**Documentation note:** the package's README should show the two-line wiring as the quickstart, plus a "consuming with overrides" recipe that demonstrates the registration-only / values-separate pattern. This obsoletes most of feedback item **C.1** (which described documenting the inscrutable three-line path) — the right fix is to make the two-line path the actual API, not document a workaround.
+
+**Why this is the highest-leverage item in the doc.** Every Tailwind-using consumer hits this in their first ten minutes. Without the fix, components silently render unstyled and the consumer has to debug "why doesn't my Button look like the Storybook" — which boils down to a Tailwind v4 mechanism (`@source`) that isn't widely documented yet. With the fix, the consumer is up and running on the canonical paths in a single `pnpm add` + two-line `globals.css`.
+
+### G.2 Mirror the clean import paths across all framework packages
+
+Whatever pattern G.1 sets for `@unbranded-ds/react`, repeat for future framework packages (`@unbranded-ds/vue`, `@unbranded-ds/svelte`, `@unbranded-ds/solid`, etc.) so consumers don't have to learn per-package wiring. Each framework package exposes `./preset.css` that wraps tokens + adds its own `@source`. Predictable.
+
+### G.3 Consider what to do about the existing flat-CSS exports
+
+`@unbranded-ds/tokens/dist/css/tokens-{light,dark,brand}.css` and `@unbranded-ds/tokens/dist/tailwind/preset.css` are currently exposed via the wildcard `./dist/css/*` and `./dist/tailwind/*` entries. These work but expose `dist/`. With G.1's named aliases (`./preset.css`, etc.), the wildcards become legacy.
+
+Two options:
+
+- **Keep wildcards** as escape hatches for advanced use. Backwards-compatible.
+- **Remove wildcards** in a 1.0 release to enforce the named API. Cleaner but breaks anyone using the long path.
+
+Probably keep them through 0.x and revisit at 1.0. The clean aliases just become the recommended path in docs.
+
+---
+
+## Summary — ranked impact
+
+If I had to rank by "would have saved the most time during for-coleman integration":
+
+1. **G.1** — bundle Tailwind wiring into `@unbranded-ds/react/preset.css`. First-ten-minutes pain for every Tailwind consumer. Three inscrutable lines → two clean lines. Also fixes the silent-failure mode where components render unstyled with no obvious error.
+2. **A.1** `<VariableText>` and **A.2** `<ThemeToggle>` shipping upstream (port them and we save ~170 lines locally + one-line swap on the consumer side).
+3. **B.2** Motion tokens (durations + easings).
+4. **C.2** Schema extension example.
+5. **C.3** FOUC-prevention doc (pairs with **A.3** `themeBootstrapScript`).
+6. **D** missing primitives — especially Slider and Tooltip.
+
+Happy to PR any of these upstream when the museum hits the next quiet stretch.

--- a/docs/workshops/2026-05-15/agent-first-workshop.md
+++ b/docs/workshops/2026-05-15/agent-first-workshop.md
@@ -1,0 +1,51 @@
+## The constitutional gap — workshop input
+
+The current constitution at [.specify/memory/constitution.md:113-124](.specify/memory/constitution.md#L113-L124) says the MCP is a first-class deliverable but treats it as a publishing concern. What you're reaching for is consumption-side principles. Things to workshop (not a draft — bullets for you to react to):
+
+- **Agents are a primary consumer of stories and autodocs.** Story `argTypes`, descriptions, and `tags` are written to be agent-legible before they're written to be pretty. (Already partly in Section V; could be stated explicitly.)
+- **Predictable beats clever.** Component APIs use names and shapes an agent can guess from analogy — `<Component>`, `<Component.Trigger>`, `<Component.Content>`, `variant`/`size`/`intent`, never bespoke shorthand. No prop named `as` in one place and `polymorphic` in another.
+- **The DS publishes more than a Storybook MCP.** Tokens are agent-queryable (which palette? what's the contrast for this pair? which token covers `accent-on-muted`?). A "design system MCP" is a stated future deliverable, distinct from the Storybook MCP.
+- **Agent-side docs are a peer surface.** `README` has a "developer quickstart" and an "agent quickstart" of equal weight. The agent quickstart names the MCP, lists the tools, gives a worked example, and links the published Storybook.
+- **Failure modes are legible.** Validation errors, missing tokens, broken theme contracts produce machine-readable structured output, not just human prose. (Already true of `validateTheme`; could be a stated principle.)
+- **Story coverage is contract surface for agents.** "If a behavior isn't exercised in a story, it isn't shipped" (Section V) gains a sharper edge: it's also "if it isn't in a story, an agent can't find it."
+
+The amendment is probably a new **Section XI: Agent consumption** (MINOR bump → 1.1.0). Section VII stays as-is; the new section captures the consumption-side philosophy and is what new specs check against.
+
+## Revised sequencing
+
+E.2 promotion pulls the agent-experience theme to the front of the queue. Reworked:
+
+1. **Constitution amendment** — workshop XI, ratify 1.1.0. Cheap, foundational, governs everything downstream.
+2. **G.1 + A.3 + A.4** — consumer DX win. Two-line wiring + `themeBootstrapScript` + `.sr-only`. Unchanged from before.
+3. **E.2 expanded — "Building with unbranded-ds as an agent"** — not a paragraph anymore. A short standalone doc (`AGENTS.md` at repo root, or `apps/storybook/AGENTS.md`) covering: MCP connection string, tool inventory, worked example ("scaffold a Card with a primary Button"), token-query examples, the agent quickstart that the constitution promises. Pairs with light edits to story autodocs to make sure they're actually agent-legible.
+4. **B.2 + B.3 + C.2** — schema growth (motion + type scale) + the extending-the-schema worked example. 0.2.0 bump.
+5. **B.1** — `font-serif`, rides 0.2.0.
+6. **D primitives** — one PR each: Tooltip → SkipLink → Slider → SegmentedControl. Each one is a chance to exercise the new Section XI principles.
+7. **A.2** — compose `<ThemeToggle>` on SegmentedControl + `useTheme`.
+8. **C.4 + C.5 + F.1** — small doc polish (validateTheme recipe, Storybook URL link, naming rationale). Roll into whichever PR is closest.
+9. **E.1** — Next.js example app, last.
+
+Order rationale: constitution first because every later spec checks against it; agent-docs next because it's the highest-conviction differentiator-bearing item; consumer-DX (G.1) high because it gates the example app at the end.
+
+## Feeding into speckit
+
+Concretely, three layers:
+
+**Layer 1 — Constitution amendment (this week).**
+Use `/speckit-constitution` or hand-edit. Single PR. Add Section XI. Bump SYNC IMPACT REPORT to 1.0.0 → 1.1.0. Update [.specify/templates/plan-template.md](.specify/templates/plan-template.md)'s Constitution Check gate to include "does this PR consider agent legibility (Section XI)?" as a checkbox. That last bit is what makes the principle bite — every future plan has to answer it.
+
+**Layer 2 — Specs, one per coherent wave.** Each becomes a directory under `specs/`:
+- `specs/002-consumer-dx-preset/` — G.1 + A.3 + A.4
+- `specs/003-agent-experience/` — E.2 expanded + autodoc audit + (maybe) a token-query MCP if you want to scope that in
+- `specs/004-token-schema-growth/` — B.1 + B.2 + B.3 + C.2
+- `specs/005-primitive-set-expansion/` — D primitives (Tooltip, SkipLink, Slider, SegmentedControl) as a unified spec with one feature per primitive
+- `specs/006-theme-toggle/` — A.2 + `useTheme` hook
+- `specs/007-example-app/` — E.1
+
+Run `/speckit-specify` on each in order — but the constitution amendment **must land first**, so each spec's Constitution Check has Section XI to point at.
+
+**Layer 3 — Tasks per spec via `/speckit-tasks`** as you start each one. Standard speckit flow.
+
+One thing I'd flag: spec 003 is the one that will need the most workshop time, because "agent legibility" is a concept that has to be operationalized into testable criteria. I'd suggest spending the first task of 003 on writing those criteria (e.g., "every story has X, every prop has Y, the MCP exposes Z") so the rest of the spec has measurable success conditions instead of vibes.
+
+Want me to draft Section XI as a concrete amendment for you to react to, or do you want to workshop the bullets above first?

--- a/docs/workshops/2026-05-15/constitution-amendment.md
+++ b/docs/workshops/2026-05-15/constitution-amendment.md
@@ -1,0 +1,138 @@
+# Constitution amendment: add Section XI (Agent and human legibility)
+
+Apply the following three edits to `.specify/memory/constitution.md`. Bump 1.0.0 → 1.1.0 (MINOR — new principle added).
+
+---
+
+## Edit 1 — Replace the SYNC IMPACT REPORT block at the top of the file
+
+```markdown
+<!--
+SYNC IMPACT REPORT
+==================
+Version change:  1.0.0 → 1.1.0  [MINOR — new Section XI added]
+Bump rationale:  Adds the consumption-side principle that pairs with Section VII's
+                 publishing-side rule. Section VII says "the MCP surface is a
+                 first-class deliverable"; Section XI says agents and humans are
+                 first-class consumers of every artifact the design system ships,
+                 and names the concrete practices that make that real (humanizer
+                 pass on prose, no three-item lists, predictable API shapes,
+                 sidecar usage docs, a planned token-query MCP, structured
+                 failure output, story-coverage as dual-audience contract).
+
+Modified principles:
+  - Section V (Stories are the source of truth): unchanged in text, but its
+    "if it isn't in a story, it isn't shipped" rule is referenced and sharpened
+    in Section XI's closing subsection.
+
+Added sections:
+  - XI – Agent and human legibility are co-equal.
+
+Removed sections:  N/A.
+
+Templates audited:
+  ⚠ .specify/templates/plan-template.md   — Constitution Check gate needs a
+                                             checkbox for Section XI (does this
+                                             change consider agent legibility?).
+                                             Update in the same PR.
+  ✅ .specify/templates/spec-template.md   — No change required; existing MUST
+                                             language already covers the new
+                                             rules when authors invoke them.
+  ✅ .specify/templates/tasks-template.md  — No change required.
+
+Deferred TODOs:
+  - The token-query MCP referenced in XI.3 has no spec yet. Track as
+    specs/00X-token-query-mcp once primary work begins. Planned for 1.0.
+  - The sidecar *.usage.md convention referenced in XI.3 has no template yet.
+    Add packages/react/src/components/_template/Component.usage.md when the
+    first new component PR lands under Section XI.
+  - TODO(RATIFICATION_DATE): still unset from 1.0.0.
+-->
+```
+
+---
+
+## Edit 2 — Insert the new section between current Section X (Governance) and the version footer
+
+```markdown
+---
+
+## XI. Agent and human legibility are co-equal
+
+The design system has two consumers. Humans browse stories and docs. Agents query autodocs, MCP tool output, sidecar files, and structured error responses. Neither audience is primary. The same artifact has to work for both.
+
+This is the principle that separates unbranded-ds from a design system that happens to publish an MCP endpoint.
+
+### XI.1 Prose
+
+Every piece of written content — story descriptions, autodoc strings, README files, sidecar usage docs, error messages — is written for both audiences:
+
+- Prose passes through the `humanizer` skill before merge. The AI tells documented in that skill (em-dash overuse, "serves as" phrasing, promotional vocabulary, hedging, signposting) are removed.
+- Lists of exactly three items are restructured. Add a fourth item, drop to two, convert to a sentence, or split into nested bullets. Three-item lists are an LLM tic and read as one to a careful editor. The rule applies to both bulleted lists and inline prose ("X, Y, and Z").
+- Prose is specific over generic and active over passive.
+
+### XI.2 API shape
+
+Component APIs are predictable from analogy:
+
+- Compound components use the `<Component.Slot>` pattern consistently. A `*.Trigger` on one component means the same thing as a `*.Trigger` on any other, and the same holds for `*.Root`, `*.Content`, `*.Item`, and any future slot name.
+- Variant axes use a small shared vocabulary: `variant`, `size`, `intent`, `disabled`. No bespoke synonyms across components.
+- Polymorphic rendering, when present, uses one prop name across the codebase.
+
+An agent who has read one component should be able to guess the prop surface of the next one and be right.
+
+### XI.3 Documentation surfaces
+
+The design system publishes two complementary documentation surfaces for agent consumption:
+
+- The Storybook MCP server, published via Chromatic, is the live remote source (see Section VII).
+- A planned token-query MCP exposes theme listing, palette, contrast math, and semantic token lookup. This is a distinct contract from the Storybook MCP and is planned before 1.0.
+- Per-component sidecar usage docs live at `packages/react/src/components/<Component>/<Component>.usage.md`. They mirror the MCP's component guidance: import path, prop table, common patterns, accessibility notes, examples. An agent or human with a local clone can answer "how do I use Button" with no network connection.
+- A top-level `AGENTS.md` indexes the sidecar docs and names the MCP endpoints. It is a peer document to `README.md`, not a footnote.
+
+Local sidecar docs are not a fallback for the MCP. They are the canonical record an agent pattern-matches against offline. The MCP is the live, queryable view of the same content.
+
+### XI.4 Failure modes
+
+Validation failures produce structured output, not only prose:
+
+- `validateTheme()` returns a typed `{ ok, issues }` shape with codes and paths. This is the existing pattern (Section III) and the model for any future validator.
+- A missing token, a broken contrast pair, a failing theme validation, a malformed sidecar doc all surface with codes an agent can pattern-match.
+
+Human-readable error messages are layered on top of the structured payload, not in place of it.
+
+### XI.5 Story coverage as dual-audience contract
+
+The rule from Section V — "if a behavior is not exercised in a story, it is not considered shipped" — sharpens here. A behavior with no story is invisible to humans browsing the deployed Storybook and invisible to agents introspecting the MCP. Both failure modes count, and either alone is enough to block merge.
+
+---
+```
+
+---
+
+## Edit 3 — Replace the version footer at the bottom of the file
+
+```markdown
+**Version**: 1.1.0 | **Ratified**: TODO(RATIFICATION_DATE): set to original adoption date | **Last Amended**: 2026-05-15
+```
+
+---
+
+## Edit 4 — Update the plan template's Constitution Check gate
+
+Add one line to `.specify/templates/plan-template.md`'s Constitution Check section so every future plan has to answer Section XI. The exact phrasing depends on the template's existing format, but the addition is:
+
+```markdown
+- [ ] Section XI — does this change keep prose, API shape, docs surfaces, failure modes, and story coverage legible to both agents and humans? List any concessions.
+```
+
+Land Edit 4 in the same PR as Edits 1–3.
+
+---
+
+## Notes for whoever reviews the PR
+
+- The amendment is structurally a sibling of Section VII, not a replacement. Section VII still owns "we publish the MCP." Section XI owns "the things we publish are designed for both consumers."
+- The "no three-item list" rule is the one most likely to feel pedantic. Keep it. Once you start counting, you see how often LLM drafts default to three, and the rule is what trains the eye.
+- The `*.usage.md` sidecar convention has no first implementation yet. The first component PR under 1.1.0 should establish a template at `packages/react/src/components/_template/Component.usage.md` so subsequent PRs copy from a known shape.
+- The token-query MCP is the largest deferred commitment in this amendment. It is named in XI.3 as planned before 1.0. If that constraint is too aggressive, soften the wording to "planned for 1.0" and remove the `before 1.0` deadline.

--- a/docs/workshops/2026-05-15/feedback-triage.md
+++ b/docs/workshops/2026-05-15/feedback-triage.md
@@ -1,0 +1,74 @@
+I read the feedback against the current state of the packages. Verified what's there ([packages/tokens/src/schema.ts](packages/tokens/src/schema.ts), [packages/react/package.json](packages/react/package.json), [packages/tokens/package.json](packages/tokens/package.json), [THEMING.md](THEMING.md)). Here's my take, item by item.
+
+## Top picks (do these)
+
+**G.1 — bundle Tailwind wiring into `@unbranded-ds/react/preset.css`.** The strongest item in the doc, and they sold it correctly:
+
+- Layering argument is right: `@source` is a framework concern; it belongs in the React package, not tokens.
+- The "why not collapse to one line" rebuttal is right: importing Tailwind from inside the DS preset couples us to a Tailwind major.
+- The "registration-only `@theme inline` preserves overrides" point is critical and we must not regress it — verified at [packages/tokens/dist/tailwind/preset.css:1-20](packages/tokens/dist/tailwind/preset.css). Default values live in `tokens-{light,dark,brand}.css`, separate from the preset. Keep them separate.
+- Concrete diff: add `"./preset.css"` exports to both packages, ship a 2-line wrapper in `@unbranded-ds/react`. ~30 min of work, ten-minutes-of-pain saved for every consumer.
+
+**A.3 + C.3 — ship `themeBootstrapScript` from `@unbranded-ds/tokens/runtime`.** Small, high-leverage. Note: the feedback says FOUC pattern isn't documented; it actually is at [THEMING.md:132-145](THEMING.md#L132-L145). But the existing version is copy-paste and consumers will drift. Exporting a stringified IIFE is cleaner. One harmonization: the existing snippet uses `ds-theme` as the localStorage key, the feedback's example uses `theme` — pick one (I'd vote `ds-theme` to avoid collision with consumer apps).
+
+**B.2 — motion tokens.** Real schema gap (none today, confirmed [packages/tokens/src/schema.ts:1-93](packages/tokens/src/schema.ts)). The Material/HIG-aligned set they propose is conservative and right. New token category — clean addition. Adopt.
+
+**A.4 — `.sr-only` Tailwind utility.** Tiny. Add to the preset. The component form can wait.
+
+## Worth doing, with modifications
+
+**A.2 — `<ThemeToggle>`.** The pattern is real but the proposed component bakes in localStorage key, document.documentElement, and a specific UX (3-state segmented). For an "unbranded" DS that's a lot of opinion. Counter-proposal: ship the two underlying primitives — `<SegmentedControl>` (also covers D's roadmap) and a `useTheme()` hook — and let consumers compose `<ThemeToggle>` in 20 lines. They get the value without us committing to a UX.
+
+**B.1 — `font-serif` token.** One-line schema change, agreed, but since `themeSchema` requires every token, adding it is a breaking change to existing consumer themes. Two ways: (a) add as required and bump to 0.2.0 (we're pre-1.0, this is fine), or (b) make the typography object's font keys partial. I'd do (a) — cleaner.
+
+**B.3 — type scale beyond `xl`.** Yes to `2xl` and `3xl` as required additions. Display sizes (`display-sm`/`display`/`display-lg`/`display-xl`) feel stylistic — defer until a component (`<Heading>`?) needs them as a contract.
+
+**D — missing primitives.** All legitimate. My priority order, slightly different from theirs:
+
+1. **Tooltip** (Base UI primitive, common, low-spec)
+2. **Skip link** (a11y staple, ~10 lines)
+3. **Slider** (real demand, more design surface)
+4. **SegmentedControl** (pairs with A.2)
+5. **Toast** — defer; semantics + portaling + queueing is a chunk of work
+6. **Form** — defer; depends on whether we want field-level error patterns
+
+**E.1 — `examples/nextjs-15-app-router/`.** Worth doing once G.1 lands, because then the example is genuinely short (2 lines of CSS wiring vs 3). Doing it before G.1 would document the soon-to-be-obsolete path.
+
+## Lighter touch / smaller items
+
+**C.2 — schema-extension worked example.** Yes, one section in THEMING.md showing how to add `motion` end-to-end (JSON → SD config → dist → Tailwind utility). Pairs naturally with shipping B.2.
+
+**C.4 — `validateTheme()` invocation context.** Yes, small recipe in THEMING.md. Recommended pattern: a Vitest test in your project's suite. Cheap doc fix.
+
+**C.5 — per-component docs.** Storybook is the source of truth and we already have Chromatic publishing wired in CI. Solution: link the published Storybook URL from both READMEs once it exists. Skip the README prop tables — they'll rot.
+
+**F.1 — token naming rationale.** One-line note in README. Free.
+
+**F.2 — oklch vs hex.** Already covered at [THEMING.md:73](THEMING.md#L73). Feedback is wrong here; no action.
+
+**C.6 — `publishConfig.access` reminder.** Already correct in [packages/tokens/package.json:42-44](packages/tokens/package.json#L42-L44). Their 404 was probably the npm registry's first-publish cache, not our config. Skip.
+
+## Defer / decline
+
+**A.1 `<VariableText>`.** Cool, but niche. Variable-font axis animation is one museum project, not a broad pattern. Costs us a framer-motion dep (or rolling our own `useReducedMotion`). No.
+
+**B.4 density / touch-target tokens.** They agree it's lower priority. Defer.
+
+**E.2 MCP-for-agents doc.** Worth a short addition to [apps/storybook/README.md](apps/storybook/README.md), but the agent-side use case is still speculative. A paragraph in the existing README, not a new doc.
+
+**G.2 — mirror clean paths to future framework packages.** N/A until `@unbranded-ds/vue` exists. Note the pattern, move on.
+
+**G.3 — wildcard exports.** Keep them through 0.x, exactly as they suggest. Revisit at 1.0.
+
+## Suggested sequencing
+
+If you want to PR this in waves rather than one bolus:
+
+1. **G.1 + A.3 + A.4** (one PR — the consumer-DX win). Two-line wiring + bootstrap helper + sr-only utility.
+2. **B.2 + B.3 + C.2** (one PR — schema growth + the worked example that explains how to grow it). Bump to 0.2.0.
+3. **B.1** (small PR — `font-serif`, ride the 0.2.0 bump).
+4. **D primitives** (one PR per component: Tooltip → Skip link → Slider → SegmentedControl).
+5. **A.2** (compose ThemeToggle on top of SegmentedControl + useTheme, after D's segmented control lands).
+6. **E.1 example app** (last, after G.1 + at least one primitive PR).
+
+The top three lines of that list are where >70% of the value sits. The rest is grind that pays off once a second consumer shows up.

--- a/docs/workshops/2026-05-18/docs-deep-research.md
+++ b/docs/workshops/2026-05-18/docs-deep-research.md
@@ -1,0 +1,817 @@
+# Documentation Strategy for `unbranded-ds`: A Ranked Study of Best-in-Class Design System Docs + Copy-Pasteable TSDoc Templates
+
+## TL;DR
+
+- **Study Adobe React Aria + GitHub Primer + IBM Carbon as your three anchors.** React Aria is the gold standard for accessibility-as-architecture and is the closest match to your shadcn/Radix substrate; Carbon is the gold standard for designer/developer parity and per-component a11y reporting; Primer is the gold standard for transparent "known a11y issues" and design-time accessibility annotations. For your stated priorities (usability, a11y depth, designer+dev parity), use Carbon's *page template* as your skeleton, React Aria's *accessibility-first prose* as your model for what to write, and Primer's *known-issues link + annotation toolkit* as your transparency pattern.
+- **In TSDoc, put accessibility in the IDE — not just on the docs site.** Adopt a strict 6-section component-level prose order (one-liner → `@remarks` extended description → "Accessibility" sub-section → "Keyboard interactions" sub-section → "When to use / alternatives" → `@example` → `@see`) and a strict 3-section prop-level order (description → behavior nuance → `@defaultValue` / a11y implication). Use TSDoc release tags (`@alpha`, `@beta`, `@public`, `@deprecated`) as canonicalized by the TSDoc spec and consumed by API Extractor and TypeDoc.
+- **Treat MDX/Storybook as the designer surface; treat TSDoc as the developer surface — and make one canonical source.** Best-in-class systems (Carbon, Primer, Polaris) split content into Usage, Style/Anatomy, Code, and Accessibility tabs; in a shadcn-style repo you can mirror that split by keeping prose authority in the TSDoc on the source `.tsx` file and re-using/importing those same comments into the MDX doc site via TypeDoc or a `react-docgen` pipeline. Write component docs *before* implementation by stubbing the file with `@alpha` + a full TSDoc block, exporting only the type definition.
+
+---
+
+## Key Findings
+
+1. **No existing shadcn-style docs system documents accessibility well — that is your differentiator.** shadcn/ui intentionally inherits a11y from Radix and writes almost no per-component a11y prose; Radix has the table but no usage/design guidance. `unbranded-ds` can occupy the gap.
+2. **The richest a11y docs in the industry are tabular per-component with three discrete artifacts:** (a) a WAI-ARIA APG link at the top (React Aria's pattern), (b) an explicit keyboard interactions table (Radix's pattern), and (c) a conformance/test-status matrix per release (Carbon, USWDS).
+3. **Status taxonomies converge on three to four labels.** TSDoc's `@alpha`/`@beta`/`@public`/`@deprecated` maps cleanly to Carbon's Draft/Preview/Stable, Workday's Labs/Preview/Main, and Atlassian's early-access/beta/stable badges. Pick one taxonomy and propagate it from the TSDoc tag → docs badge → CLI install warning.
+4. **Designer-developer parity is achieved by separate-but-mirrored content surfaces.** Carbon's public markdown templates (Usage/Style/Code/Accessibility) and Primer's open-source Figma Annotation Toolkit are the two most-emulatable artifacts.
+5. **The strongest transparency posture in the industry is GOV.UK's per-failure ledger plus USWDS's per-version VPAT.** Most teams can't afford a VPAT but every team can afford Primer's "Known accessibility issues" link out to a labelled GitHub issue search.
+
+---
+
+## Details
+
+### Part A — Ranked Analysis: Which Design Systems to Study
+
+#### Scoring framework
+
+Each system is scored 1–5 on three axes that reflect your stated priorities:
+
+1. **Docs usability** — IA, search, navigation, examples-on-page, copy-able code, in-place playgrounds.
+2. **A11y documentation depth** — per-component WCAG mapping, keyboard tables, ARIA attribute disclosure, screen-reader testing notes, known-issues transparency, ACR/VPAT availability.
+3. **Designer ↔ developer parity** — anatomy diagrams, do/don't, content guidance, when-to-use, alternatives, design tokens AND API docs in one place, status/lifecycle taxonomy.
+
+The final ranking weights a11y heaviest (because you've declared it the differentiator), then docs usability, then parity.
+
+#### The ranking
+
+| Rank | System | Usability | A11y depth | Parity | Why it ranks here |
+|------|--------|-----------|------------|--------|-------------------|
+| 1 | **Adobe React Aria / React Spectrum** | 5 | 5 | 4 | Accessibility *is* the product. WAI-ARIA APG pattern reference at the top of every component; behavior, keyboard, focus, i18n explicitly enumerated. The closest analog to what `unbranded-ds` is technically. |
+| 2 | **IBM Carbon** | 5 | 5 | 5 | The reference template for multi-audience docs. Per-component **Usage / Style / Code / Accessibility** tabs with a documented status taxonomy (Draft → Preview candidate → Preview → Stable) and a public testing-status matrix. |
+| 3 | **GitHub Primer** | 4 | 5 | 5 | Best-in-class *transparency*: a per-component "Known accessibility issues" link plus an open-source Figma Annotation Toolkit and Primer A11y Presets that bridge design handoff. |
+| 4 | **Shopify Polaris** | 5 | 4 | 5 | Best designer/UX-writing guidance and the cleanest do/don't pattern; a11y is covered foundationally but not consistently per-component. |
+| 5 | **Radix Primitives** | 4 | 4 | 2 | Every component page has an *explicit* keyboard interactions table mapping `Key → Description`. Developer-only audience, but the API/keyboard pattern is what shadcn already ships on top of. |
+| 6 | **GOV.UK Design System** | 5 | 5 | 3 | Documents WCAG 2.2 AA conformance and tracks individual failures publicly under the GitHub label `accessibility regulations failure` across both the GOV.UK Design System website repo and the GOV.UK Frontend codebase repo. Less applicable for product UI primitives but excellent transparency model. |
+| 7 | **Atlassian Design System** | 4 | 3 | 4 | Strong status tags (e.g., `beta`, `early access`, `caution`, `deprecated`) shown right in the component index; weaker per-component a11y. |
+| 8 | **Microsoft Fluent UI** | 3 | 4 | 4 | Strong on accessibility behaviors (`useAccessibility` hook surface); API Extractor / TSDoc pipeline is documented in-house. Docs site itself fragmented across Fluent 1/2 and Northstar. |
+| 9 | **Workday Canvas Kit** | 4 | 4 | 4 | Explicit *Main / Preview / Labs* maturity buckets analogous to TSDoc's `@public`/`@beta`/`@alpha`. Useful precedent for status conventions. |
+| 10 | **USWDS** | 4 | 5 | 3 | Publishes a real VPAT 2.5 ACR. Per the official accessibility documentation: "we assessed 44 components of USWDS 3.11.0 in March 2025 and published the report in May 2025." Lower parity for designers/devs because focus is government accessibility compliance. |
+| 11 | **Nord (Nordhealth)** | 5 | 3 | 4 | Beautiful, highly opinionated information design — frequently cited as a docs reference. Less per-component a11y depth than Carbon/React Aria. |
+| 12 | **Orbit (Kiwi.com)** | 4 | 3 | 3 | Categorizes components into UI / Layout / Utility / **Accessibility components** (a useful taxonomy), and ships explicit a11y helpers (`SkipLink`, `SkipNavigation`). |
+| 13 | **Material Design (Google)** | 4 | 3 | 4 | Excellent visual specs and do/don't, but a11y per-component is shallower and the docs split between MDC, MUI, and m3.material.io is confusing. |
+| 14 | **shadcn/ui** | 4 | 2 | 2 | Optimized for developer copy-paste; intentionally inherits a11y from Radix and provides almost no in-page a11y prose. **This is exactly the gap `unbranded-ds` should fill.** |
+| 15 | **Salesforce Lightning Design System** | 3 | 3 | 3 | Comprehensive but legacy IA; some Aura/LWC API split confuses readers. Not a strong template. |
+
+> Material Design and Salesforce Lightning are included for completeness but I'd skip them as primary models — they're too platform-specific and their docs IA is older than the others.
+
+#### What makes Carbon strong (and where others exceed it)
+
+**Carbon's strengths** (worth keeping as your template floor):
+
+- **Four-tab template per component** — Usage, Style, Code, Accessibility — applied consistently across the catalog with documented markdown templates and "office hours" review process for contributors.
+- **A documented status taxonomy**, mapped to the IBM Product Development Lifecycle (PDLC). Carbon's contribution checklist defines four explicit lifecycle labels (Draft → Preview candidate → Preview → Stable), each with a one-line definition (e.g., **Stable** = "Complete across code, kit, docs, design, and ready for production use."). Carbon's PDLC page also tells you publicly that **Preview was formerly called "experimental"** but was renamed to raise the bar of production-readiness — a clear precedent for `@alpha`/`@beta` semantics.
+- **A public accessibility testing-status matrix** at `/components/overview/accessibility-status/` that tags every component across four dimensions: **Default state**, **Advanced states**, **Keyboard navigation**, **Screen reader**, with statuses **Tested** ("Passes all automated tests with no reported accessibility violations.") and **Manually tested** ("A human has manually tested this component, e.g. screen reader testing.").
+- **Per-component a11y page structure** with a stable heading hierarchy: `## What Carbon provides` (sub: Keyboard interactions, Behavior) → `## Design recommendations` (sub: Labeling) → `## Development considerations` → `## Accessibility testing status`. Each page links out to the corresponding W3C ARIA APG pattern (e.g., Button page links to `https://www.w3.org/TR/wai-aria-practices-1.2/#button`).
+- **Per-component a11y prose surfaces specific guidance for designers** (e.g., "Icon-only buttons … must be annotated with a label that will be exposed on hover or focus"), making the page useful at design-handoff, not just at code review.
+
+**Where others exceed Carbon:**
+
+- **React Aria — accessibility-as-architecture and APG-link-at-the-top.** React Aria component pages don't actually contain a keyboard-table; they place a single `HeaderInfo` reference to the W3C ARIA APG pattern at the top (e.g., ComboBox links to `https://www.w3.org/WAI/ARIA/apg/patterns/combobox/`) and a bulleted "Features" list. The "Keyboard navigation" bullet states behavior in prose: *"ComboBox can be opened and navigated using the arrow keys, along with page up/down, home/end, etc. The list of options is filtered while typing into the input, and items can be selected with the enter key."* The Dialog/useDialog page describes focus management verbatim: *"Focus is moved into the dialog on mount, and restored to the trigger element on unmount. While open, focus is contained within the dialog, preventing the user from tabbing outside."* This pattern — short, behavioral, vendor-neutral, and linked to the APG — is what you want inside your TSDoc.
+- **Primer — known-issues transparency.** Every Primer component page renders an `<AccessibilityLink label="ComponentName"/>` that links to the open issues filed in the GitHub repo for that component, exposing not just what works but what's broken. This is unusual and powerful.
+- **Radix — explicit keyboard interactions table.** Radix is the only system among your shadcn-substrate set that ships an explicit per-component table mapping `Key → Description` (e.g., Dialog: `Tab → Moves focus to the next focusable element. Escape → Closes the component and moves focus to Dialog.Trigger.`). Since your components inherit Radix behavior, you should reproduce these tables in your TSDoc verbatim where applicable.
+- **GOV.UK — public WCAG-2.2-failure ledger.** Per the GOV.UK Design System accessibility statement: "The team documents WCAG 2.2 A and AA failures in two repositories under the 'accessibility regulations failure' issue label: GOV.UK Design System website label for accessibility regulations failures · GOV.UK Frontend codebase label for accessibility regulations failures." The pattern is more transparent than Carbon's "Tested / Manually tested" labels.
+- **USWDS — actual VPAT.** USWDS publishes a VPAT 2.5 ACR covering 44 components (USWDS 3.11.0 assessed March 2025, published May 2025). If `unbranded-ds` ever wants to be picked up by government or enterprise consumers, publishing a per-major-version ACR is the gold standard.
+- **Polaris — UX-writing prose embedded in component pages.** Polaris is unmatched at integrating content guidance into the component itself ("Do: 'Save changes' / Don't: 'Submit'").
+
+#### Concrete patterns worth emulating per category
+
+##### How they structure component pages
+
+| System | Page template (top-level sections) |
+|---|---|
+| Carbon | `Usage` · `Style` · `Code` · `Accessibility` (tabbed) |
+| React Aria | `Example` → `Features` → `Anatomy` → `Examples` → `Reusable wrappers` → … → `Props` → `Styling` → `Advanced customization` → `Testing` (single page) |
+| Primer | `Overview` → `Examples` → `Accessibility` → `Anatomy` → `Options/Props` → `Status` → `Related links` |
+| Polaris | `Examples` → `Best practices` → `Content guidelines` → `Accessibility` → `Props` |
+| Radix | `Features` → `Installation` → `Anatomy` → `API Reference` → `Accessibility` (with **Keyboard Interactions** sub-table) → `Examples` |
+| Atlassian | `Description (with status tag)` → `Examples` → `Props` (with deprecation banners inline) |
+
+**Recommendation:** Adopt a 6-tab/section template: **Overview → Anatomy → Usage (Do/Don't) → API/Props → Accessibility → Examples**. This is the union of Carbon's four-tab template and Radix's explicit keyboard table, with Primer's anatomy diagram in slot 2.
+
+##### How they document props/API
+
+- **Carbon and Fluent UI** generate prop tables from TSDoc/`@fluentui/api-docs` via Microsoft's API Extractor pipeline.
+- **React Aria** auto-generates prop tables from typed render props and includes a "Description" column populated from the TSDoc.
+- **Radix** uses a `Name | Type | Default | Description` table on every component, with a small annotation `(*) Required` and inline links to types.
+- **Atlassian** decorates props with status badges inline (`deprecated`, `beta`, `early access`).
+
+**Recommendation:** Use `Name | Type | Default | Description` columns and route your prop documentation through TSDoc on the `interface ComponentProps` declaration so that both IDE tooltips and your docs site share a single source of truth. The TypeDoc default theme handles this natively; API Extractor is the production-grade option for monorepos like yours.
+
+##### How they handle accessibility documentation specifically
+
+| Pattern | Best example | What it looks like |
+|---|---|---|
+| **Per-component WCAG conformance statement** | Carbon, GOV.UK | "This component has been validated to meet the WCAG 2.1 AA and Section 508 accessibility guidelines, however changes made by the content owner can affect accessibility compliance." (verbatim from Carbon Button page) |
+| **Per-component WCAG failure ledger** | GOV.UK | GitHub issue label `accessibility regulations failure` per failed WCAG 2.2 A/AA criterion, tracked across both the design-system website repo and the `govuk-frontend` codebase repo |
+| **Keyboard interactions table** | Radix, plus implicit in Carbon's "What Carbon provides" prose | `Tab → Moves focus to next element` — two columns: Key (using `<kbd>` semantically) and Description |
+| **ARIA attribute disclosure** | Radix, React Aria | Lists which ARIA roles/states are applied (e.g., Radix Dialog: "automatically has `role='dialog'`, `aria-modal='true'`") |
+| **Screen reader testing notes per component** | Carbon (v10 docs) | Records test environment: `macOS Mojave 10.14.6 + VoiceOver + Chrome 77 + Carbon React 7.7.1` and tested-against-the-script results |
+| **Accessibility design-handoff annotations** | Primer (Figma Annotation Toolkit), GitHub Annotation Toolkit | Reusable Figma stamps for landmarks, heading structure, focus management, live regions |
+| **Known a11y issues link** | Primer | `<AccessibilityLink label="Button"/>` rendered on every component page |
+| **Component-level ACR/VPAT** | USWDS | VPAT 2.5 ACR covering 44 components assessed in March 2025 and published in May 2025 against USWDS 3.11.0 |
+| **Accessibility status matrix** | Carbon | Public table per component × {Default state, Advanced states, Keyboard navigation, Screen reader} × {Tested, Manually tested} |
+
+**Recommendation for `unbranded-ds`:** Combine **Radix's keyboard table** (you can quote it directly from Radix's docs since your behavior is identical) with **Carbon's per-component WCAG conformance statement** and Carbon's testing-status matrix, plus **Primer's "Known issues" link** out to your GitHub issue tracker filtered by component label. This trio uniquely positions you as the most transparent shadcn-style design system available.
+
+##### How they document usage guidance vs. technical API
+
+- **Polaris and Carbon** are best at usage guidance: every component opens with a one-sentence definition, then "When to use" and "When not to use" sections with do/don't visuals.
+- **Material Design** uses a "Behavior" section to capture interaction semantics that aren't quite API.
+- **React Aria** intentionally separates usage prose from props — props live in their own auto-generated table at the bottom of the page, while usage is composed of named feature sections (Selection, Sections, Asynchronous loading, Validation, etc.).
+
+##### Designer vs. developer parity tactics
+
+- **Carbon's markdown templates are public and prescribe a Usage template, a Code template, and an Accessibility template separately**, so designers writing prose and engineers writing code own different files.
+- **Primer's Annotation Toolkit** is the strongest tool for bridging design and engineering — it turns accessibility considerations into a Figma library of stamps designers drop on their canvases.
+- **Atlassian** publishes a "Design component template" through Confluence (component basics → anatomy → states → content/accessibility/mobile guidance) — a useful checklist even if you don't use Confluence.
+- **Nord** keeps a public *accessibility checklist* alongside the system, frequently cited as one of the best.
+- **shadcn/ui** does effectively zero of this. That is the opportunity.
+
+##### Versioning / status / experimental / deprecated handling
+
+| System | Status taxonomy | How it's surfaced |
+|---|---|---|
+| Carbon | Draft, Preview candidate, Preview, Stable | Badge on component card; PDLC page documents semantics |
+| Workday Canvas | Main, Preview, Labs | Separate npm packages (`@workday/canvas-kit-react`, `@workday/canvas-kit-preview-react`, `@workday/canvas-kit-labs-react`) |
+| Atlassian | New, Beta, Early access, Caution, Deprecated | Inline tag on every component in the index |
+| Fluent UI | API Extractor release tags | `@public`/`@beta`/`@alpha`/`@internal` in TSDoc |
+| TSDoc spec | `@alpha`, `@beta`, `@public`, `@internal`, `@experimental`, `@deprecated` | TSDoc modifier tags; trimmable by API Extractor |
+
+**Recommendation:** Align your status taxonomy with TSDoc release tags (which API Extractor and TypeDoc both natively respect) and mirror Atlassian's pattern of rendering the status as a visible badge on the docs site. Concretely: `@alpha` → Atlassian's "early access" badge; `@beta` → Atlassian's "beta" badge; `@public` → no badge (stable); `@deprecated` → red banner with `@see` migration target.
+
+---
+
+### Part B — Concrete TSDoc Prose Templates for shadcn-style Components
+
+#### TSDoc spec recap (current, as of mid-2026)
+
+TSDoc, the Microsoft-owned standard descended from JSDoc, distinguishes three tag kinds:
+
+- **Block tags** — `@remarks`, `@param`, `@returns`, `@example`, `@defaultValue`, `@deprecated`, `@throws`, `@see`. Block tags always start their own line; their content extends until the next tag.
+- **Modifier tags** — `@public`, `@beta`, `@alpha`, `@experimental`, `@internal`, `@readonly`, `@sealed`, `@override`, `@virtual`. They are bare switches with no content.
+- **Inline tags** — `{@link}`, `{@inheritDoc}`, `{@label}`. They appear inline and are delimited by `{` and `}`.
+
+Block-tag ordering convention (from the TSDoc spec and the API Extractor reference): the **summary** (un-tagged text) comes first; then `@remarks` for extended description; then `@param`/`@returns`/`@throws` (only applicable to functions/methods, not React components, but still relevant for hooks); then `@example` (one per snippet); then `@see`; then modifier tags last. Release tags **inherit recursively from the container** — marking a class/interface `@public` means all members are public unless individually overridden.
+
+**TypeDoc-specific behavior to know:** TypeDoc honors `@example` as a heading-anchored fenced code block; it has a `jsDocCompatibility` option that lets `@example` and `@default` accept JSDoc-style content. TypeDoc resolves `{@link}` using TypeScript's symbol resolution by default. Multi-line `@example` blocks should always use fenced code (\`\`\`tsx).
+
+**API Extractor specifics:** Use `@packageDocumentation` exactly once per `index.ts` entry to describe the whole package. Use `@alpha`/`@beta` to allow API Extractor to trim experimental APIs out of your public `.d.ts` rollup at release.
+
+#### Recommended prose structure
+
+**Component-level TSDoc (placed immediately above the `forwardRef`/function declaration that is the public surface):**
+
+1. **One-line summary** (≤ 120 chars). Describes what the component is, in the same voice as Radix/React Aria ("A button triggers an event or action.").
+2. **`@remarks` extended description.** 2–6 sentences. Composition behavior, intended slot, polymorphism (`asChild`), and any non-obvious render semantics.
+3. **`### Accessibility` (using a Markdown heading inside the TSDoc).** ARIA pattern reference link, ARIA roles applied automatically, focus management behavior, screen reader name resolution.
+4. **`### Keyboard interactions`.** A Markdown table of `Key | Description`, copied/adapted from Radix's docs or the WAI-ARIA APG.
+5. **`### When to use`** and **`### When not to use`** (alternatives → use `{@link}` to point at sibling components).
+6. **`@example`** — one per common usage; the *first* `@example` should be the minimum viable usage; subsequent ones should layer in `asChild`, controlled state, and a11y-relevant variants (e.g., icon-only).
+7. **`@see`** for the Radix/React Aria/W3C APG link and any deeper design-doc URL.
+8. **Modifier tag** (`@public` / `@beta` / `@alpha`) on its own final line.
+
+**Prop-level TSDoc (placed above each property in `interface ComponentProps`):**
+
+1. **One-sentence description.** What the prop does, in the active voice.
+2. **(Optional) one-sentence behavior nuance.** Edge cases, controlled vs. uncontrolled, side effects on focus/ARIA.
+3. **`@defaultValue`** — the literal default, using backticks (e.g., `` `false` ``).
+4. **(Optional) accessibility implication** as a single sentence prefixed with "Accessibility:" so it's `Cmd+F`-discoverable in the rendered docs.
+5. **(Optional) `@example`** — only for props whose behavior is hard to grasp from the type alone.
+
+#### Worked example 1 — Button (simple)
+
+```tsx
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(/* … */);
+
+/**
+ * Props for the `Button` component.
+ *
+ * @public
+ */
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  /**
+   * Render as the immediate child element, merging the Button's props and
+   * behavior onto it (Radix `Slot` pattern).
+   *
+   * Use this to render a Button as an `<a>` (link) or a custom component
+   * while preserving Button's styling, focus handling, and `aria-disabled`
+   * semantics.
+   *
+   * Accessibility: when `asChild` is `true`, the child element MUST be a
+   * focusable, semantically appropriate element (e.g. `<a href>` for
+   * navigation). The component will not transform a non-focusable element
+   * into a focusable one.
+   *
+   * @defaultValue `false`
+   *
+   * @example
+   * ```tsx
+   * <Button asChild>
+   *   <a href="/docs">Read the docs</a>
+   * </Button>
+   * ```
+   */
+  asChild?: boolean;
+}
+
+/**
+ * A button triggers an event or action — for example, submitting a form,
+ * opening a dialog, or canceling an action.
+ *
+ * @remarks
+ * `Button` renders a native `<button>` element by default and inherits all
+ * of its accessibility primitives from the browser. Pass `asChild` to
+ * compose with other elements (e.g. a Next.js `<Link>`) without losing the
+ * button's visual treatment.
+ *
+ * `Button` is unstyled in the same sense that shadcn/ui is — the visual
+ * treatment is composed from Tailwind classes via `class-variance-authority`
+ * and can be overridden with `className` (merged via `cn()`).
+ *
+ * ### Accessibility
+ *
+ * - Implements the WAI-ARIA Button pattern; the rendered element is a
+ *   native `<button>` and therefore exposes the implicit `role="button"`
+ *   without explicit ARIA.
+ * - The accessible name is computed from the button's text content. For
+ *   icon-only buttons, supply an `aria-label`.
+ * - When `disabled`, the browser sets the implicit `aria-disabled` state
+ *   and removes the button from the focus order. If you need a button that
+ *   is visually disabled but remains focusable (e.g. for tooltips that
+ *   explain *why* it's disabled), use `aria-disabled` instead of `disabled`.
+ *
+ * ### Keyboard interactions
+ *
+ * | Key       | Description                                |
+ * | --------- | ------------------------------------------ |
+ * | `Space`   | Activates the button.                      |
+ * | `Enter`   | Activates the button.                      |
+ * | `Tab`     | Moves focus to the next focusable element. |
+ *
+ * ### When to use
+ *
+ * - Triggering an action (submit, save, delete, open dialog).
+ * - Initiating a process that *stays on the current page*.
+ *
+ * ### When not to use
+ *
+ * - Use {@link Link} (or `<a>`) for navigation that changes the URL.
+ * - Use {@link Toggle} for two-state on/off controls.
+ * - Use {@link IconButton} when the only content is an icon (it enforces
+ *   `aria-label`).
+ *
+ * @example
+ * Basic usage:
+ * ```tsx
+ * <Button onClick={() => save()}>Save changes</Button>
+ * ```
+ *
+ * @example
+ * As a link (preserves keyboard activation as Enter, not Space):
+ * ```tsx
+ * <Button asChild variant="link">
+ *   <a href="/settings">Settings</a>
+ * </Button>
+ * ```
+ *
+ * @example
+ * Icon-only (always pair with `aria-label`):
+ * ```tsx
+ * <Button size="icon" aria-label="Close">
+ *   <XIcon aria-hidden="true" />
+ * </Button>
+ * ```
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/button/ — WAI-ARIA Button pattern
+ * @see {@link IconButton}
+ * @public
+ */
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = "Button";
+```
+
+#### Worked example 2 — Dialog (composed, focus-trapping, a11y-rich)
+
+```tsx
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+
+/**
+ * A modal dialog that interrupts the user with important content and
+ * expects a response.
+ *
+ * @remarks
+ * `Dialog` is a compound component built on `@radix-ui/react-dialog`. Compose
+ * it from the exported parts: `Dialog`, `DialogTrigger`, `DialogContent`,
+ * `DialogHeader`, `DialogTitle`, `DialogDescription`, `DialogFooter`,
+ * `DialogClose`. The compound shape mirrors Radix's primitive so all Radix
+ * data attributes (`data-state="open|closed"`) are preserved for animations.
+ *
+ * Use {@link AlertDialog} instead when the dialog interrupts the user with
+ * a destructive or irreversible action — `AlertDialog` enforces an explicit
+ * Cancel control and uses `role="alertdialog"`.
+ *
+ * ### Accessibility
+ *
+ * - Applies `role="dialog"` and `aria-modal="true"` automatically on
+ *   `DialogContent`.
+ * - Labels itself via `aria-labelledby` pointing at `DialogTitle` and
+ *   `aria-describedby` pointing at `DialogDescription`. **`DialogTitle` is
+ *   required**; Radix will emit a development warning if it is missing.
+ *   Use the `VisuallyHidden` primitive to hide it visually when the dialog
+ *   is purely decorative.
+ *
+ * - **Focus management:** on open, focus is moved to the first focusable
+ *   element inside `DialogContent` (override with the `onOpenAutoFocus`
+ *   event on `DialogContent`). On close, focus is restored to the element
+ *   that opened the dialog. While open, focus is trapped inside the dialog
+ *   — `Tab` and `Shift+Tab` cycle within the dialog only.
+ *
+ * - **Inert background:** content outside the dialog is marked
+ *   `aria-hidden="true"` while the dialog is open, so screen readers do
+ *   not traverse it.
+ *
+ * ### Keyboard interactions
+ *
+ * | Key                | Description                                                |
+ * | ------------------ | ---------------------------------------------------------- |
+ * | `Space` / `Enter`  | When focus is on `DialogTrigger`, opens the dialog.        |
+ * | `Tab`              | Moves focus to the next focusable element inside dialog.   |
+ * | `Shift + Tab`      | Moves focus to the previous focusable element inside.      |
+ * | `Escape`           | Closes the dialog and returns focus to `DialogTrigger`.    |
+ *
+ * ### When to use
+ *
+ * - Asking the user to confirm a non-destructive action.
+ * - Requesting a small amount of focused input that blocks the underlying
+ *   flow (e.g., naming a new file).
+ *
+ * ### When not to use
+ *
+ * - For destructive or irreversible actions, use {@link AlertDialog}.
+ * - For non-blocking notifications, use {@link Toast}.
+ * - For passive information disclosure, use {@link Popover} or
+ *   {@link HoverCard}.
+ *
+ * @example
+ * Minimum viable dialog:
+ * ```tsx
+ * <Dialog>
+ *   <DialogTrigger asChild>
+ *     <Button>Open</Button>
+ *   </DialogTrigger>
+ *   <DialogContent>
+ *     <DialogTitle>Rename file</DialogTitle>
+ *     <DialogDescription>
+ *       Choose a new name for this document.
+ *     </DialogDescription>
+ *     <Input defaultValue="Untitled.txt" />
+ *     <DialogFooter>
+ *       <DialogClose asChild>
+ *         <Button variant="ghost">Cancel</Button>
+ *       </DialogClose>
+ *       <Button onClick={save}>Save</Button>
+ *     </DialogFooter>
+ *   </DialogContent>
+ * </Dialog>
+ * ```
+ *
+ * @example
+ * Controlled open state:
+ * ```tsx
+ * const [open, setOpen] = React.useState(false);
+ * <Dialog open={open} onOpenChange={setOpen}>{/* … *\/}</Dialog>
+ * ```
+ *
+ * @example
+ * Decorative dialog with a visually-hidden title (still required by AT):
+ * ```tsx
+ * <DialogContent>
+ *   <VisuallyHidden asChild>
+ *     <DialogTitle>Image preview</DialogTitle>
+ *   </VisuallyHidden>
+ *   <img src="/preview.png" alt="" />
+ * </DialogContent>
+ * ```
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
+ * @see https://www.radix-ui.com/primitives/docs/components/dialog
+ * @see {@link AlertDialog}
+ * @public
+ */
+export const Dialog = DialogPrimitive.Root;
+
+/**
+ * The visible label of a {@link Dialog}.
+ *
+ * @remarks
+ * `DialogTitle` is **required**. It is referenced by `aria-labelledby` on
+ * the dialog content and provides the dialog's accessible name. Wrap in
+ * {@link VisuallyHidden} if you need to hide it visually.
+ *
+ * Accessibility: rendered as an `<h2>` by default; pass `asChild` to
+ * change the underlying heading level if the dialog appears inside a
+ * deeper section hierarchy.
+ *
+ * @public
+ */
+export const DialogTitle = DialogPrimitive.Title;
+```
+
+#### Worked example 3 — Combobox (complex, keyboard-heavy)
+
+```tsx
+/**
+ * Props for the `Combobox` component.
+ *
+ * @public
+ */
+export interface ComboboxProps<TValue> {
+  /**
+   * The list of selectable options.
+   *
+   * Accessibility: each option's `label` is used as the option's accessible
+   * name. Provide a non-empty, human-readable label even for icon-led options.
+   */
+  options: ReadonlyArray<ComboboxOption<TValue>>;
+
+  /**
+   * The currently selected value (controlled).
+   *
+   * Leave undefined to use uncontrolled state; in that case the component
+   * tracks its own selection internally and notifies via `onValueChange`.
+   *
+   * @defaultValue `undefined`
+   */
+  value?: TValue;
+
+  /**
+   * Called whenever the selected value changes, including via keyboard
+   * (Enter on a highlighted option), pointer (click), or via the
+   * type-ahead match-on-Enter behavior.
+   *
+   * @defaultValue `undefined`
+   */
+  onValueChange?: (value: TValue) => void;
+
+  /**
+   * Whether the combobox accepts custom (non-list) values typed by the user.
+   *
+   * Accessibility: when `true`, the combobox uses `aria-autocomplete="list"`
+   * and the listbox is treated as a suggestion list rather than the
+   * authoritative source of valid values. When `false`, the combobox uses
+   * `aria-autocomplete="list"` but rejects values that don't match an option.
+   *
+   * @defaultValue `false`
+   */
+  allowsCustomValue?: boolean;
+
+  /**
+   * Custom filter function. Receives the current input value and the
+   * option's label, and returns `true` to include the option.
+   *
+   * @defaultValue case-insensitive `startsWith` match
+   */
+  filter?: (inputValue: string, optionLabel: string) => boolean;
+}
+
+/**
+ * A combobox combines a text input with a popover listbox, letting users
+ * filter a list of options and select one.
+ *
+ * @remarks
+ * `Combobox` follows the WAI-ARIA 1.2 combobox pattern with `aria-haspopup
+ * ="listbox"`. It is built on `@radix-ui/react-popover` for positioning and
+ * implements its own listbox / keyboard navigation in order to match the
+ * APG keyboard contract precisely (Radix does not ship a combobox primitive
+ * at the time of writing).
+ *
+ * Use {@link Select} when the set of options is small and known up-front
+ * and the user does not need to type to filter — `Select` uses the simpler
+ * `listbox` pattern and is easier for screen reader users.
+ *
+ * ### Accessibility
+ *
+ * - The text input has `role="combobox"`, `aria-expanded`,
+ *   `aria-controls` pointing at the listbox `id`, and `aria-autocomplete
+ *   ="list"`.
+ * - The popover content has `role="listbox"` and is labeled via
+ *   `aria-labelledby` pointing at the visible field label (or
+ *   `aria-label` when no visible label is provided).
+ * - Each option has `role="option"` and `aria-selected` reflecting the
+ *   selection state. The highlighted (not yet selected) option is
+ *   communicated via `aria-activedescendant` on the combobox input, so
+ *   DOM focus stays on the input throughout — this is the WAI-ARIA APG
+ *   recommended pattern.
+ * - When the listbox is empty (no options match the current filter), an
+ *   ARIA live region announces "No results."
+ *
+ * ### Keyboard interactions
+ *
+ * | Key                       | Description                                                       |
+ * | ------------------------- | ----------------------------------------------------------------- |
+ * | `ArrowDown`               | If closed, opens the listbox and highlights the first option. If open, moves highlight to the next option. |
+ * | `ArrowUp`                 | If closed, opens the listbox and highlights the last option. If open, moves highlight to the previous option. |
+ * | `Home`                    | Moves highlight to the first option.                              |
+ * | `End`                     | Moves highlight to the last option.                               |
+ * | `Enter`                   | Selects the highlighted option and closes the listbox.            |
+ * | `Escape`                  | Closes the listbox without selecting; clears input if `allowsCustomValue` is `false`. |
+ * | `Tab` / `Shift + Tab`     | Selects the highlighted option (if any), closes the listbox, and moves focus. |
+ * | Printable characters      | Filter the option list; the listbox opens automatically.          |
+ *
+ * ### When to use
+ *
+ * - The user needs to select one value from a large or unknown list
+ *   (countries, users, GitHub repos).
+ *
+ * ### When not to use
+ *
+ * - For a small, fixed list, use {@link Select}.
+ * - For free-form multi-select tags, use {@link TagInput}.
+ *
+ * @example
+ * Uncontrolled combobox over a known list:
+ * ```tsx
+ * <Combobox
+ *   options={[
+ *     { value: "us", label: "United States" },
+ *     { value: "ca", label: "Canada" },
+ *     { value: "mx", label: "Mexico" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @example
+ * Controlled, allowing custom user-entered values:
+ * ```tsx
+ * const [value, setValue] = React.useState<string | undefined>();
+ * <Combobox
+ *   value={value}
+ *   onValueChange={setValue}
+ *   allowsCustomValue
+ *   options={fruits}
+ * />
+ * ```
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
+ * @see {@link Select}
+ * @public
+ */
+export function Combobox<TValue>(props: ComboboxProps<TValue>): JSX.Element {
+  /* … */
+}
+```
+
+#### Worked example 4 — Checkbox (form primitive)
+
+```tsx
+/**
+ * Props for the `Checkbox` component.
+ *
+ * @public
+ */
+export interface CheckboxProps {
+  /**
+   * The controlled checked state. Use `"indeterminate"` for the
+   * "partially checked" tri-state (e.g., a parent checkbox whose children
+   * are mixed).
+   *
+   * Accessibility: `"indeterminate"` is exposed as `aria-checked="mixed"`,
+   * which screen readers announce as "mixed". The visual rendering uses
+   * a horizontal line glyph by default.
+   *
+   * @defaultValue `false` (uncontrolled defaults to `defaultChecked` or `false`)
+   */
+  checked?: boolean | "indeterminate";
+
+  /**
+   * Called when the checked state changes via user interaction.
+   *
+   * The callback receives the new state, including `"indeterminate"` →
+   * `true` transitions. Indeterminate is not reachable via user input;
+   * it must be set programmatically.
+   */
+  onCheckedChange?: (checked: boolean | "indeterminate") => void;
+
+  /**
+   * Whether the checkbox is required for form submission.
+   *
+   * Accessibility: when `true`, the underlying input receives
+   * `aria-required="true"`. Pair with a visible required indicator
+   * (e.g., an asterisk in the label) and a descriptive error message
+   * via {@link FormMessage}.
+   *
+   * @defaultValue `false`
+   */
+  required?: boolean;
+}
+
+/**
+ * A checkbox allows users to select one or more options from a set, or to
+ * toggle a single binary option.
+ *
+ * @remarks
+ * Built on `@radix-ui/react-checkbox`. The visible "check" glyph is
+ * rendered by a child `Checkbox.Indicator`; the rendered DOM is a native
+ * `<button role="checkbox">` so that all native browser focus rings and
+ * form-association behavior apply.
+ *
+ * For a single yes/no setting that takes immediate effect (e.g., toggling
+ * a feature), prefer {@link Switch} — it communicates "on/off" rather
+ * than "checked/unchecked" and is more discoverable for screen reader users
+ * in settings contexts.
+ *
+ * ### Accessibility
+ *
+ * - Implements the WAI-ARIA checkbox pattern with `role="checkbox"` and
+ *   `aria-checked` reflecting `true | false | "mixed"`.
+ * - The accessible name comes from the associated `<label>` element. Use
+ *   {@link Label} and pass `htmlFor` matching the checkbox's `id`, or
+ *   wrap the checkbox inside the label.
+ * - When `disabled`, the component is removed from the focus order.
+ *
+ * ### Keyboard interactions
+ *
+ * | Key      | Description                                                  |
+ * | -------- | ------------------------------------------------------------ |
+ * | `Space`  | Toggles the checkbox between checked and unchecked. From the indeterminate state, transitions to `checked`. |
+ * | `Tab`    | Moves focus to the next focusable element.                   |
+ *
+ * @example
+ * ```tsx
+ * <div className="flex items-center gap-2">
+ *   <Checkbox id="terms" />
+ *   <Label htmlFor="terms">Accept terms and conditions</Label>
+ * </div>
+ * ```
+ *
+ * @example
+ * Controlled with indeterminate state (parent of a group):
+ * ```tsx
+ * <Checkbox
+ *   checked={allSelected ? true : someSelected ? "indeterminate" : false}
+ *   onCheckedChange={(c) => setAll(c === true)}
+ * />
+ * ```
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/
+ * @see {@link Switch}
+ * @see {@link RadioGroup}
+ * @public
+ */
+export const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  CheckboxProps & React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(/* … */);
+```
+
+#### Documenting components that don't exist yet ("stubs")
+
+This is a real and useful workflow because in your repo the registry, the docs site, and the consuming product can all be built ahead of implementation. The pattern:
+
+**Step 1 — Create the file with a typed empty implementation:**
+
+```tsx
+// packages/ui/src/data-table/data-table.tsx
+import * as React from "react";
+
+/**
+ * Props for the `DataTable` component.
+ *
+ * @alpha
+ */
+export interface DataTableProps<TRow> {
+  /** Rows to render. */
+  rows: ReadonlyArray<TRow>;
+  /** Column definitions. */
+  columns: ReadonlyArray<DataTableColumn<TRow>>;
+}
+
+/**
+ * A data grid with column sorting, multi-row selection, and keyboard
+ * navigation.
+ *
+ * @remarks
+ * **Status: planned / not yet implemented.** This module exports a typed
+ * stub that throws at runtime. The TSDoc here is the authoritative design
+ * spec until implementation lands — feedback is welcome via GitHub issues
+ * before the API is frozen at `@beta`.
+ *
+ * ### Accessibility (planned)
+ *
+ * - Will implement the WAI-ARIA grid pattern (`role="grid"`,
+ *   `aria-rowcount`, `aria-colcount`, roving `tabindex` for cell focus).
+ * - Will support arrow-key navigation between cells and `Home/End/PageUp
+ *   /PageDown` for jump navigation.
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/grid/
+ * @alpha
+ */
+export function DataTable<TRow>(_props: DataTableProps<TRow>): JSX.Element {
+  throw new Error(
+    "DataTable is not yet implemented. Track progress at " +
+      "https://github.com/your-org/unbranded-ds/issues/42",
+  );
+}
+```
+
+**Step 2 — Conventions for stable docs while implementation evolves:**
+
+- Mark with **`@alpha`** while shape may change. Graduate to **`@beta`** once API is frozen but implementation is unstable. Graduate to **`@public`** when stable. (API Extractor will trim `@alpha` items out of your public `.d.ts` rollup automatically — this is the same lever Workday Canvas Kit pulls with separate `@workday/canvas-kit-labs-react` packages, but at the symbol level instead of the package level.)
+- Keep the prose stable: the TSDoc is the spec. Implementation changes should rarely require prose changes; if they do, the design contract has moved and that needs a SemVer minor/major.
+- Add `**Status: planned / not yet implemented.**` as the first sentence of `@remarks` for `@alpha` symbols so an IDE tooltip flags it immediately.
+- Wire your docs site renderer to badge `@alpha`/`@beta` symbols visibly (Atlassian's pattern). Wire your registry / CLI to refuse `--no-include-alpha` flag (your own convention).
+
+#### Bridging designer and developer audiences
+
+TSDoc primarily serves devs in the IDE. To reach designers and PMs you need a complementary MDX/Storybook surface — but the goal is **one source of truth, multiple presentations**.
+
+**Architecture for `unbranded-ds`:**
+
+```
+packages/
+  ui/                              # the components
+    src/
+      button/
+        button.tsx                 # AUTHORITATIVE prose lives in TSDoc here
+        button.stories.tsx         # Storybook: variants, states, do/don't
+        button.mdx                 # docs-site MDX: anatomy diagram + design tokens + imports prose from button.tsx
+  docs/                            # Next.js or Astro docs site
+    components/[slug]/page.tsx     # renders the MDX, props table from TypeDoc JSON, and Storybook iframe
+```
+
+**Concrete recommendations, mirroring how the best-in-class systems do it:**
+
+1. **Generate the props table from your TSDoc, don't hand-write it.** Use `react-docgen` (the engine Storybook and Styleguidist already use) or `@microsoft/api-extractor` + `api-documenter`. Storybook will render the prop table from the TSDoc-derived metadata automatically. Carbon and Fluent UI both do this in production via API Extractor; Atlassian uses `react-docgen-typescript`.
+
+2. **Author the page in MDX with a fixed template** modeled on Carbon's four-tab template:
+   - `## Overview` — pulls the component's TSDoc summary via `{@inheritDoc Button}` (or a build step that injects it).
+   - `## Anatomy` — a Figma frame or SVG with numbered callouts (Primer's pattern; Atlassian's design-component template).
+   - `## Usage` — when-to-use, when-not-to-use, do/don't (Polaris and Carbon are the references).
+   - `## API` — auto-rendered from TSDoc.
+   - `## Accessibility` — the **only** place where you re-author prose that's also in TSDoc; this prose can be the designer-flavored long form (whereas the TSDoc is the developer-flavored short form). Carbon does this split explicitly.
+   - `## Examples` — Storybook iframes.
+
+3. **Hand designers a Figma "Annotation Toolkit."** Per the official `github/annotation-toolkit` README: "The GitHub Annotation Toolkit is a fork of the CVS Health Inclusive Design team's Web Accessibility Annotation Kit (CC-BY 4.0)… This project is licensed under the terms of the CC-BY 4.0 license." It was open-sourced on September 22, 2025 (GitHub Changelog) and provides ready-made annotation stamps for landmarks, headings, focus order, live regions, and per-component a11y presets. Either fork it for `unbranded-ds` brand-neutrality or document how designers can use it as-is with your components — this single move closes the design-handoff gap better than any other practice in the industry. (Carbon, Polaris, and Atlassian all *talk about* accessibility annotations but no one else ships a free tool of this quality.)
+
+4. **Surface "known a11y issues" per component.** Adopt Primer's pattern: in each MDX page, render a link to GitHub issues filtered to `label:a11y label:component/<name>`. Combined with a per-major-release ACR (USWDS's pattern), this is the highest transparency posture in the industry.
+
+5. **Mirror the lifecycle status everywhere.** Whatever release tag is on the TSDoc (`@alpha`/`@beta`/`@public`/`@deprecated`) should appear (a) in the component card on the docs index (Atlassian's pattern), (b) as a badge on the component page (Carbon's pattern), and (c) in the CLI output when a user runs `npx unbranded-ds add <component>`.
+
+---
+
+## Recommendations
+
+### Stage 1 — Foundations (week 1)
+- Adopt the **6-section component-level TSDoc template** above and the **3-section prop-level TSDoc template**. Commit the templates as `.github/COMPONENT_TSDOC_TEMPLATE.md` and `.github/PROP_TSDOC_TEMPLATE.md`.
+- Configure **TypeDoc** in the monorepo with `jsDocCompatibility.exampleTag: true` to allow your `@example` fenced blocks to render as code.
+- Decide on release-tag semantics: `@alpha` = API may change, `@beta` = API frozen / impl unstable, `@public` = SemVer-stable, `@deprecated` = remove in next major.
+
+### Stage 2 — Write docs ahead of code (weeks 1-4)
+- For every component you plan to ship — *including* not-yet-implemented ones — create the file with the typed `interface` + a throwing stub function + full TSDoc + `@alpha` tag. This forces design decisions early and gives you a complete docs site before implementation.
+- For each component, copy the relevant **Radix keyboard interactions table verbatim** into the TSDoc. (Radix's docs license allows this; your behavior is identical.)
+- Link every Accessibility section to the relevant **W3C WAI-ARIA APG pattern** as a `@see`.
+
+### Stage 3 — Docs site (weeks 2-6)
+- Stand up an MDX docs site using Next.js or Astro with a fixed 6-section component-page template (Overview / Anatomy / Usage / API / Accessibility / Examples).
+- Auto-generate prop tables from your TSDoc via `react-docgen-typescript` or API Extractor.
+- Embed Storybook iframes for live examples.
+
+### Stage 4 — Accessibility differentiator (weeks 6-12)
+- Publish a **per-component accessibility status matrix** modeled on Carbon's (`carbondesignsystem.com/components/overview/accessibility-status/`): rows = components, columns = {Default state, Advanced states, Keyboard navigation, Screen reader}, statuses = {Tested, Manually tested, Not tested}.
+- Adopt or fork the **GitHub Annotation Toolkit** for Figma (CC-BY-4.0) and link it from your docs.
+- Set up the issue label scheme `a11y` + `component/<name>` and render the "Known a11y issues" link on every component page (Primer's pattern).
+- For your first major release, consider publishing a **VPAT 2.5 ACR** modeled on USWDS's — they assessed 44 components of USWDS 3.11.0 in March 2025 and published the report in May 2025.
+
+### Decision benchmarks (when to change course)
+- If maintaining hand-written keyboard tables in TSDoc is more than 10% of doc churn → switch to `{@inheritDoc}` from a shared `keyboard-tables.ts` data file.
+- If your props tables drift from your interfaces → stop hand-writing them; mandate `react-docgen` / API Extractor generation.
+- If consumers ignore status tags → make `npx unbranded-ds add <component>` refuse to install `@alpha` components without `--include-alpha`.
+
+---
+
+## Caveats
+
+- **Several "best practice" claims about competing systems are based on docs that change frequently.** I observed React Aria's pages directly: contrary to a widespread assumption, React Aria does **not** use a per-component `Key | Description` keyboard table — it uses a bulleted "Features" list and links once to the WAI-ARIA APG. The keyboard tables you may have seen actually live on the APG itself and in **Radix's docs** (where they're explicit and tabular). Use Radix as your tabular keyboard reference.
+- **Carbon renamed its "experimental" status to "Preview"** to raise the bar for production-readiness. Don't reuse the word "experimental" in your status taxonomy without weighing this — Carbon's PDLC page explicitly says preview is "available to use in production" but "not stable yet."
+- **The shadcn registry CLI strips non-declaration-attached comments on install.** Per GitHub issue #9206 (shadcn-ui/ui), titled *"[bug]: Registry install strips leading comments and JSDoc blocks not attached to declarations,"* CLI version 2.10.0+ has this behavior; the root cause is that ts-morph treats comments as "trivia" attached to nodes, and the CLI's `transform-import.ts` and `transform-rsc.ts` neither explicitly preserves leading trivia. Verbatim from the issue: *"Only JSDoc comments that are directly attached to a declaration (const, function, type) are preserved."* Test that your TSDoc blocks survive the install path; **always attach blocks directly to the declaration (`forwardRef`, `interface`, `type`) rather than floating them between imports**.
+- **TypeDoc and TSDoc disagree about `@example`**: TSDoc treats the first line as a heading title; TypeDoc by default treats the whole tag content as a code block. Configure `jsDocCompatibility.exampleTag` deliberately and pick one convention across the repo.
+- **USWDS's, GOV.UK's, and Carbon's a11y transparency are exceptional but expensive to maintain.** Don't promise an ACR/VPAT unless you have a sustained tester budget. The Primer "known issues link" model is the cheapest meaningful transparency posture and is the recommended starting point.
+- **Designer-facing docs require *someone* to write them.** TSDoc is a developer artifact. The recommended MDX/Storybook layer above is necessary but adds an authoring surface; budget for it explicitly or accept that `unbranded-ds` will be a developer-only system in practice, like Radix and React Aria.

--- a/docs/workshops/2026-05-18/post-008-pickup-notes.md
+++ b/docs/workshops/2026-05-18/post-008-pickup-notes.md
@@ -1,0 +1,131 @@
+# Post-008 pickup notes
+
+Cold-start context for picking up specs 010, 011, and 012 after spec 005 (constitution amendment + agent-experience foundation) and spec 008 (token schema growth) have shipped. Written 2026-05-15 with full session context. Assume by the time you read this, the original session is gone.
+
+---
+
+## First thing to do when you sit back down
+
+The workshop output lives in `/tmp` right now, which evaporates on reboot. Before doing anything else:
+
+```bash
+mkdir -p docs/workshops/2026-05-15
+mv /tmp/agent-first-workshop.md docs/workshops/2026-05-15/
+mv /tmp/feedback-triage.md docs/workshops/2026-05-15/
+mv /tmp/constitution-amendment-section-xi.md docs/workshops/2026-05-15/
+mv /tmp/working-memory-kit-evaluation.md docs/workshops/2026-05-15/
+mv /tmp/spec-*.md docs/workshops/2026-05-15/
+mv /tmp/post-008-pickup-notes.md docs/workshops/2026-05-15/
+git add docs/workshops/2026-05-15/
+git commit -m "docs: capture 2026-05-15 workshop output"
+```
+
+If the move already happened, the docs live wherever you moved them — adjust the references in this file accordingly.
+
+---
+
+## State check: what 005 should have produced
+
+Before starting 010 or 011, verify that 005 actually landed all of these. If anything is missing, that's what 010 is for.
+
+- [.specify/memory/constitution.md](.specify/memory/constitution.md) at version 1.1.0 with Section XI present
+- [.specify/templates/plan-template.md](.specify/templates/plan-template.md) has a Section XI checkbox in its Constitution Check gate
+- An `AGENTS.md` exists at the repo root, peer to `README.md`
+- Every component under `packages/react/src/components/` has a `<Component>.usage.md` sidecar (13 components total: the original 9 plus the 4 from spec 004)
+- A template at `packages/react/src/components/_template/Component.usage.md` exists
+- Every component's autodocs prose has been audited (humanizer pass, no three-item lists)
+- The token-query MCP decision is recorded — either "required before 1.0" with a spec stub, or "planned for 1.0" with no commitment
+
+If any of those are missing or weak, 010 is where you fix them.
+
+---
+
+## Spec 010 — Constitution-driven retrofit
+
+There is no brief for this one because what 010 contains depends entirely on what 005 surfaces. Probably trivial. Possibly absorbed into 005's tasks list and never needed.
+
+### How to know what to put in 010
+
+When you come back, check three sources:
+
+- The 005 spec's tasks list — any tasks marked "moved to 010" or "out of scope, retrofit later"
+- GitHub issues filed against the 0.2.0 or 0.3.0 release with the "constitution" or "section-xi" label
+- A diff between the existing nine components' autodocs before and after 005's audit. Anything that got rewritten in 005 may have parallel patterns in the four new primitives that didn't get caught.
+
+### Likely candidates for retrofit
+
+- **Slot name harmonization.** Section XI says `*.Trigger`, `*.Content`, `*.Item`, `*.Root` must mean the same thing across components. The existing nine were written before this rule. Spec 005 audits them but may not refactor breaking ones. 010 might land breaking slot-rename changes paired with a minor bump.
+- **Prop name harmonization.** Variant axes should be `variant`, `size`, `intent`, `disabled` — no bespoke synonyms. Same situation: 005 surfaces, 010 fixes.
+- **Polymorphic prop unification.** If different components use different prop names (`as` vs `polymorphic` vs `render`), pick one and rename the others. Likely a breaking change.
+- **Structured failure output.** Any component or validator currently throwing or warning with prose only — refactor to a structured payload.
+- **`AGENTS.md` content gaps.** If the agent quickstart, MCP tool inventory, or sidecar index in `AGENTS.md` has holes, fill them.
+- **Motion token swap.** Primitive components (especially Tooltip from spec 004) use Tailwind's built-in duration utilities for their open/close transitions because the DS motion tokens did not exist when 004 shipped. Now that spec 008 has introduced the motion token category, swap the primitive transitions to use the DS tokens (`duration-base`, `easing-standard`, etc.) so the design system controls the timing surface.
+
+### When 010 is empty
+
+It's a real possibility. If 005 was thorough, 010 has nothing in it. Don't fabricate work — skip 010 and move to 011.
+
+---
+
+## Spec 011 — ThemeToggle
+
+The brief lives at `docs/workshops/2026-05-15/spec-011-theme-toggle.md` (or `/tmp/spec-011-theme-toggle.md` if you haven't moved it yet). Three things in that brief are easy to misread cold:
+
+### Why the for-coleman component was modified
+
+The original for-coleman proposal was a single `<ThemeToggle>` component that baked in three opinions: the localStorage key, the use of `document.documentElement`, and a specific three-state UX. For an "unbranded" DS, that's a lot of opinion to ship as one component.
+
+The workshop decision: split into a `useTheme()` hook (owns the persistence and listener logic) plus a thin `<ThemeToggle>` component (twenty lines, composes the hook with `<SegmentedControl>`). Consumers wanting a different UX (a switch, a button cycle, a dropdown) compose their own using `useTheme()` directly.
+
+The hook is the load-bearing primitive; the component is a default convenience.
+
+### The localStorage key is `unbranded-ds-theme`
+
+This is in memory (see `~/.claude/projects/-Users-k-arnett-repos-unbranded-ds/memory/project_ds_theme_localstorage_key.md`). The key is shared between `themeBootstrapScript` (shipped in spec 002) and `useTheme` (ships in spec 011). They must not drift. If they drift, consumers get FOUC even with correct wiring.
+
+If you're about to type `theme` or `theme-preference` or anything else, stop. Use `unbranded-ds-theme`. Ideally export the constant from `@unbranded-ds/tokens/runtime` so neither package can drift from the other.
+
+### Why the hook returns an object, not a tuple
+
+Section XI of the constitution (ratified in spec 005) says failure modes and APIs are structured for agent legibility. A tuple `[theme, setTheme]` reads fine to humans but is harder for an agent introspecting the return shape than `{ theme, preference, setPreference }`. Named fields are pattern-matchable.
+
+This is a subtle Section XI compliance point that's easy to miss when reaching for the React idiom.
+
+### SegmentedControl dependency
+
+`<ThemeToggle>` composes on top of `<SegmentedControl>` (ships in spec 004). If for some reason 004 didn't ship SegmentedControl as planned, that's an 011 blocker — not something to work around in 011.
+
+---
+
+## Spec 012 — Next.js 15 example app
+
+The brief at `docs/workshops/2026-05-15/spec-012-example-app.md` is fairly complete. Two reminders that might fade:
+
+### The example is a starter, not a tutorial
+
+This came up in the workshop. The example demonstrates the canonical wiring and the primitive set. It does not teach Tailwind, React, or Next.js. The README should make this clear so consumers don't expect step-by-step instruction.
+
+### The custom font override demonstrates the consumer-overrides pattern from spec 002
+
+Spec 002 explicitly preserves the consumer-overrides design — `@theme inline` is registration-only, values live in separate files, consumers add their own `:root { --color-* }` declarations. The example app's use of `next/font/local` plus a `:root { --typography-font-sans: ... }` override is the canonical demonstration of this pattern. If you're tempted to simplify the example by skipping the override, don't — that override is the whole point of the example being more than a hello-world.
+
+---
+
+## Things that are easy to forget if you cold-start
+
+- **`unbranded-ds-theme`** is the localStorage key. Not `theme`, not `color-mode`, not `preferred-theme`. See memory.
+- **The constitution amendment draft** is at `docs/workshops/2026-05-15/constitution-amendment-section-xi.md`. If 005 didn't ratify it cleanly, that's where to look.
+- **Three-item lists are still forbidden** after the constitution ratifies. Check your own prose, including this doc if you edit it.
+- **The for-coleman feedback** lives at [TODO.md](TODO.md). All six spec briefs pull the relevant context inline, so you shouldn't need TODO.md, but it's there if you do.
+- **The auto-memory** at `~/.claude/projects/-Users-k-arnett-repos-unbranded-ds/memory/` contains: agent-first differentiator, prose rules, commit granularity, test quality, tests-required, and the unbranded-ds-theme key. New sessions read it automatically.
+
+---
+
+## When you're done with 012
+
+The for-coleman feedback is fully addressed. The release that includes 012 is the moment to consider:
+
+- Reaching out to for-coleman with a "here's what we shipped" note
+- Closing the loop on [TODO.md](TODO.md) — either delete it or move it to `docs/workshops/2026-05-15/` and rename to `for-coleman-feedback.md` for historical record
+- Evaluating [working-memory-kit](https://github.com/kendrick/working-memory-kit) per the notes at `docs/workshops/2026-05-15/working-memory-kit-evaluation.md`
+- Deciding whether to start the next set of specs (display sizes, more primitives, the token-query MCP if it was deferred)

--- a/docs/workshops/2026-05-18/spec-007-autodoc-audit.md
+++ b/docs/workshops/2026-05-18/spec-007-autodoc-audit.md
@@ -1,0 +1,86 @@
+# Spec 007 — Autodoc legibility audit
+
+**Target version:** next patch bump after spec 006 (prose-only edits to existing stories and TSDoc; no behavior or API changes)
+**Depends on:** 005 (Section XI ratified; the humanizer-pass rule is now binding)
+**Blocks:** 010 (the API retrofit may surface from this audit; spec 010 lands the actual refactors)
+**Bundles for-coleman items:** none — this is purely an internal quality pass surfaced during spec 005
+
+---
+
+## Motivation
+
+Section XI.1 says every piece of written content passes through the humanizer skill before merge. The 14 currently shipped components were authored before XI.1 was ratified. Their stories and TSDoc comments contain prose that doesn't meet the rule: three-item lists, em-dash overuse, "serves as" phrasing, promotional vocabulary, hedging, signposting. Some prop descriptions explain WHAT a prop does without explaining WHEN a consumer would reach for it (per FR-019 from spec 005).
+
+This spec is a focused, in-place pass on the four prose surfaces that surface in Storybook autodocs and the MCP. Git history is the audit ledger; no parallel audit-log doc.
+
+---
+
+## Scope
+
+### Four prose surfaces per component
+
+Per FR-021a from spec 005:
+
+1. The component-level `description` in `stories.tsx` meta
+2. Every prop's `argTypes.description` in `stories.tsx`
+3. Every named story's `parameters.docs.description.story`
+4. Every TSDoc comment block in the component's `.tsx` source
+
+FR-030 (revised during spec 005's clarify) explicitly permits prose edits to `.tsx` files since they don't change behavior or public API. The constraint that does apply: this spec MUST NOT change component behavior or API. API-shape issues that the audit surfaces (e.g., a prop name that violates Section XI.2's shared vocabulary) get deferred to spec 010.
+
+### The 14 components
+
+Same set as spec 006:
+
+- Button, Card, Checkbox, Dialog, Input, Label, Select, Switch, Tabs (0.1.0)
+- VisuallyHidden (0.2.0)
+- Tooltip, SkipLink, Slider, SegmentedControl (0.3.0)
+
+### What the audit fixes
+
+For every prose surface:
+
+- Three-item prose enumerations restructured to two, four, or a sentence
+- Em-dash overuse replaced with commas, periods, or parentheses
+- Promotional vocabulary ("powerful", "seamless", "groundbreaking") removed
+- Hedging and signposting ("In order to", "It's important to note that") trimmed
+- Copula avoidance ("serves as", "stands as") replaced with `is`/`are`/`has`
+- Prop descriptions that only say WHAT updated to also say WHEN — the consumer scenario that warrants reaching for the prop
+
+### PR organization
+
+Up to the implementer. The spec doesn't mandate one-PR-per-component. A single bulk PR works because the audit is mechanical and each change is small. Multiple PRs (one per component, or grouped by category like "primitives" vs "compound") also work.
+
+If multiple PRs, each carries a `.changeset/audit-<scope>.md` declaring `@unbranded-ds/react: patch`.
+
+## Out of scope
+
+- Component API renames (e.g., a prop named `tone` should be `intent` per Section XI.2's shared vocabulary). Defers to spec 010.
+- Component behavior changes. Same — defers to spec 010.
+- Sidecars themselves. Those are spec 006. The autodoc audit and the sidecar retrofit are independent passes — no merge conflict between them since they touch different files.
+- New components, new variants, new tests beyond regression. Strictly a prose pass.
+
+## Acceptance criteria
+
+- Every component's component-level `description` in stories.tsx identifies the consumer scenario the component addresses.
+- Every prop's `argTypes.description` explains both WHAT the prop does AND WHEN a consumer would reach for it (per FR-019).
+- Every named story's `parameters.docs.description.story` passes humanizer review.
+- Every TSDoc comment block in the 14 component `.tsx` source files passes humanizer review.
+- No three-item prose lists remain in any of the audited surfaces. (Variant enums with three options like `size: 'sm' | 'md' | 'lg'` are code lists and are exempt.)
+- The audit does not change behavior or public API. Component tests still pass. Storybook stories still render.
+
+## Constitution check
+
+Section XI is ratified at this point (spec 005, constitution 1.1.0). The relevant rules:
+
+- XI.1 — prose rules: the entire spec is one big application of these
+- XI.5 — story coverage as dual-audience contract: this spec sharpens the existing surface; doesn't add or remove behavior, so the contract stays intact
+
+Section IX bullet 6 (SSR safety) applies: the audit may edit `.tsx` source for TSDoc only. Behavior or rendering changes that compromise SSR are out of scope.
+
+## References
+
+- [specs/005-agent-experience-foundation/spec.md](specs/005-agent-experience-foundation/spec.md) — US3 acceptance scenarios; FR-018 through FR-021a; the revised FR-030 that permits TSDoc edits
+- [specs/005-agent-experience-foundation/tasks.md](specs/005-agent-experience-foundation/tasks.md) — T025 through T038 carry the canonical per-component audit task detail
+- `humanizer` skill — the canonical reference for which AI tells get caught
+- [.specify/memory/constitution.md](.specify/memory/constitution.md) Section XI.1 — the rule being enforced

--- a/docs/workshops/2026-05-18/spec-008-token-schema-growth.md
+++ b/docs/workshops/2026-05-18/spec-008-token-schema-growth.md
@@ -1,0 +1,141 @@
+# Spec 008 — Token schema growth
+
+**Target version:** next minor bump after spec 005 (introduces required token additions, which is a breaking change to consumer themes)
+**Depends on:** 003 (versioning workflow handles the multi-package bump and the breaking-change changelog entry cleanly)
+**Blocks:** 010 (retrofit swaps primitive transitions to the DS motion tokens this spec introduces)
+**Bundles for-coleman items:** B.1, B.2, B.3, C.2
+**Also addresses:** the theme-override scope gap surfaced during spec 005's `/speckit.implement` (themes currently carry only `color`; Constitution Section III's "values float at runtime" applies to every category)
+**Splits with:** spec 012 (`tmp/spec-012-theming-system-expansion.md`) — that spec picks up theme composition (multi-axis) and first-class theme-extension tokens, which need their own clarify cycle for the API design decisions involved. This spec stays narrowly: schema additions plus the small structural fix that lets themes override any category.
+
+---
+
+## Motivation
+
+The for-coleman team needed a serif font, motion tokens for animation, and display-sized type — none of which the `@unbranded-ds/tokens@0.1.0` schema includes. They ended up adding the values themselves and treating the "extra tokens beyond the schema are allowed" line in THEMING.md as permission. That works, but it means every consumer reinvents the same handful of additions. Worse, components like `<Heading size="display-lg">` can't be standardized when the size names aren't in the schema.
+
+This spec brings the missing categories into the canonical schema and documents the extension pattern for future additions.
+
+---
+
+## Context (theme overrides beyond color)
+
+Surfaced during spec 005's `/speckit.implement`, when the new token-query MCP's `palette` tool was exercised against `'spacing'` and `'radius'` categories and returned `unknown-category`. The root cause: the bundled theme JSON files at `packages/tokens/themes/{light,dark,brand}.json` carry only `color` overrides. Every other category (`spacing`, `typography`, `radii`, `shadows`, `opacity`, and the `motion` category this spec adds) lives in the schema's default values and cannot be overridden per theme.
+
+Constitution Section III states "token values float at runtime" without restricting which categories. Strict reading: a theme should be able to override any token, not just colors. Loose reading: themes are color skins and the rest is design-system-fixed. The current implementation matches the loose reading; the constitution implies the strict one.
+
+Most consumers won't hit this — color shifts are 95% of theming. But for-coleman-style brand themes that want different rounding or different default spacing can't express that today. Fixing it in the same release as B.1/B.2/B.3 keeps the breaking-change announcement to one cycle.
+
+The fix is structural, not new functionality:
+
+- The Zod theme schema loosens to accept overrides for any category, not just `color`. Categories not present in a theme JSON inherit from the schema defaults.
+- The validator merges theme overrides on top of schema defaults rather than treating non-color sections as either-present-or-error.
+- A theme that overrides only some keys in a category is valid; missing keys inherit the schema default.
+- THEMING.md grows a "Overriding non-color tokens" subsection alongside the existing schema-extension walkthrough.
+- The token-query MCP's `palette` tool automatically starts returning useful results for `'spacing'`, `'radius'`, `'motion'`, etc. once theme JSON carries them — no MCP code change required.
+
+Decision to make during this spec's implementation: do the built-in themes (`light.json`, `dark.json`, `brand.json`) gain default sections for non-color categories, or do they stay color-only and let consumers add their own? The brand theme is the strongest candidate to ship with non-color overrides (different border radius, accent font weight) since "brand" implies fuller customization.
+
+---
+
+## For-coleman context (B.1 — `font-serif`)
+
+The schema declares `font-sans` and `font-mono` but not `font-serif`. Editorial, curatorial, museum, and book-style sites need serif body type. for-coleman added it via `--typography-font-serif` and treated the schema's passthrough behavior as permission.
+
+The fix is a one-line schema addition. Note: because `themeSchema` requires every typography token, adding `font-serif` as a required key is a breaking change for any existing consumer theme. Pre-1.0 this is fine. Bump to 0.2.0 announces it.
+
+---
+
+## For-coleman context (B.2 — motion tokens)
+
+The schema has zero motion tokens. Real apps need durations and easings. The for-coleman feedback proposed this exact set, sourced from Material Design and iOS HIG:
+
+```
+--duration-fast:     120ms
+--duration-base:     240ms
+--duration-slow:     480ms
+
+--easing-standard:   cubic-bezier(0.4, 0, 0.2, 1)
+--easing-decelerate: cubic-bezier(0, 0, 0.2, 1)
+--easing-accelerate: cubic-bezier(0.4, 0, 1, 1)
+```
+
+These are conservative defaults. Adopt them as a new top-level `motion` token category alongside `color`, `spacing`, `typography`, `radius`, `shadow`, `opacity`.
+
+---
+
+## For-coleman context (B.3 — type scale beyond `xl`)
+
+The schema currently stops at `size-xl` (1.25rem). Editorial sites need display sizes: `2xl`, `3xl`, `display-sm`, `display`, `display-lg`, `display-xl`. The triage decision was to add `2xl` and `3xl` as required additions, and defer the display sizes until a component contract (likely `<Heading>`) demands them. Naming display stops stylistically without a consumer is premature.
+
+---
+
+## For-coleman context (C.2 — schema extension worked example)
+
+THEMING.md says "extra tokens beyond the schema are allowed; forward compatible by design." That's true but unhelpful without an example. A first-time consumer hits the question: "how do I add a new token type and have it flow through Style Dictionary into the dist outputs?"
+
+This spec adds a worked example to THEMING.md that demonstrates the full pipeline using motion tokens (from B.2) as the working example. The example covers:
+
+- Adding a new DTCG source file (`packages/tokens/src/tokens/motion.json`)
+- Updating the Zod schema in [packages/tokens/src/schema.ts](packages/tokens/src/schema.ts)
+- Updating each theme JSON file ([packages/tokens/themes/light.json](packages/tokens/themes/light.json), `dark.json`, `brand.json`) to include motion values
+- Running `tsx sd.config.ts` to regenerate dist outputs
+- Verifying the new tokens appear in `dist/tailwind/preset.css`, `dist/css/tokens-*.css`, and the typed token map at `dist/ts/token-map.js`
+
+The example doubles as the implementation log for B.2 itself — if you wrote B.2, you generated the content for C.2 as a side effect.
+
+---
+
+## Scope
+
+- Schema: add `font-serif` to the typography category as a required key
+- Schema: add a new `motion` category with the six durations and easings from B.2
+- Schema: add `size-2xl` and `size-3xl` to the typography category as required keys
+- Schema: loosen theme JSON validation to accept overrides for any category, not just `color`. Theme JSON files may include any subset of categories; missing keys inherit from the schema defaults.
+- All three built-in themes ([light.json](packages/tokens/themes/light.json), [dark.json](packages/tokens/themes/dark.json), [brand.json](packages/tokens/themes/brand.json)): add values for every newly required token
+- Built-in theme decision (in scope): decide during clarify whether `brand.json` ships with non-color overrides (e.g., a different `radii` set, a different `typography.font-sans` value) to demonstrate the broader theming surface, or stays color-only with the override capability documented but not exercised
+- Token sources under [packages/tokens/src/tokens/](packages/tokens/src/tokens/): add `motion.json`, update `typography.json` for font-serif and the larger sizes
+- Style Dictionary build: confirm motion category flows through to all four artifacts (CSS variables, Tailwind preset, TypeScript token map, JSON)
+- Validator: merge per-theme overrides on top of schema defaults so `validateTheme()` accepts partial category coverage in a theme file
+- THEMING.md: add an "Extending the schema" section with the worked example AND an "Overriding non-color tokens" subsection that shows how a brand theme overrides spacing or radii
+- Validation: `validateTheme()` reports a clear error for themes missing any of the new required tokens (and for the WCAG contrast pairs that still apply unchanged)
+- Bump to 0.2.0
+
+## Out of scope
+
+- Display sizes (`display-sm`, `display`, `display-lg`, `display-xl`) — deferred until a component contract requires them
+- Density / touch-target tokens (B.4 from the for-coleman feedback) — deferred indefinitely
+- Adding values for the new tokens to existing consumer themes outside this repo — that's their migration cost (announced via the 0.2.0 bump)
+- Theme composition (multi-axis themes like `data-theme="vaporwave compact"`) — deferred to spec 012
+- First-class theme-extension tokens (TypeScript types + MCP visibility for tokens declared in a theme JSON but not in the schema) — deferred to spec 012
+
+## Acceptance criteria
+
+- The Zod schema in [packages/tokens/src/schema.ts](packages/tokens/src/schema.ts) declares `motion` as a top-level token category with six required keys; `typography` requires `font-serif`, `size-2xl`, `size-3xl` in addition to the existing keys.
+- All three built-in themes pass `validateTheme()` against the new schema.
+- The motion tokens appear as Tailwind utilities (`duration-fast`, `easing-standard`, etc.) via the generated [packages/tokens/dist/tailwind/preset.css](packages/tokens/dist/tailwind/preset.css).
+- A consumer can write a new component using `transition-[duration-base] ease-[--easing-standard]` (or equivalent Tailwind syntax) and have it resolve correctly.
+- A theme missing any required new token gets a structured validation error from `validateTheme()` naming the missing path.
+- THEMING.md has a working "Extending the schema" walkthrough that another contributor can follow to add a new token category from scratch.
+- A theme JSON file may include `spacing`, `radii`, `typography`, or any other category and the build accepts it. A consumer's brand theme that overrides only `color` and `radii` validates cleanly and produces a working CSS variable set.
+- The token-query MCP's `palette` tool returns the resolved values for any category present in the active theme (no MCP code change in this spec; the unblock is automatic once the theme JSON carries the data).
+- 0.2.0 published.
+
+## Constitution check (bridge rules)
+
+Section XI is not yet ratified. The prose rules apply informally:
+
+- THEMING.md additions pass through the humanizer skill
+- No three-item lists in the worked example or the section prose
+- Validator error messages stay structured (`{ ok: false, issues: [{ code, path, message }] }`) — the existing pattern from Section III of the constitution
+
+No components added → the sidecar `*.usage.md` rule doesn't bite this spec.
+
+## References
+
+- [TODO.md](TODO.md) sections B.1, B.2, B.3, C.2 — original for-coleman feedback
+- [packages/tokens/src/schema.ts](packages/tokens/src/schema.ts) — current Zod schema, six categories
+- [packages/tokens/themes/light.json](packages/tokens/themes/light.json) — example theme structure
+- [packages/tokens/src/tokens/](packages/tokens/src/tokens/) — DTCG source files (color.json, spacing.json, etc.)
+- [packages/tokens/sd.config.ts](packages/tokens/sd.config.ts) — Style Dictionary build configuration
+- [packages/tokens/src/validate.ts](packages/tokens/src/validate.ts) — `validateTheme()` implementation
+- [THEMING.md](THEMING.md) — currently lacks the extension walkthrough

--- a/docs/workshops/2026-05-18/spec-009-theming-system-expansion.md
+++ b/docs/workshops/2026-05-18/spec-009-theming-system-expansion.md
@@ -1,0 +1,111 @@
+# Spec 009 — Theming system expansion
+
+**Target version:** next minor bump after spec 008 (introduces multi-axis theme application and a typed surface for theme-extension tokens — both are breaking-shape changes for the `data-theme` API and the typed token map)
+**Depends on:** 008 (schema additions plus per-category overrides; both prerequisites for the work here)
+**Blocks:** 010 (the API retrofit may want to lean on multi-axis themes once available)
+**Split from:** spec 008 — that spec stayed narrow to schema additions plus the small structural fix that lets themes override any category. This spec picks up the larger design questions surfaced during spec 005's `/speckit.implement`: composable theme axes and first-class theme-extension tokens.
+
+---
+
+## Motivation
+
+The "themes as color skins" framing misses the heart of unbranded-ds. A genuinely themable design system has to support visual aesthetics that move more than color: brutalist (sharper radii, harder shadows, condensed type), solarpunk (serif typography, generous spacing, earth-toned colors), vaporwave (decorative typography, glow-style shadows, saturated colors). Spec 008 fixes the small structural issue that themes can only override `color`. This spec fixes the two bigger gaps:
+
+1. **Composition.** Consumers want orthogonal axes: aesthetic AND density. "Vaporwave + compact" is one selection in the consumer's head and should be one selection in the API. Today themes are single-valued — a consumer who wants two axes either writes a combinatorial set of merged themes or nests `data-theme` DOM scopes, neither of which is the API they want.
+2. **Extension tokens.** A vaporwave theme might want `shadows.neon` (a glow effect) that the base schema doesn't declare. Today the build emits these as CSS variables (THEMING.md says "extra tokens are allowed; forward compatible by design") but they don't show up in the typed token map and don't surface in the token-query MCP. Half-supported extension tokens are a footgun — agents using the MCP can't discover them, TypeScript consumers can't type-check against them.
+
+Both gaps make the difference between a design system that supports aesthetic theming as a first-class concern and one that treats themes as color skins with a passthrough escape hatch.
+
+---
+
+## Context (theme composition — multiple axes)
+
+The choices for representing multiple theme axes:
+
+**Option A — multi-value `data-theme`.** `data-theme="vaporwave compact"` (space-separated like `className`). CSS variable resolution merges values from each named theme; later values override earlier ones on collision. Pro: one API stays. Con: ordering becomes load-bearing; merge semantics need careful documentation.
+
+**Option B — separate `data-` attributes per axis.** `data-theme="vaporwave"` plus `data-density="compact"`. Each attribute is its own theme namespace with its own JSON files. Pro: orthogonality is explicit; CSS selectors stay simple (`[data-theme=vaporwave]` independent of `[data-density=compact]`). Con: more API surface; consumers need to know which axis a theme belongs to. Constitution Section III needs an update to name the recognized axes.
+
+**Option C — theme inheritance / extension at the JSON level.** A `vaporwave-compact.json` declares `"extends": ["vaporwave", "compact"]` and the validator merges at build time. Pro: ordering is explicit per theme; runtime stays single-axis. Con: combinatorial explosion of theme files for N×M axes; consumers re-author every combination.
+
+Decision belongs in clarify and affects the runtime, validator, and MCP. My read going in: Option B is the most ergonomically honest — it makes axes a first-class API surface, and the multi-attribute selector model is conventional in CSS frameworks. Option A is tempting for "less API" but the ordering semantics are subtle. Option C punts the complexity to JSON authoring.
+
+Whichever option lands, the MCP tools (`lookupToken`, `palette`, `contrast`) need to accept the multi-axis input shape and merge during resolution.
+
+---
+
+## Context (per-theme token additions)
+
+A vaporwave theme might want a `--shadow-neon` that the base schema doesn't declare. Today THEMING.md says "extra tokens beyond the schema are allowed; forward compatible by design" — those tokens DO emit as CSS variables. But two things don't follow through:
+
+- The typed token map at `dist/ts/token-map.js` enumerates only schema-defined tokens. Theme-extension tokens are invisible to TypeScript consumers.
+- The token-query MCP's `palette` and `lookupToken` tools walk the schema-defined token tree. Theme-extension tokens don't appear in the responses.
+
+The fix:
+
+- Build step: the typed token map is generated from the **union** of schema tokens AND any tokens found across the bundled theme JSON files. Theme-extension tokens get TypeScript types like `'shadows.neon': { name, category, type, cssVariable, source: 'theme-extension' }`.
+- MCP: `palette` and `lookupToken` walk the resolved theme's actual contents and label theme-extension tokens with their source. The response shape distinguishes schema tokens from theme-extension tokens so consumers know which are portable across themes that don't carry them.
+
+Constitution implication: Section III's "schema locked at build time" remains true for the built-in tokens. Theme-extension tokens are a documented escape hatch for per-theme primitives the schema doesn't generalize. The constitution may want a paragraph clarifying that the schema-lock applies to the canonical token set, not to extension tokens.
+
+Decision to confirm during clarify: do consumer-defined theme-extension tokens get the same first-class TS-types + MCP-visibility treatment as schema tokens, or do we keep the current "passthrough as CSS variables only, no typed support" stance? Recommendation: full first-class treatment. Half-supported extension tokens are the kind of design-system rough edge that pushes consumers toward forking.
+
+---
+
+## Scope
+
+### Theme composition
+
+- Decide composition approach (Option A, B, or C). Lock in during clarify.
+- Update Constitution Section III to reflect the chosen API. Section III currently says "Multiple themes may coexist on the page via nested `data-theme` scopes." That stays true regardless. The amendment adds whichever axis API the spec lands.
+- Runtime: theme-application code resolves the active axis or axes into the appropriate CSS variable set. If Option B (multiple `data-` attributes), the runtime accepts each attribute and merges in the documented order. If Option A, the runtime parses the space-separated value. If Option C, the runtime stays single-axis but the validator merges at build time.
+- Validator: `validateTheme()` handles the merge semantics of whichever option lands. The validator surfaces structured errors when two axes collide on a value and the consumer needs to disambiguate.
+- MCP tools (`lookupToken`, `palette`, `contrast`): accept the multi-axis input shape. The `theme` parameter becomes either a string list (Option A) or an object keyed by axis name (Option B) or stays a string (Option C). The contract docs in `specs/005-agent-experience-foundation/contracts/token-query-mcp.md` get updated.
+- A `vaporwave.json` and a `compact.json` ship in the repo as concrete examples of the composition API. The README's quickstart shows a `data-theme="vaporwave compact"` (or equivalent) example.
+
+### Theme-extension tokens
+
+- Build step: typed token map is generated from the union of schema tokens AND tokens found across the bundled theme JSON files. Theme-extension tokens get TypeScript types with a `source` discriminator.
+- MCP tools: `palette` and `lookupToken` responses include theme-extension tokens AND label them as such in the response shape.
+- THEMING.md: a "Theme-extension tokens" subsection explains the build flow, the TS types, and the MCP visibility. Includes a worked example showing how to add `shadows.neon` to a vaporwave theme and how the agent sees it through the MCP.
+
+### Built-in theme examples
+
+- Add `vaporwave.json` and `compact.json` to `packages/tokens/themes/` as demonstration themes that exercise the new capabilities. `vaporwave.json` overrides color, shadows (including an extension `shadows.neon`), and typography. `compact.json` overrides spacing and typography.line-heights.
+- These ship in the npm package. Consumers can apply them directly via `data-theme` or use them as starting templates for their own theme files.
+
+## Out of scope
+
+- The full theme palette beyond the two demonstration themes. Brutalist and solarpunk are tempting examples but they're aesthetic choices for the project's later marketing, not API design work.
+- Per-axis token validation (e.g., "compact density themes may only override spacing and typography"). The spec accepts any axis overriding any category; tighter rules can land in a future spec if needed.
+- Component-level theme overrides. A consumer who wants Button to render differently in vaporwave can't do that through the theming system — they'd reach for a wrapper component or a CVA override. Component theming is a different design problem and out of scope.
+
+## Acceptance criteria
+
+- The chosen theme-composition approach works end-to-end: a consumer can apply `vaporwave` and `compact` simultaneously (whichever syntax the chosen option dictates) and the resolved CSS variables on the page reflect the union of the two themes per the chosen merge semantics.
+- The validator surfaces a structured error when a theme JSON declares an invalid axis combination or conflicts with the chosen API.
+- The token-query MCP's tools accept the multi-axis input shape and return the merged-resolved values.
+- A theme JSON that declares a token not in the schema (e.g., `"shadows": { "neon": { "$value": "0 0 10px var(--color-primary)", "$type": "shadow" } }`) produces a working CSS variable, a typed entry in the token map with `source: 'theme-extension'`, and an MCP response that includes the token with its source label.
+- `vaporwave.json` and `compact.json` ship in `packages/tokens/themes/` and pass validation. Both are documented in THEMING.md as worked examples.
+- Constitution Section III is amended to reflect the chosen composition API. The amendment is a MINOR bump (new principle / materially expanded guidance).
+- README quickstart demonstrates multi-axis theme application.
+
+## Constitution check (bridge rules)
+
+This spec amends Constitution Section III to name the chosen composition API. The amendment is a MINOR bump (1.1.x → 1.2.0). Section XI rules apply to all prose touched.
+
+Specifically:
+
+- THEMING.md additions pass through the humanizer skill
+- Theme-extension token examples follow Section XI.1 prose rules (no three-item lists in the worked examples)
+- MCP tool contract updates in `specs/005-agent-experience-foundation/contracts/token-query-mcp.md` go through the same prose pass
+
+## References
+
+- [tmp/spec-008-token-schema-growth.md](spec-008-token-schema-growth.md) — the smaller schema-additions spec this one builds on
+- [.specify/memory/constitution.md](../.specify/memory/constitution.md) Section III — the theming contract that this spec amends
+- [packages/tokens/src/schema.ts](../packages/tokens/src/schema.ts) — Zod schema that needs the composition update
+- [packages/tokens/src/validate.ts](../packages/tokens/src/validate.ts) — `validateTheme()` that gets the merge semantics
+- [packages/tokens/src/mcp/](../packages/tokens/src/mcp/) — MCP tools that need the multi-axis input shape
+- [packages/tokens/src/token-map.ts](../packages/tokens/src/token-map.ts) — typed token map that gets the union-with-theme-extensions treatment
+- [THEMING.md](../THEMING.md) — gets two new subsections (composition, theme-extension tokens)

--- a/docs/workshops/2026-05-18/spec-011-theme-toggle.md
+++ b/docs/workshops/2026-05-18/spec-011-theme-toggle.md
@@ -1,0 +1,99 @@
+# Spec 011 — ThemeToggle
+
+**Target version:** next minor bump after specs 005, 008, and 010 have shipped
+**Depends on:** 002 (themeBootstrapScript pairs with the toggle), 004 (SegmentedControl is the underlying primitive), 005 (sidecar template and AGENTS.md exist)
+**Blocks:** 012 (example app uses the toggle)
+**Bundles for-coleman items:** A.2
+
+---
+
+## Motivation
+
+The for-coleman team described `<ThemeToggle>` as a pattern every DS-driven app rebuilds. The pattern is well-defined (localStorage persistence plus system fallback plus a live media-query listener for the auto state) but each consumer reimplements it.
+
+This is the last for-coleman item to land. After this spec ships, the for-coleman scorecard is 6 of 6.
+
+---
+
+## For-coleman context (A.2)
+
+The for-coleman team built their own `<ThemeToggle>` and proposed shipping it upstream:
+
+> Three-state segmented control. Persists to `localStorage` (key `'theme'`). When in `auto`, listens to `prefers-color-scheme` changes mid-session. Sets `data-theme` on `document.documentElement`. Accessible: semantic `<fieldset>` + radio inputs, visually-hidden but keyboard-navigable.
+
+Suggested location: `packages/react/src/components/ThemeToggle/`.
+Reference: `components/theme-toggle.tsx` in for-coleman. ~100 lines + ~40 lines of CSS.
+
+### Triage modification
+
+The proposed component bakes in three opinions: the localStorage key, the use of `document.documentElement`, and a specific three-state UX (light/auto/dark). For an "unbranded" DS that's heavy commitment. Counter-proposal from the workshop:
+
+Ship two pieces and let consumers compose:
+
+1. **`useTheme()` hook** — owns the localStorage key (`unbranded-ds-theme`, matching `themeBootstrapScript` from spec 002), the `data-theme` selector, the system-fallback behavior, and the live `prefers-color-scheme` listener. Returns the current theme, an explicit-preference value (`'light' | 'auto' | 'dark'`), and a setter.
+
+2. **`<ThemeToggle>` component** — a thin shell on top of `<SegmentedControl>` (from spec 004) and `useTheme()`. About twenty lines. Consumers who want a different UX (a switch, a button cycle, a dropdown) compose their own using `useTheme()` directly.
+
+The hook is the load-bearing primitive; the component is a default convenience.
+
+---
+
+## Scope
+
+### `useTheme()` hook
+
+- Located at `packages/react/src/hooks/useTheme/useTheme.ts`
+- Reads and persists to `localStorage.getItem('unbranded-ds-theme')` (key matches `themeBootstrapScript` from spec 002 — consumers who use the bootstrap script get no flash on first paint)
+- Returns:
+  - `theme`: the currently-applied theme (`'light' | 'dark' | <consumer-registered theme name>`)
+  - `preference`: the user's stated preference (`'light' | 'auto' | 'dark'`)
+  - `setPreference(next)`: updates localStorage and applies the new theme
+- When preference is `'auto'`, subscribes to `prefers-color-scheme` and updates `theme` live as the OS preference changes (without writing to localStorage)
+- Sets `data-theme` on `document.documentElement` (overridable via an optional `root` parameter)
+- Safe in SSR (returns sensible defaults during first render, hydrates on mount)
+
+### `<ThemeToggle>` component
+
+- Located at `packages/react/src/components/ThemeToggle/`
+- Renders a three-segment `<SegmentedControl>` (light/auto/dark) wired to `useTheme()`
+- Labels are translatable via props; defaults are English
+- Each segment has an accessible label and an icon (lucide-react icons: Sun, SunMoon, Moon, or similar)
+- Honors the constitution's prose rules in autodocs and sidecar
+- Ships with a `<ThemeToggle>.usage.md` sidecar per Section XI
+
+## Out of scope
+
+- A switch-style two-state toggle (light/dark without auto) — consumers can compose this on `useTheme()` directly
+- Theme preview thumbnails in the toggle — premature
+- Multi-tenant theme registration UI — that's a different concern
+- Custom theme names beyond light/auto/dark in the toggle UI — the toggle ships with three segments; consumers wanting more compose their own
+
+## Acceptance criteria
+
+- `useTheme()` hook exported from the package root
+- `<ThemeToggle>` component exported from the package root
+- When a consumer wires `themeBootstrapScript` (from spec 002) plus `<ThemeToggle>` plus `useTheme()`, no theme-flash occurs on page reload
+- Switching the OS color scheme while the toggle is in `auto` updates the page live without a reload
+- The toggle is keyboard-navigable (arrow keys move between segments, Space/Enter selects)
+- Zero `serious` or `critical` axe violations
+- Component honors all of Section XI: humanizer pass on prose, predictable slot names (`<ThemeToggle.Segment>` if there's a slot), structured failure output if invalid preference values are passed, sidecar `*.usage.md` present
+- Stories cover: default state, each preference value selected, the live `prefers-color-scheme` change interaction
+- Unit tests cover the hook's localStorage read/write, the media-query listener subscription/cleanup, and the SSR-safe initial render
+
+## Constitution check
+
+Section XI is ratified at this point (spec 005). All of it applies:
+
+- Sidecar `<ThemeToggle>.usage.md` ships with the component
+- Autodocs prose passes humanizer
+- Slot names match the established vocabulary
+- The hook's return shape is structured (object with named fields, not a tuple) so agents can pattern-match
+- No three-item lists in prose
+
+## References
+
+- [TODO.md](TODO.md) section A.2 — original for-coleman proposal
+- [/tmp/feedback-triage.md](/tmp/feedback-triage.md) — the modification rationale (split into hook + component)
+- [packages/react/src/components/SegmentedControl/](packages/react/src/components/SegmentedControl/) — the underlying primitive (lands in spec 004)
+- `packages/tokens/src/runtime.ts` — exports `themeBootstrapScript` after spec 002, uses the same `unbranded-ds-theme` localStorage key
+- Constitution Section XI (ratified in spec 005)

--- a/docs/workshops/2026-05-18/spec-012-example-app.md
+++ b/docs/workshops/2026-05-18/spec-012-example-app.md
@@ -1,0 +1,103 @@
+# Spec 012 — Next.js 15 example app
+
+**Target version:** independent (lives under `examples/`, not in a published package)
+**Depends on:** 002 (canonical two-line wiring), 004 (primitives demonstrated), 005 (sidecars referenced from the app's README), 008 (motion tokens demonstrated), 011 (ThemeToggle demonstrated)
+**Blocks:** none
+**Bundles for-coleman items:** E.1
+
+---
+
+## Motivation
+
+The for-coleman team currently IS the example app for `@unbranded-ds`, but they're a real project with project-specific concerns layered on top. A stripped-down, copy-paste-able starter under `examples/` unblocks new consumers significantly. It's also the proof that the canonical wiring from spec 002 actually works as advertised.
+
+This spec lands last for two reasons. The example demonstrates the canonical wiring, the full primitive set, AND the agent docs — so it depends on most of the prior specs. And building it earlier would document a moving target.
+
+---
+
+## For-coleman context (E.1)
+
+> A minimal, copy-paste-able starter showing `@unbranded-ds/tokens` + `@unbranded-ds/react` wired up in a Next.js 15 App Router project with:
+> - Tailwind v4 preset import
+> - Theme bootstrap script in `app/layout.tsx`
+> - A `ThemeToggle` (once A.2 lands)
+> - `next/font/local` for self-hosted fonts that override the schema's font tokens
+>
+> for-coleman currently IS this example, but it's a real project rather than a minimal template. Even a stripped-down version under `examples/` would unblock new consumers significantly.
+
+---
+
+## Scope
+
+### Project location and shape
+
+- New directory at `examples/nextjs-15-app-router/`
+- Standalone pnpm workspace member, included in the root `pnpm-workspace.yaml`
+- Pins `@unbranded-ds/tokens` and `@unbranded-ds/react` to `workspace:*` so it tracks the local versions during development
+- Excluded from publishing (no `publishConfig`, not in any release manifest)
+
+### What the example demonstrates
+
+- **Tailwind wiring.** `app/globals.css` contains exactly the canonical two lines from spec 002:
+  ```css
+  @import 'tailwindcss';
+  @import '@unbranded-ds/react/preset.css';
+  ```
+- **Theme bootstrap.** `app/layout.tsx` inlines the `themeBootstrapScript` from `@unbranded-ds/tokens/runtime` in the `<head>` to prevent FOUC.
+- **Theme toggle.** The header includes the `<ThemeToggle>` from spec 011. Switching light/auto/dark works without page reload.
+- **Custom font that overrides token defaults.** Uses `next/font/local` to load a self-hosted font and applies it via a `:root { --typography-font-sans: ... }` override, demonstrating the "consumer overrides" pattern from spec 002's docs.
+- **Custom palette.** A `:root { --color-* }` block in `globals.css` overrides several colors, demonstrating the same override pattern for color tokens.
+- **One example using each new primitive.** A page that uses Button (existing), Tooltip (spec 004), Slider (spec 004), SkipLink (spec 004), and the four other existing components, in plausible contexts.
+- **Motion tokens in use.** A simple transition somewhere (e.g., on the ThemeToggle, or a Card hover) uses `--duration-base` and `--easing-standard` from spec 008.
+
+### What the example does NOT include
+
+- A real backend or data fetching — keep it a static demo
+- Authentication, payments, or other application concerns
+- Storybook (the example pulls from the published one, doesn't reimplement it)
+- Tests (the example is a starter, not a test fixture)
+
+### README
+
+The `examples/nextjs-15-app-router/README.md` covers:
+
+- What this example is and isn't (a starter, not a tutorial)
+- The exact `pnpm create` or copy-paste command to get a fresh copy outside the monorepo
+- A walkthrough of the four interesting files (globals.css, layout.tsx, the override block, the page using the primitives)
+- A link back to the main README and AGENTS.md (from spec 005)
+
+## Out of scope
+
+- A second example app for a non-Next.js framework (deferred until there's demand)
+- A Vue or Svelte example (no Vue/Svelte React package exists yet)
+- Deployment configuration (Vercel, Netlify, etc.) — left to the consumer
+- A CMS integration, an i18n setup, or any application-pattern-of-the-week
+
+## Acceptance criteria
+
+- `pnpm install && pnpm --filter @unbranded-ds/example-nextjs dev` (or equivalent) starts the example on a local port without manual setup
+- The example renders without FOUC when the saved theme is dark and the page is reloaded
+- Switching the OS color scheme while the toggle is in `auto` updates the example live
+- The example uses each of the four new primitives from spec 004 at least once in a realistic context
+- A consumer can copy the entire `examples/nextjs-15-app-router/` directory out of the repo, change the `workspace:*` deps to real version numbers, and have it work
+- The example's README explains the wiring and links the relevant docs
+
+## Constitution check
+
+Section XI is fully ratified at this point. The example app honors:
+
+- Humanizer pass on the README and any inline doc strings
+- No three-item lists in the README
+- Predictable wiring (the example is itself an artifact agents will read to learn how to scaffold a new consumer app)
+- The README at `examples/nextjs-15-app-router/README.md` is itself a candidate for agent consumption — write it for both audiences
+
+## References
+
+- [TODO.md](TODO.md) section E.1 — original for-coleman request
+- [/tmp/feedback-triage.md](/tmp/feedback-triage.md) — placement at the end of the sequence
+- [/tmp/agent-first-workshop.md](/tmp/agent-first-workshop.md) — sequencing rationale
+- Spec 002 — canonical Tailwind wiring (the API the example demonstrates)
+- Spec 008 — motion tokens (used in the example's transitions)
+- Spec 004 — primitives (each one demonstrated in the example)
+- Spec 005 — AGENTS.md and sidecars (linked from the example's README)
+- Spec 011 — ThemeToggle (demonstrated in the example's header)

--- a/docs/workshops/2026-06-11/spec-010-constitution-retrofit.md
+++ b/docs/workshops/2026-06-11/spec-010-constitution-retrofit.md
@@ -1,0 +1,105 @@
+# Spec 010 — Constitution-driven retrofit
+
+**Target version:** Part A is non-breaking (internal Tailwind-class swaps) and rides a `@unbranded-ds/react` patch. Part B, if kept here, is breaking and needs a minor bump with a migration note.
+**Depends on:** 008 (the motion, ring, and z-index tokens must exist before components can consume them). The API-shape issues were surfaced by 005, 006, and 007.
+**Blocks:** nothing hard. 009 (composition) noted that 010 "may want to lean on" multi-axis themes, but the token-consumption work here does not need 009.
+**Assembled from:** deferrals deposited by specs 005, 006, 007, and 008. There was never a standalone brief by design; this document compiles what those specs kicked downstream.
+
+---
+
+## Why this exists
+
+Several specs deliberately stayed prose-only or tokens-only and recorded the component-touching follow-up "for spec 010." Spec 005's foundation work, spec 006's sidecars, and spec 007's TSDoc audit all surfaced API-shape issues but were forbidden from changing component behavior or public API. Spec 008 introduced motion, ring, and z-index tokens but explicitly left the component swap to 010. This spec is where that accumulated retrofit lands.
+
+The work splits into two halves with very different risk profiles. Read the split recommendation before scoping.
+
+## The split (read this first)
+
+**Part A — Token consumption (non-breaking, mechanical, ready now).** Swap hardcoded values in component source onto the spec 008 tokens. No public API change; these are internal Tailwind-class edits. Unblocked the moment 008 shipped.
+
+**Part B — API and vocabulary harmonization (breaking, needs discovery).** Rename props and slots that violate Section XI.2's shared vocabulary. These are breaking changes to consumer component APIs, and nobody has enumerated the actual violations yet, so Part B needs a discovery audit before any rename.
+
+**Recommendation: ship Part A as spec 010; move Part B to its own spec (a later number, e.g. 013).** Part A is non-breaking and ready; Part B is breaking and undiscovered. Bundling a mechanical internal retrofit with a breaking API redesign muddies the changeset, the review, and the migration note. Part A also fixes a live bug (A.3), so it should not wait behind Part B's discovery work.
+
+The rest of this brief scopes Part A concretely and sketches Part B for the follow-up.
+
+---
+
+## Part A — Token consumption retrofit
+
+### A.1 Motion token swap
+
+Primitive components use Tailwind's built-in duration and easing utilities for their transitions because the DS motion tokens did not exist when those components shipped (Tooltip from spec 004 especially). Now that spec 008 ships the motion category, swap those transitions onto the DS tokens so the design system owns the timing surface.
+
+- Find transition utilities in component source (hardcoded `duration-*`, `ease-*` timings).
+- Replace with the DS motion tokens: `ease-standard` / `ease-decelerate` / `ease-accelerate` (these are real Tailwind utilities), and durations via `duration-[var(--duration-base)]` since Tailwind v4 has no named duration namespace (per spec 008 research).
+- Tooltip's open and close transition is the primary target; Dialog, Select, and any other animated primitive follow.
+
+### A.2 Ring width token swap
+
+The focus-ring width `ring-3` is hardcoded 14 times across components. Spec 008 shipped `ring.width` (default 3px, the value those usages resolve to).
+
+- Replace the 14 `ring-3` usages with the token (`ring-[length:var(--ring-width)]` or the equivalent).
+- Behavior is unchanged at the default; the win is that a theme can now vary focus-ring thickness.
+
+### A.3 Z-index scale swap (fixes a live bug)
+
+Four portal components (Dialog, Select, Tooltip, SkipLink) all stack at a hardcoded `z-50`. A tooltip opened inside a dialog has no defined order over it. Spec 008 shipped an ordered `z-index` scale (overlay below popover below tooltip).
+
+- Replace the 6 `z-50` usages with the appropriate scale stop per component: the dialog/overlay layer, the popover/select layer, the tooltip layer.
+- This is the fix for the latent nested-overlay stacking bug, not only a tidiness change.
+
+### Part A acceptance criteria
+
+- No component source contains a hardcoded `ring-3`, `z-50`, or a built-in transition timing where a DS token now exists.
+- A tooltip rendered inside an open dialog stacks above the dialog.
+- The component test suite stays green. No public API change, and no behavior change beyond the corrected stacking order.
+- Non-breaking: ships without a consumer migration note.
+
+---
+
+## Part B — API and vocabulary harmonization (sketch for a follow-up spec)
+
+Surfaced by specs 005, 006, and 007, which recorded API-shape issues but were forbidden from renaming. Breaking; needs its own clarify cycle.
+
+### B.0 Discovery first
+
+Nobody has enumerated the actual violations. The first task is an audit that lists every prop and slot that breaks Section XI.2's shared vocabulary, with the proposed rename and the blast radius (which stories, sidecars, TSDoc, and consumer call sites move). Do not start renames before this list exists.
+
+### Known and likely candidates
+
+- **Prop names off the shared vocabulary.** Section XI.2 fixes the variant axes to `variant`, `size`, `intent`, `disabled`. Any bespoke synonym (a `tone` that should be `intent`, a `kind` that should be `variant`) gets renamed. Spec 007 flagged this class explicitly.
+- **Slot-name consistency.** `*.Trigger`, `*.Content`, `*.Item`, `*.Root` must mean the same thing on every compound. The pre-XI components were written before the rule.
+- **Polymorphic prop unification.** Pick one prop name for polymorphic rendering across the codebase (the repo currently mixes `as` and Base UI's `render`).
+- **Structured failure output.** Any component or helper that warns or throws with prose only gets a structured `{ code, path, message }` payload per Section XI.4.
+
+### Why it is a separate spec
+
+Breaking API changes need a migration note, a coordinated bump (pre-1.0, a minor with a clear changelog), and codemods or a documented upgrade path. That is a different kind of work from Part A's internal swaps, and it should not delay the bug fix in A.3.
+
+---
+
+## Out of scope
+
+- Everything in Part B, if you take the split recommendation (it becomes its own spec).
+- New tokens or new components.
+- Theme composition (spec 009) and the example app (spec 012).
+- Changing the motion token values themselves (spec 008 set them).
+
+## Constitution check (bridge rules)
+
+Section XI is ratified. This spec is the one that finally enforces XI.2 (predictable API shape) on the pre-XI components.
+
+- Part A touches component source, so the Section IX Definition of Done applies: tokens-only styling, stories cover variants, a11y clean, SSR-safe, autodocs render. The swaps must not regress any of these.
+- Part B prose (the migration note, the discovery audit) passes through the humanizer.
+- Any new structured-failure output follows the XI.4 shape.
+- No three-item lists in the prose.
+
+## References
+
+- `specs/008-token-schema-growth/spec.md` — FR-020 and Out of Scope defer the component retrofit here; `research.md` notes the duration-token consumption form
+- `specs/007-autodoc-audit/spec.md` — defers prop renames and behavior changes to 010 (Out of Scope, FR-013, edge cases)
+- `specs/006-sidecar-retrofit/spec.md` — defers argTypes drift and API issues to 010 (FR-015)
+- `specs/005-agent-experience-foundation/spec.md` — FR-030 defers API refactors to 010
+- `tmp/post-008-pickup-notes.md` — the original 010 candidate list (slot/prop harmonization, motion swap, structured output)
+- `.specify/memory/constitution.md` Section XI.2 — the shared vocabulary this retrofit enforces

--- a/docs/workshops/2026-06-11/spec-013-api-vocabulary-harmonization.md
+++ b/docs/workshops/2026-06-11/spec-013-api-vocabulary-harmonization.md
@@ -1,0 +1,79 @@
+# Spec 013 — API and vocabulary harmonization
+
+**Target version:** breaking change to consumer component APIs; a minor bump (pre-1.0) with a migration note and, where feasible, codemods. The exact number depends on what ships before it.
+**Depends on:** 005, 006, 007 (which surfaced and recorded the API-shape issues), and ideally lands after 010 Part A (the non-breaking token retrofit) so the two kinds of change stay in separate releases. The sidecars (006) and TSDoc (007) update in lockstep with each rename.
+**Split from:** spec 010 (constitution-driven retrofit). 010 took Part A (token consumption: non-breaking, mechanical). This is Part B: the breaking API renames that enforce Section XI.2's shared vocabulary on the pre-XI components.
+**Blocks:** nothing hard.
+
+> Numbering note: "013" is indicative, following the tmp/ brief convention. The speckit script assigns the real spec number at `/speckit.specify` time based on the next available slot.
+
+---
+
+## Why this exists
+
+Section XI.2 says component APIs must be predictable from analogy: variant axes use a small shared vocabulary (`variant`, `size`, `intent`, `disabled`), compound slots use the `*.Root` / `*.Trigger` / `*.Content` / `*.Item` pattern consistently, and polymorphic rendering uses one prop name across the codebase. The components shipped before XI.2 was ratified (spec 005) were written without that constraint. Specs 005, 006, and 007 audited prose and docs but were explicitly forbidden from renaming props or slots, recording every API-shape issue "for spec 010" instead.
+
+Spec 010 took the non-breaking half (token consumption). This spec takes the breaking half: the actual renames. Splitting them keeps a mechanical internal retrofit out of the same release as a breaking API redesign, so the changeset, the review, and the migration note each stay coherent.
+
+## Discovery comes first (the gating task)
+
+No one has enumerated the actual violations. The first deliverable is an audit that produces, for every component, the props and slots that break XI.2, each with:
+
+- the current name and the proposed canonical name
+- the blast radius: which stories, sidecars, TSDoc blocks, tests, and the example app move with the rename
+- whether a codemod can cover it, or it needs a manual touch
+
+No rename starts before this list is reviewed. The audit is what turns "harmonize the API" from a vibe into a bounded set of changes with a known migration cost.
+
+## Scope (the discovery audit sets the exact list)
+
+These are the known and likely categories:
+
+### Prop vocabulary
+
+Rename bespoke variant-axis synonyms to the shared set. Any prop meaning "visual treatment" becomes `variant`; "semantic intent" becomes `intent`; "scale" becomes `size`. A `tone`, `kind`, `appearance`, or `color`-as-variant prop is the kind of thing that moves. Spec 007 flagged this class explicitly.
+
+### Slot consistency
+
+Every compound's slots use the same names for the same roles. `*.Root`, `*.Trigger`, `*.Content`, `*.Item` mean one thing across Dialog, Select, Tabs, Tooltip, SegmentedControl, Slider, and Card. Where a compound named a slot differently, rename to the shared pattern.
+
+### Polymorphic prop unification
+
+The repo mixes `as` (VisuallyHidden) and Base UI's `render` (Dialog, Select, Tabs triggers). Pick one prop name for "render as a different element" and apply it everywhere, or document the two as a deliberate split with a clear rule for which applies when.
+
+### Structured failure output
+
+Any component or helper that warns or throws with a prose-only message gets a structured `{ code, path, message }` payload per Section XI.4, with the human-readable string layered on top. The existing `warn()` helper and `validateTheme` are the model.
+
+## Migration
+
+Because these are breaking changes to consumer APIs, the spec ships:
+
+- a migration note in the changeset and CHANGELOG enumerating every rename (old to new)
+- codemods where the rename is mechanical (a prop or import rename), so consumers run one command
+- a deprecation window where the team prefers a soft landing: accept both the old and new name for one minor, warn on the old, remove in the next. The discovery audit recommends per rename whether to hard-break or deprecate.
+
+## Out of scope
+
+- Part A (token consumption). That is spec 010's scope.
+- New components, new tokens, new variants.
+- Behavior changes beyond what a rename strictly requires. This spec moves names, not semantics.
+- Theme work (009) and the example app (012), except as downstream consumers that update in lockstep with each rename.
+
+## Constitution check (bridge rules)
+
+This spec finally brings the pre-XI components into XI.2 compliance.
+
+- Every renamed component re-satisfies the Section IX Definition of Done: stories, a11y, SSR-safety, autodocs.
+- The sidecars (XI.3) and TSDoc (the spec 007 surface) update with each rename, in the same PR, so the docs never describe a stale API.
+- The migration note and the audit prose pass through the humanizer.
+- New structured-failure output follows the XI.4 shape.
+- No three-item lists in the prose.
+
+## References
+
+- `tmp/spec-010-constitution-retrofit.md`: Part A (token consumption) and the original split recommendation that produced this spec
+- `specs/007-autodoc-audit/spec.md`: defers prop renames and behavior changes here (Out of Scope, FR-013)
+- `specs/006-sidecar-retrofit/spec.md`: defers API issues here (FR-015)
+- `specs/005-agent-experience-foundation/spec.md`: FR-030 defers API refactors here
+- `.specify/memory/constitution.md` Section XI.2: the shared vocabulary this spec enforces


### PR DESCRIPTION
## Summary

The design-system planning docs (the workshop output, the for-coleman TODO, the deep research, and the spec briefs for 007 through 013) lived in gitignored `tmp/`, one clean checkout or new machine away from gone. This moves them into version control under `docs/workshops/`, organized by the date each was written so the planning history reads as the three distinct sessions it actually was.

No source, token, or component changes. Documentation only.

## What's Included

- **`2026-05-15/`**: the workshop core (feedback triage, the Section XI constitution-amendment draft, agent-first notes, the for-coleman TODO)
- **`2026-05-18/`**: the docs deep research, the post-008 pickup notes, and the spec briefs for 007 through 012
- **`2026-06-11/`**: the spec 010 (constitution retrofit) and spec 013 (API vocabulary harmonization) briefs

13 files, all previously untracked.

## Notes

- Bucketed by actual modification date rather than lumped under one folder, so a reader can tell which planning session produced what.
- A few briefs still reference siblings by their old `tmp/` paths. They're historical artifacts, so the internal links were left as-written rather than rewritten.
