### PR TITLE
Constitution retrofit Part A: token consumption (spec 010)

### DIFF
--- a/.changeset/constitution-retrofit-token-consumption.md
+++ b/.changeset/constitution-retrofit-token-consumption.md
@@ -1,0 +1,10 @@
+---
+'@unbranded-ds/tokens': minor
+'@unbranded-ds/react': patch
+---
+
+Consume the spec 008 design tokens in component source. Focus rings now read `ring.width`, the overlay components read the `z-index` scale, and overlay open/close animations read the `motion` tokens, so a consumer theming any of those now sees the components respond.
+
+Adds a `z-index.max` token (9999) for the always-on-top focus-revealed SkipLink, so a focused skip link beats every overlay, including a consumer's own.
+
+The z-index work fixes a latent stacking bug: a tooltip opened inside a dialog now renders above it (tooltip 60 over overlay 50) instead of both sharing a hardcoded `z-50` with no defined order. No public component API changes; the only visible differences are the corrected overlay stacking and the design-system motion timing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # heliostat Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-06-10
+Auto-generated from all feature plans. Last updated: 2026-06-11
 
 ## Active Technologies
 - TypeScript 5.x in `tsx`-tagged code blocks only (validated via `tsc --noEmit` per spec 005's compile validator). Sidecar prose is plain CommonMark. + All shipped in spec 005. The template at `packages/react/src/components/_template/Component.usage.md`, the validator at `scripts/validate-sidecars.ts`, the `AGENTS.md` component index, and the CI step that wires the validator into the verify job. (006-sidecar-retrofit)
@@ -9,6 +9,7 @@ Auto-generated from all feature plans. Last updated: 2026-06-10
 - N/A (prose-only edits to existing source files) (007-autodoc-audit)
 - TypeScript 5.x, strict mode, no `any` + Style Dictionary v4 (DTCG build), Zod (theme schema + validation), Tailwind CSS v4 (`@theme` preset consumption) (008-token-schema-growth)
 - Filesystem only. DTCG source files under `packages/tokens/src/tokens/`, built-in theme files under `packages/tokens/themes/`, generated artifacts under `packages/tokens/dist/`. (008-token-schema-growth)
+- TypeScript 5.x, strict mode, no `any` + Tailwind CSS v4 (`@theme` preset consumption), `@base-ui-components/react`, `class-variance-authority`, Storybook 10.3 (interaction + a11y test runner) (010-constitution-retrofit)
 
 - TypeScript 5.x, strict mode, no `any` (Constitution Section VIII) (004-primitive-set-expansion)
 - N/A (component library; no persisted data) (004-primitive-set-expansion)
@@ -38,9 +39,9 @@ npm test && npm run lint
 TypeScript 5.x, strict mode, no `any` (EVER): Follow standard conventions
 
 ## Recent Changes
+- 010-constitution-retrofit: Added TypeScript 5.x, strict mode, no `any` + Tailwind CSS v4 (`@theme` preset consumption), `@base-ui-components/react`, `class-variance-authority`, Storybook 10.3 (interaction + a11y test runner)
 - 008-token-schema-growth: Added TypeScript 5.x, strict mode, no `any` + Style Dictionary v4 (DTCG build), Zod (theme schema + validation), Tailwind CSS v4 (`@theme` preset consumption)
 - 007-autodoc-audit: Added TypeScript 5.x, strict mode, no `any` + `@base-ui-components/react`, `class-variance-authority`, Storybook 10.3 (`@storybook/react-vite`), react-docgen (Storybook-bundled)
-- 006-sidecar-retrofit: Added TypeScript 5.x in `tsx`-tagged code blocks only (validated via `tsc --noEmit` per spec 005's compile validator). Sidecar prose is plain CommonMark. + All shipped in spec 005. The template at `packages/react/src/components/_template/Component.usage.md`, the validator at `scripts/validate-sidecars.ts`, the `AGENTS.md` component index, and the CI step that wires the validator into the verify job.
 
 
 

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -6,7 +6,7 @@ import { cva } from 'class-variance-authority';
 import { cn } from '../../lib/cn';
 
 const buttonVariants = cva(
-	'group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
+	'group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-(length:--ring-width) focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-(length:--ring-width) aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
 	{
 		variants: {
 			variant: {

--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -181,7 +181,7 @@ function Checkbox({ className, ...props }: CheckboxProps) {
 		<CheckboxPrimitive.Root
 			data-slot="checkbox"
 			className={cn(
-				'peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input shadow-xs transition-shadow outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary',
+				'peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input shadow-xs transition-shadow outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-(length:--ring-width) focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-(length:--ring-width) aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary',
 				className,
 			)}
 			{...props}

--- a/packages/react/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/Dialog/Dialog.stories.tsx
@@ -3,6 +3,7 @@ import { expect, userEvent, within } from 'storybook/test';
 import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
 import { Label } from '../Label/Label';
+import { Tooltip } from '../Tooltip/Tooltip';
 import {
 	Dialog,
 	DialogClose,
@@ -117,5 +118,53 @@ export const OpenCloseInteraction: Story = {
 		const trigger = canvas.getByRole('button', { name: 'Open' });
 		await userEvent.click(trigger);
 		await expect(await within(document.body).findByText('Interaction Test')).toBeVisible();
+	},
+};
+
+export const TooltipStacksAboveDialog: Story = {
+	name: 'Tooltip stacks above dialog',
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Regression test for the nested-overlay stacking fix (spec 010). A tooltip opened on a control inside an open dialog renders above the dialog: the tooltip reads the `z-index.tooltip` stop (60) and the dialog reads `z-index.overlay` (50), so the tooltip wins. Before the fix, both stacked at a shared `z-50` with no defined order.',
+			},
+		},
+	},
+	render: () => (
+		<Dialog>
+			<DialogTrigger render={<Button />}>Open</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Nested overlay</DialogTitle>
+					<DialogDescription>A tooltip inside a dialog must stack above it.</DialogDescription>
+				</DialogHeader>
+				<Tooltip.Provider delayDuration={0}>
+					<Tooltip.Trigger>
+						<Button variant="outline">Hover for tooltip</Button>
+					</Tooltip.Trigger>
+					<Tooltip.Content>Above the dialog</Tooltip.Content>
+				</Tooltip.Provider>
+			</DialogContent>
+		</Dialog>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole('button', { name: 'Open' }));
+
+		const body = within(document.body);
+		const dialogContent = (await body.findByText('Nested overlay')).closest(
+			'[data-slot="dialog-content"]',
+		) as HTMLElement;
+
+		await userEvent.hover(await body.findByRole('button', { name: 'Hover for tooltip' }));
+		const tooltipContent = (await body.findByText('Above the dialog')).closest(
+			'[data-slot="tooltip-content"]',
+		) as HTMLElement;
+
+		// The fix: the tooltip's z-index resolves above the dialog's, instead of
+		// both sharing z-50. Reads the computed (var-resolved) values.
+		const zIndexOf = (el: HTMLElement) => Number.parseInt(getComputedStyle(el).zIndex, 10);
+		await expect(zIndexOf(tooltipContent)).toBeGreaterThan(zIndexOf(dialogContent));
 	},
 };

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -222,7 +222,7 @@ function DialogOverlay({
 		<DialogPrimitive.Backdrop
 			data-slot="dialog-overlay"
 			className={cn(
-				'fixed inset-0 isolate z-50 bg-foreground/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+				'fixed inset-0 isolate z-(--z-index-overlay) bg-foreground/10 duration-(--duration-fast) supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
 				className,
 			)}
 			{...props}
@@ -274,7 +274,7 @@ function DialogContent({
 			<DialogPrimitive.Popup
 				data-slot="dialog-content"
 				className={cn(
-					'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-popover p-6 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+					'fixed top-1/2 left-1/2 z-(--z-index-overlay) grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-popover p-6 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-(--duration-fast) outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
 					className,
 				)}
 				{...props}

--- a/packages/react/src/components/Input/Input.tsx
+++ b/packages/react/src/components/Input/Input.tsx
@@ -172,7 +172,7 @@ function Input({ className, type, ...props }: InputProps) {
 			type={type}
 			data-slot="input"
 			className={cn(
-				'h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+				'h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-(length:--ring-width) focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-(length:--ring-width) aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
 				className,
 			)}
 			{...props}

--- a/packages/react/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/react/src/components/SegmentedControl/SegmentedControl.tsx
@@ -56,7 +56,7 @@ const segmentedControlItemVariants = cva(
 	// Each item is a focusable segment. The selected segment lifts onto a
 	// solid background; unselected segments fade. Inner corners stay subtle
 	// because the outer wrapper provides the outer pill curve.
-	'relative inline-flex shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-[calc(var(--radius-md)-2px)] border border-transparent font-medium whitespace-nowrap transition-colors outline-none select-none hover:text-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-checked:bg-background data-checked:text-foreground data-checked:shadow-sm data-disabled:pointer-events-none data-disabled:opacity-50 dark:data-checked:bg-input/30 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
+	'relative inline-flex shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-[calc(var(--radius-md)-2px)] border border-transparent font-medium whitespace-nowrap transition-colors outline-none select-none hover:text-foreground focus-visible:border-ring focus-visible:ring-(length:--ring-width) focus-visible:ring-ring/50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-checked:bg-background data-checked:text-foreground data-checked:shadow-sm data-disabled:pointer-events-none data-disabled:opacity-50 dark:data-checked:bg-input/30 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
 	{
 		variants: {
 			size: {

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -204,7 +204,7 @@ function SelectTrigger({
 			data-slot="select-trigger"
 			data-size={size}
 			className={cn(
-				'flex w-fit items-center justify-between gap-1.5 rounded-md border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
+				'flex w-fit items-center justify-between gap-1.5 rounded-md border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-(length:--ring-width) focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-(length:--ring-width) aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
 				className,
 			)}
 			{...props}
@@ -295,12 +295,12 @@ function SelectContent({
 				align={align}
 				alignOffset={alignOffset}
 				alignItemWithTrigger={alignItemWithTrigger}
-				className="isolate z-50"
+				className="isolate z-(--z-index-popover)"
 			>
 				<SelectPrimitive.Popup
 					data-slot="select-content"
 					data-align-trigger={alignItemWithTrigger}
-					className={cn('relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95', className)}
+					className={cn('relative isolate z-(--z-index-popover) max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-(--duration-fast) data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95', className)}
 					{...props}
 				>
 					<SelectScrollUpButton />

--- a/packages/react/src/components/SkipLink/SkipLink.tsx
+++ b/packages/react/src/components/SkipLink/SkipLink.tsx
@@ -130,10 +130,10 @@ function SkipLink({
 			href={`#${targetId}`}
 			className={cn(
 				'sr-only',
-				'focus-visible:not-sr-only focus-visible:fixed focus-visible:top-2 focus-visible:left-2 focus-visible:z-50',
+				'focus-visible:not-sr-only focus-visible:fixed focus-visible:top-2 focus-visible:left-2 focus-visible:z-(--z-index-max)',
 				'focus-visible:inline-flex focus-visible:items-center focus-visible:rounded-md focus-visible:border focus-visible:border-ring focus-visible:bg-primary focus-visible:px-3 focus-visible:py-2',
 				'focus-visible:text-sm focus-visible:font-medium focus-visible:text-primary-foreground focus-visible:shadow-md',
-				'focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50',
+				'focus-visible:outline-none focus-visible:ring-(length:--ring-width) focus-visible:ring-ring/50',
 				className,
 			)}
 		>

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -49,7 +49,7 @@ const sliderIndicatorVariants = cva(
 );
 
 const sliderThumbVariants = cva(
-	'block rounded-full border border-primary/50 bg-background shadow-xs ring-ring/50 transition-[color,box-shadow] outline-none focus-visible:ring-3 disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50',
+	'block rounded-full border border-primary/50 bg-background shadow-xs ring-ring/50 transition-[color,box-shadow] outline-none focus-visible:ring-(length:--ring-width) disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50',
 	{
 		variants: {
 			size: {

--- a/packages/react/src/components/Switch/Switch.tsx
+++ b/packages/react/src/components/Switch/Switch.tsx
@@ -184,7 +184,7 @@ function Switch({
 			data-slot="switch"
 			data-size={size}
 			className={cn(
-				'peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50',
+				'peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-(length:--ring-width) focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-(length:--ring-width) aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50',
 				className,
 			)}
 			{...props}

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -197,7 +197,7 @@ function TooltipContent({
 				<TooltipPrimitive.Popup
 					data-slot="tooltip-content"
 					className={cn(
-						'z-50 w-fit origin-(--transform-origin) rounded-md bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md ring-1 ring-foreground/10 transition-[opacity,transform] duration-150 motion-reduce:transition-none motion-reduce:duration-0 data-instant:duration-0 data-open:opacity-100 data-closed:opacity-0',
+						'z-(--z-index-tooltip) w-fit origin-(--transform-origin) rounded-md bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md ring-1 ring-foreground/10 transition-[opacity,transform] data-open:ease-decelerate data-closed:ease-accelerate duration-(--duration-fast) motion-reduce:transition-none motion-reduce:duration-0 data-instant:duration-0 data-open:opacity-100 data-closed:opacity-0',
 						className,
 					)}
 					{...props}

--- a/packages/tokens/src/defaults.ts
+++ b/packages/tokens/src/defaults.ts
@@ -129,5 +129,8 @@ export const canonicalDefaultTokens: ResolvedTokens = {
 		overlay: '50',
 		popover: '55',
 		tooltip: '60',
+		// always-on-top layer for the focused SkipLink (spec 010). MUST match
+		// src/tokens/z-index.json.
+		max: '9999',
 	},
 };

--- a/packages/tokens/src/schema.ts
+++ b/packages/tokens/src/schema.ts
@@ -110,6 +110,9 @@ const zIndexTokens = z.object({
 	overlay: z.string(),
 	popover: z.string(),
 	tooltip: z.string(),
+	// `max` is the always-on-top layer: a focused SkipLink must beat every overlay,
+	// including a consumer's own. Consumed by SkipLink (spec 010).
+	max: z.string(),
 });
 
 // The complete tokens shape: required categories required, ring/z-index optional.

--- a/packages/tokens/src/tokens/z-index.json
+++ b/packages/tokens/src/tokens/z-index.json
@@ -11,6 +11,10 @@
 		"tooltip": {
 			"$value": "60",
 			"$type": "number"
+		},
+		"max": {
+			"$value": "9999",
+			"$type": "number"
 		}
 	}
 }

--- a/specs/010-constitution-retrofit/checklists/requirements.md
+++ b/specs/010-constitution-retrofit/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Constitution-driven retrofit (Part A)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- **Part A / Part B split is explicit.** This spec is scoped to token consumption (non-breaking). The breaking API and vocabulary harmonization is spec 013, named in Background, Clarifications, and Out of Scope so a reader never expects renames here.
+- **The spec names concrete values** (`ring-3`, `z-50`, `ring.width`, the `z-index` scale, the `motion` tokens). These are the audit's input state and the spec 008 token vocabulary, not implementation choices being made here. Naming the values being swapped is naming the work.
+- **Spec number forced to 010** (not the sequential 009) to keep brief-numbers and spec-numbers aligned across the roadmap; 009 is reserved for the composition spec.
+- **One bug fix rides along** (nested-overlay stacking). It is framed as US1 because it is the highest-value outcome, and it falls out of the z-index consumption rather than being separate work.
+- **Clarify session 2026-06-11 resolved two scope decisions**: SkipLink is excluded from the z-index swap (it is a focus-reveal bypass link, not an overlay; the scale shipped three stops for the three overlays), and the motion swap is scoped to overlay enter/exit animations only (the micro-transitions keep their inline timings). Both narrowed the surface and removed contradictions the first draft carried ("four portal components," "every animated primitive").

--- a/specs/010-constitution-retrofit/contracts/token-consumption-patterns.md
+++ b/specs/010-constitution-retrofit/contracts/token-consumption-patterns.md
@@ -1,0 +1,58 @@
+# Contract: Token consumption patterns
+
+The canonical class form for consuming each spec 008 token. Every component copies these so the swaps are uniform. The syntax-lock step verifies each against a real Tailwind v4 build before the parallel edits begin; if a form does not generate, the whole set updates here once and the components follow.
+
+## Ring width
+
+```
+ring-3  →  ring-(length:--ring-width)
+```
+
+Applies wherever a focus ring is set (`focus-visible:ring-3`, `aria-invalid:ring-3`). The `length:` hint disambiguates the custom property as a width.
+
+- Fallback if the shorthand does not generate: `ring-[length:var(--ring-width)]`.
+- Default resolves to 3px (unchanged appearance).
+- Does NOT apply to `ring-1` (hairline border ring, out of scope).
+
+## Z-index
+
+```
+z-50 (Dialog backdrop + popup)   →  z-(--z-index-overlay)
+z-50 (Select positioner + popup) →  z-(--z-index-popover)
+z-50 (Tooltip popup)             →  z-(--z-index-tooltip)
+```
+
+- Fallback: `z-[var(--z-index-overlay)]` etc.
+- Ordering overlay (50) < popover (55) < tooltip (60) is the nested-overlay fix.
+- SkipLink's `focus-visible:z-50` is NOT swapped.
+
+## Duration
+
+```
+duration-100 / duration-150  →  duration-(--duration-fast)
+```
+
+- Fallback: `duration-[var(--duration-fast)]`.
+- MUST be verified to apply to keyframe `animate-in/out` (Dialog, Select), not only to `transition` (Tooltip). This is the highest-risk pattern.
+
+## Easing
+
+```
+(implicit browser default)  →  ease-standard
+                            or  data-open:ease-decelerate data-closed:ease-accelerate
+```
+
+- `ease-*` are real utilities (spec 008 emits the `--ease-*` namespace).
+- Per-direction variants are the recommended form for overlays (enter decelerates, exit accelerates).
+- For keyframe animations, confirm the easing reaches `animation-timing-function`; if not, leave the keyframe preset's easing and tokenize only the duration.
+
+## Verification (the syntax-lock step)
+
+Build a throwaway sample using each form and confirm against the generated CSS / a Storybook build that:
+
+1. `ring-(length:--ring-width)` emits a 3px ring referencing the variable.
+2. `z-(--z-index-overlay)` emits `z-index: var(--z-index-overlay)`.
+3. `duration-(--duration-fast)` retimes both a `transition` and a keyframe `animate-in` element.
+4. `ease-decelerate` / `ease-accelerate` resolve to the token cubic-beziers.
+
+Lock the four exact strings here, then the per-component edits copy them verbatim.

--- a/specs/010-constitution-retrofit/contracts/token-consumption-patterns.md
+++ b/specs/010-constitution-retrofit/contracts/token-consumption-patterns.md
@@ -24,7 +24,7 @@ z-50 (Tooltip popup)             →  z-(--z-index-tooltip)
 
 - Fallback: `z-[var(--z-index-overlay)]` etc.
 - Ordering overlay (50) < popover (55) < tooltip (60) is the nested-overlay fix.
-- SkipLink's `focus-visible:z-50` is NOT swapped.
+- SkipLink's `focus-visible:z-50` → `z-(--z-index-max)` (the new always-on-top token added by spec 010).
 
 ## Duration
 

--- a/specs/010-constitution-retrofit/data-model.md
+++ b/specs/010-constitution-retrofit/data-model.md
@@ -31,7 +31,7 @@ No runtime data. The "model" is the catalog of swap sites: which file, which har
 
 5 sites, 3 components. The ordering (overlay 50 < popover 55 < tooltip 60) is what fixes the nested-overlay bug: a Select dropdown inside a Dialog now sits above the dialog, and a Tooltip sits above both.
 
-**Excluded**: SkipLink `focus-visible:z-50` (1 site) — not an overlay; retained.
+**SkipLink** `focus-visible:z-50` (1 site) → `z-(--z-index-max)`. Revised from the original exclusion: spec 010 adds a `z-index.max` (9999) token so the focus-revealed skip link sits above every overlay.
 
 ### Motion (overlay open/close timing → `motion` tokens)
 
@@ -47,12 +47,12 @@ No runtime data. The "model" is the catalog of swap sites: which file, which har
 
 - **Swap site**: one location in a component class string holding a value a spec 008 token now names. Rewritten to the token-referencing form from `contracts/token-consumption-patterns.md`.
 - **Overlay layer**: one of three stacking depths (overlay, popover, tooltip). Each overlay component maps to exactly one.
-- **Excluded site**: a hardcoded value intentionally retained — SkipLink's `z-50`, every `ring-1`, and every micro-transition `transition-*`/`duration-*` on an interactive (non-overlay) component.
+- **Excluded site**: a hardcoded value intentionally retained — every `ring-1` hairline border, and every micro-transition `transition-*`/`duration-*` on an interactive (non-overlay) component. (SkipLink's z is no longer excluded; it reads `z-index.max`.)
 
 ## Invariants after the retrofit
 
 - No `ring-3` in component source (all → `ring.width`).
-- No `z-50` in Dialog, Select, or Tooltip (all → a scale stop). SkipLink's `z-50` remains by design.
+- No `z-50` anywhere; the overlays read a scale stop and SkipLink reads `z-index.max`.
 - Overlay open/close durations reference a `motion` duration token; the keyframe presets are unchanged.
 - A tooltip inside an open dialog stacks above it.
 - Default rendered output is unchanged except the nested-overlay order and the overlay timing.

--- a/specs/010-constitution-retrofit/data-model.md
+++ b/specs/010-constitution-retrofit/data-model.md
@@ -1,0 +1,58 @@
+# Data Model: Constitution-driven retrofit (Part A)
+
+**Phase 1 output** | **Date**: 2026-06-11
+
+No runtime data. The "model" is the catalog of swap sites: which file, which hardcoded value, which token replaces it. This is the work list the parallel edits execute against.
+
+## Swap-site catalog
+
+### Ring width (`ring-3` → `ring.width`)
+
+| Component | Sites | Form |
+| --- | --- | --- |
+| Button | 2 | `focus-visible:ring-3` → `focus-visible:ring-(length:--ring-width)` |
+| Checkbox | 2 | same pattern |
+| Input | 2 | `focus-visible:ring-3`, `aria-invalid:ring-3` |
+| Switch | 2 | same |
+| Select | 2 | `focus-visible:ring-3`, `aria-invalid:ring-3` (on the trigger) |
+| Slider | 1 | `focus-visible:ring-3` (on the thumb) |
+| SegmentedControl | 1 | `focus-visible:ring-3` |
+| SkipLink | 1 | `focus-visible:ring-3` (ring swapped; z-50 retained) |
+
+~13 sites, 8 components. Default value unchanged (3px), so focus rings render identically; the gain is a themeable width.
+
+### Z-index (`z-50` → the scale, overlay components only)
+
+| Component | Sites | Stop | Form |
+| --- | --- | --- | --- |
+| Dialog | 2 (backdrop, popup) | `overlay` (50) | `z-50` → `z-(--z-index-overlay)` |
+| Select | 2 (positioner, popup) | `popover` (55) | `z-50` → `z-(--z-index-popover)` |
+| Tooltip | 1 (popup) | `tooltip` (60) | `z-50` → `z-(--z-index-tooltip)` |
+
+5 sites, 3 components. The ordering (overlay 50 < popover 55 < tooltip 60) is what fixes the nested-overlay bug: a Select dropdown inside a Dialog now sits above the dialog, and a Tooltip sits above both.
+
+**Excluded**: SkipLink `focus-visible:z-50` (1 site) — not an overlay; retained.
+
+### Motion (overlay open/close timing → `motion` tokens)
+
+| Component | Mechanism | Current | After |
+| --- | --- | --- | --- |
+| Tooltip | `transition-[opacity,transform]` | `duration-150` | `duration-(--duration-fast)` + `ease-standard` (or `data-open:ease-decelerate data-closed:ease-accelerate`) |
+| Dialog | keyframe `animate-in/out` | `duration-100` | `duration-(--duration-fast)`; keyframe presets stay |
+| Select | keyframe `animate-in/out` | `duration-100` | `duration-(--duration-fast)`; keyframe presets stay |
+
+3 components. The `fade`/`zoom`/`slide` keyframe presets are not motion tokens and stay. `motion-reduce:*` and `data-instant:*` handling on Tooltip stays intact.
+
+## Entities
+
+- **Swap site**: one location in a component class string holding a value a spec 008 token now names. Rewritten to the token-referencing form from `contracts/token-consumption-patterns.md`.
+- **Overlay layer**: one of three stacking depths (overlay, popover, tooltip). Each overlay component maps to exactly one.
+- **Excluded site**: a hardcoded value intentionally retained — SkipLink's `z-50`, every `ring-1`, and every micro-transition `transition-*`/`duration-*` on an interactive (non-overlay) component.
+
+## Invariants after the retrofit
+
+- No `ring-3` in component source (all → `ring.width`).
+- No `z-50` in Dialog, Select, or Tooltip (all → a scale stop). SkipLink's `z-50` remains by design.
+- Overlay open/close durations reference a `motion` duration token; the keyframe presets are unchanged.
+- A tooltip inside an open dialog stacks above it.
+- Default rendered output is unchanged except the nested-overlay order and the overlay timing.

--- a/specs/010-constitution-retrofit/plan.md
+++ b/specs/010-constitution-retrofit/plan.md
@@ -59,7 +59,7 @@ packages/react/src/components/
 ├── Switch/Switch.tsx              # ring-3 (2)
 ├── Slider/Slider.tsx              # ring-3 (1)
 ├── SegmentedControl/SegmentedControl.tsx  # ring-3 (1)
-├── SkipLink/SkipLink.tsx          # ring-3 (1); z-50 RETAINED (excluded)
+├── SkipLink/SkipLink.tsx          # ring-3 (1); z-50 → z-index.max
 ├── Dialog/Dialog.tsx              # z-50 → overlay (2); duration-100 → motion (enter/exit)
 ├── Select/Select.tsx              # ring-3 (2); z-50 → popover (2); duration-100 → motion
 └── Tooltip/Tooltip.tsx            # z-50 → tooltip (1); transition duration-150 → motion + easing

--- a/specs/010-constitution-retrofit/plan.md
+++ b/specs/010-constitution-retrofit/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Constitution-driven retrofit (Part A — token consumption)
+
+**Branch**: `010-constitution-retrofit` | **Date**: 2026-06-11 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/010-constitution-retrofit/spec.md`
+
+## Summary
+
+Consume the spec 008 tokens in component source: swap the focus-ring width (`ring-3` → `ring.width`, ~13 sites across 8 components), the overlay stacking layer (`z-50` → the `z-index` scale in Dialog/Select/Tooltip, which fixes the nested-overlay bug), and the overlay open/close timing (`duration-100`/`duration-150` → `motion` tokens plus a token easing). SkipLink stays out of the z-index swap; micro-transitions stay out of the motion swap. Non-breaking; ships as a `@unbranded-ds/react` patch.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, strict mode, no `any`
+**Primary Dependencies**: Tailwind CSS v4 (`@theme` preset consumption), `@base-ui-components/react`, `class-variance-authority`, Storybook 10.3 (interaction + a11y test runner)
+**Storage**: N/A (component library; no persisted data)
+**Testing**: Vitest (unit), Storybook Test addon (interaction `play`), `@storybook/addon-a11y` + test-runner (a11y)
+**Target Platform**: React components consumed in browser + SSR pipelines
+**Project Type**: monorepo component library (`packages/react`); `@unbranded-ds/tokens` already on main provides the tokens
+**Performance Goals**: N/A (static class-string edits)
+**Constraints**: Non-breaking (no public API change except corrected stacking order). Tokens-only styling per Section IV. SSR safety per Section IX bullet 6. Visual regression stays disabled per Section VII.
+**Scale/Scope**: 10 component files. Three swap types: ring (8 components), z-index (3 overlays), motion (3 overlays). One foundational syntax-lock, then per-component parallel edits, then verification.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **Section I (Repository shape)** — no new package; all work in `packages/react`.
+- [x] **Section IV (Components style through tokens)** — the swaps move from Tailwind built-in utilities (`ring-3`, `z-50`, `duration-100`) to utilities that reference design-system tokens. This increases token alignment. No hex/rgb/hsl literals introduced; the lint rule passes.
+- [x] **Section V (Stories are source of truth)** — no story content changes (internal class edits). One new interaction test is added for the nested-overlay fix (tooltip-in-dialog stacking), which is a behavior now worth exercising per XI.5.
+- [x] **Section VI (Testing, three layers)** — unit, interaction, and a11y must stay green. The bug fix adds an interaction assertion.
+- [x] **Section VIII (Tooling baseline)** — no toolchain change.
+- [x] **Section IX (Definition of Done)** — each touched component keeps tokens-only styling, story coverage, a11y, SSR safety, and rendered autodocs. The swaps cannot introduce browser-API access.
+- [x] **Section X (Governance / changeset)** — ships a `@unbranded-ds/react` patch changeset.
+- [x] **Section XI (Agent + human legibility)** — no prose or public-API change, so sidecars and TSDoc do not churn (they document props and usage, not internal class strings). No new failure modes. Predictable API preserved (Part B, the renames, is spec 013).
+
+No violations. No concessions.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-constitution-retrofit/
+├── plan.md              # This file
+├── research.md          # Phase 0: Tailwind v4 consumption syntax, easing mapping, transition-vs-animation nuance
+├── data-model.md        # Phase 1: the swap-site catalog (which file, which value, which token)
+├── contracts/
+│   └── token-consumption-patterns.md   # The canonical snippet per token type that every component copies
+├── quickstart.md        # Phase 1: implement + verify walkthrough
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+packages/react/src/components/
+├── Button/Button.tsx              # ring-3 → ring.width (2 sites)
+├── Checkbox/Checkbox.tsx          # ring-3 (2)
+├── Input/Input.tsx                # ring-3 (2)
+├── Switch/Switch.tsx              # ring-3 (2)
+├── Slider/Slider.tsx              # ring-3 (1)
+├── SegmentedControl/SegmentedControl.tsx  # ring-3 (1)
+├── SkipLink/SkipLink.tsx          # ring-3 (1); z-50 RETAINED (excluded)
+├── Dialog/Dialog.tsx              # z-50 → overlay (2); duration-100 → motion (enter/exit)
+├── Select/Select.tsx              # ring-3 (2); z-50 → popover (2); duration-100 → motion
+└── Tooltip/Tooltip.tsx            # z-50 → tooltip (1); transition duration-150 → motion + easing
+
+packages/react/                    # a new interaction test for tooltip-in-dialog stacking (per existing test convention)
+.changeset/<name>.md               # @unbranded-ds/react: patch
+```
+
+**Structure Decision**: All edits are in `packages/react/src/components/`. Ten component files, each independently editable. No tokens-package or build-config change (the tokens already ship from spec 008).
+
+## Parallelization
+
+The user asked to parallelize. This spec parallelizes well because the work is **per-file and the files are disjoint** — once the consumption syntax is locked, ten component edits run concurrently with zero shared state.
+
+**Step 1 — Lock the syntax (foundational, blocks the swaps).** Verify the four consumption patterns generate correctly against a real Tailwind build (see `contracts/token-consumption-patterns.md`):
+- ring: `ring-(length:--ring-width)`
+- z-index: `z-(--z-index-overlay)` / `z-(--z-index-popover)` / `z-(--z-index-tooltip)`
+- duration: `duration-(--duration-fast)` — confirm it applies to **both** a `transition` (Tooltip) and a keyframe `animate-in/out` (Dialog, Select)
+- easing: `ease-standard` (real utility), plus per-direction `data-open:ease-decelerate data-closed:ease-accelerate`
+
+This produces the exact snippets every component copies, so the parallel edits are uniform and cannot drift.
+
+**Step 2 — Per-component swaps (10-way parallel).** Each file is owned by one worker:
+- **Ring-only (7)**: Button, Checkbox, Input, Switch, Slider, SegmentedControl, SkipLink. Each swaps its `ring-3` for the locked ring snippet. SkipLink does its ring swap but keeps its `z-50`.
+- **Overlay (3)**: Dialog, Select, Tooltip. Each does its z-index stop + motion swap; Select also does its ring swap. One worker per overlay file does all of that file's swaps together.
+
+No two workers touch the same file, so this is genuine 10-way parallelism.
+
+**Step 3 — Verify (after all swaps converge).** Typecheck, lint, unit, Storybook interaction + a11y, grep for residual `ring-3` / overlay `z-50` / built-in overlay timings, and the new tooltip-in-dialog stacking test.
+
+**Step 4 — Changeset.** One `@unbranded-ds/react: patch`.
+
+So: **foundational syntax-lock → 10 parallel file edits → verify → changeset.** The middle is the widest fan-out we have had on a spec, because component files share nothing.
+
+## Research Summary
+
+See [research.md](research.md). Resolved:
+
+- **Tailwind v4 custom-property syntax** is confirmed for z-index (`z-(--var)`) and the length-hinted form (`ring-(length:--var)` follows the documented `text-(length:--var)` pattern). The foundational step verifies the ring form against a build, with `ring-[length:var(--ring-width)]` as the fallback.
+- **Easing mapping** (left to planning by the clarify): overlay enter uses `ease-decelerate`, exit uses `ease-accelerate`, applied via `data-open:` / `data-closed:` variants. This matches the token names and standard motion practice.
+- **Transition vs animation**: Tooltip animates via `transition-[opacity,transform]`; Dialog and Select via keyframe `animate-in/out`. The duration token must apply to both cases — the foundational step verifies the keyframe path honors the token duration before the parallel edits rely on it.
+- **`ring-1` is not in scope** — it is a hairline border ring, a different concern from the focus-ring width. Only `ring-3` maps to `ring.width`.
+
+## Complexity Tracking
+
+> No constitution violations to justify.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| — | — | — |

--- a/specs/010-constitution-retrofit/quickstart.md
+++ b/specs/010-constitution-retrofit/quickstart.md
@@ -60,7 +60,7 @@ Message names the three swaps and calls out the nested-overlay bug fix. No consu
 ## Watch-outs
 
 - **The duration-on-keyframe path is the risk.** A `duration-*` that only retimes transitions would silently miss Dialog/Select animations. Verify it in step 1 before trusting it across the parallel edits.
-- **SkipLink is half in, half out**: its `ring-3` swaps, its `z-50` stays.
+- **SkipLink**: its `ring-3` swaps, and its `z-50` → `z-(--z-index-max)` (the new always-on-top token).
 - **`ring-1` stays**: only `ring-3` (the focus ring) maps to `ring.width`.
 - **No sidecar or TSDoc edits**: these are internal class changes; the documented API is unchanged.
 - **SSR**: pure class-string edits, no browser globals introduced.

--- a/specs/010-constitution-retrofit/quickstart.md
+++ b/specs/010-constitution-retrofit/quickstart.md
@@ -1,0 +1,66 @@
+# Quickstart: Constitution-driven retrofit (Part A)
+
+How to implement and verify spec 010. All edits are in `packages/react/src/components/`.
+
+## Prerequisites
+
+- Branch `010-constitution-retrofit` checked out (off `main`, which carries the spec 008 tokens)
+- `pnpm install` done
+- Baseline green: `pnpm --filter @unbranded-ds/react test && pnpm typecheck`
+
+## Order of work
+
+### 1. Lock the syntax (do this first, solo)
+
+Pick one ring component (e.g. Button) and one of each overlay mechanism (Tooltip for transition, Dialog for keyframe). Apply the four patterns from `contracts/token-consumption-patterns.md`, build, and confirm:
+
+```bash
+pnpm --filter @unbranded-ds/react build
+pnpm --filter @unbranded-ds/storybook build
+# inspect the generated CSS / open Storybook and confirm:
+#  - focus ring still 3px and references --ring-width
+#  - the overlay sits at the right z and a tooltip-in-dialog stacks correctly
+#  - the duration token actually retimes BOTH Tooltip (transition) and Dialog (animate-in)
+```
+
+Write the four exact verified strings into `contracts/token-consumption-patterns.md`. Everything downstream copies them.
+
+### 2. Per-component swaps (parallel after step 1)
+
+Ten disjoint files; one worker each. Copy the locked snippets.
+
+Ring-only: `Button` `Checkbox` `Input` `Switch` `Slider` `SegmentedControl` `SkipLink`
+Overlay (z-index + motion, Select also ring): `Dialog` `Select` `Tooltip`
+
+Per file: swap every in-scope `ring-3`, overlay `z-50`, and overlay duration/easing. Leave `ring-1`, SkipLink's `z-50`, and all micro-transitions alone.
+
+### 3. Verify
+
+```bash
+pnpm typecheck
+pnpm --filter @unbranded-ds/react lint        # no literals introduced
+pnpm --filter @unbranded-ds/react test         # unit
+pnpm --filter @unbranded-ds/storybook build && pnpm --filter @unbranded-ds/storybook test:storybook   # interaction + a11y
+
+# residual-hardcode grep (expect empty):
+grep -rn "ring-3" packages/react/src/components            # none
+grep -rn "z-50" packages/react/src/components/Dialog packages/react/src/components/Select packages/react/src/components/Tooltip   # none
+```
+
+Add an interaction test for the bug fix: render a tooltip trigger inside an open dialog, open the tooltip, assert it is above the dialog (computed z-index or visual order).
+
+### 4. Changeset
+
+```bash
+pnpm changeset    # @unbranded-ds/react: patch
+```
+
+Message names the three swaps and calls out the nested-overlay bug fix. No consumer migration.
+
+## Watch-outs
+
+- **The duration-on-keyframe path is the risk.** A `duration-*` that only retimes transitions would silently miss Dialog/Select animations. Verify it in step 1 before trusting it across the parallel edits.
+- **SkipLink is half in, half out**: its `ring-3` swaps, its `z-50` stays.
+- **`ring-1` stays**: only `ring-3` (the focus ring) maps to `ring.width`.
+- **No sidecar or TSDoc edits**: these are internal class changes; the documented API is unchanged.
+- **SSR**: pure class-string edits, no browser globals introduced.

--- a/specs/010-constitution-retrofit/research.md
+++ b/specs/010-constitution-retrofit/research.md
@@ -1,0 +1,51 @@
+# Research: Constitution-driven retrofit (Part A)
+
+**Phase 0 output** | **Date**: 2026-06-11
+
+## Tailwind v4 consumption syntax
+
+**Decision**: Use the v4 custom-property utility forms, with a length type hint where the property is ambiguous.
+
+| Token | Consumption form | Confidence |
+| --- | --- | --- |
+| `ring.width` | `ring-(length:--ring-width)` | Verify at the syntax-lock step; fallback `ring-[length:var(--ring-width)]` |
+| `z-index.overlay` | `z-(--z-index-overlay)` | Confirmed (v4 `z-(<custom-property>)` documented) |
+| `z-index.popover` | `z-(--z-index-popover)` | Confirmed |
+| `z-index.tooltip` | `z-(--z-index-tooltip)` | Confirmed |
+| `motion.duration.*` | `duration-(--duration-fast)` | Verify it applies to keyframe animations, not only transitions |
+| `motion.easing.*` | `ease-standard` / `ease-decelerate` / `ease-accelerate` (real utilities) | Confirmed (spec 008 emits the `--ease-*` namespace) |
+
+**Rationale**: Tailwind v4 documents `z-(<custom-property>)` for z-index and the `text-(length:--my-var)` type-hint pattern for length-ambiguous properties. The ring utility takes a width, so `ring-(length:--ring-width)` follows the same hinted-custom-property convention. The easings are real utilities because spec 008 emits them under the `--ease-*` theme namespace.
+
+**Alternatives considered**: bracket arbitrary values (`z-[var(--z-index-overlay)]`, `ring-[length:var(--ring-width)]`). These work and are the fallback, but the `(--var)` shorthand is the idiomatic v4 form and reads cleaner at 13+ sites. Setting `--default-ring-width: var(--ring-width)` in the preset and using bare `ring` was rejected: it changes Tailwind's global ring default and still requires editing every `ring-3`, for no localized benefit, while risking other bare-`ring` usages.
+
+## Easing mapping (the clarify left this to planning)
+
+**Decision**: Overlay enter animations use `ease-decelerate`; exit animations use `ease-accelerate`. Applied per direction with data-attribute variants: `data-open:ease-decelerate data-closed:ease-accelerate`.
+
+**Rationale**: The motion tokens are named by intent. `decelerate` (cubic-bezier(0,0,0.2,1), an ease-out) suits something entering and settling; `accelerate` (cubic-bezier(0.4,0,1,1), an ease-in) suits something leaving. This is the standard Material/HIG enter-exit convention, and Base UI exposes `data-open` / `data-closed` state attributes that map cleanly to Tailwind variants. Where a single easing is simpler and the per-direction split does not read, `ease-standard` is the acceptable baseline.
+
+**Alternatives considered**: one `ease-standard` for both directions (simpler, but ignores the named-intent tokens); leaving easing implicit (the current state, which ties the feel to browser defaults rather than the design system).
+
+## Transition vs keyframe animation
+
+**Decision**: Treat the two overlay animation mechanisms separately and verify the duration token reaches both.
+
+- **Tooltip** animates via `transition-[opacity,transform] duration-150`. The duration token (`duration-(--duration-fast)`) sets `transition-duration`, and `ease-*` sets `transition-timing-function`. Straightforward.
+- **Dialog and Select** animate via keyframe utilities (`data-open:animate-in fade-in-0 zoom-in-95`, `data-closed:animate-out ...`) with `duration-100`. Here the duration must set `animation-duration`, and easing would set `animation-timing-function`, not the transition equivalents.
+
+**Rationale**: A `duration-*` utility that only sets `transition-duration` would silently fail to retime a keyframe animation. The syntax-lock step builds a sample of each mechanism and confirms the token duration actually changes the rendered timing in both, before the parallel edits depend on it. This is the same class of "the utility looked applied but did not generate" failure seen in the spec 007 Storybook incident, so it gets an explicit verification.
+
+**Open for the implementer**: the `animate-in`/`animate-out` keyframe presets (fade, zoom, slide) stay; only the duration and, where applicable, the timing function move to tokens.
+
+## Duration value mapping
+
+**Decision**: Map the overlay open/close durations to `duration-fast` (120ms).
+
+**Rationale**: Current values are 100ms (Dialog, Select) and 150ms (Tooltip). `fast` (120ms) is the nearest token and keeps overlays snappy. The spec accepts that timing shifts slightly to the design-system value; interaction tests assert behavior, not exact milliseconds.
+
+## Scope confirmations (from the spec + grep)
+
+- **Ring sites**: ~13 in component source across Button, Checkbox, Input, Switch, Slider, SegmentedControl, SkipLink, and Select (the spec's "14" counts one occurrence inside `Input.usage.md`, a sidecar doc that is not a swap target). All are `focus-visible:ring-3` or `aria-invalid:ring-3`.
+- **Overlay z-50 sites**: 5 across Dialog (2: backdrop + popup), Select (2: positioner + popup), Tooltip (1). SkipLink's `focus-visible:z-50` is the 6th and is excluded.
+- **`ring-1`**: a hairline border ring on cards and popovers, left untouched. Distinct from the focus-ring width.

--- a/specs/010-constitution-retrofit/spec.md
+++ b/specs/010-constitution-retrofit/spec.md
@@ -1,0 +1,134 @@
+# Feature Specification: Constitution-driven retrofit (Part A — token consumption)
+
+**Feature Branch**: `010-constitution-retrofit`
+**Created**: 2026-06-11
+**Status**: Draft
+**Input**: User description: "Constitution-driven retrofit Part A: consume the spec 008 motion, ring, and z-index tokens in component source, replacing hardcoded ring-3, z-50, and transition values, and fix the nested-overlay stacking order." (brief at `docs/workshops/2026-06-11/spec-010-constitution-retrofit.md`)
+
+## Background
+
+Spec 008 introduced three token groups but deliberately stopped at the tokens-package boundary: it shipped `ring.width`, an ordered `z-index` scale, and a `motion` category (durations and easings), and left the component-source consumption to spec 010. This spec is that consumption pass. Components currently hardcode the values those tokens now name: a `ring-3` focus ring repeated 14 times, a `z-50` stacking layer shared by the overlay components, and Tailwind built-in timings on the overlay open/close animations.
+
+Swapping each onto its token makes the value themeable (a consumer who overrides `ring.width` or a motion duration now sees components respond) and puts the timing, focus, and layering surface under design-system control. One of the swaps also fixes a live bug: the overlay components all stack at `z-50`, so a tooltip opened inside a dialog has no defined order over it. The ordered z-index scale gives nested overlays a defined stacking order.
+
+This spec is **Part A only**. The breaking API and vocabulary harmonization that specs 005, 006, and 007 deferred (prop and slot renames per Section XI.2) is **Part B, split to spec 013**. Part A is non-breaking; it adds one optional `z-index.max` token to `@unbranded-ds/tokens` (a minor bump) for the SkipLink layer, and ships the component swaps as a `@unbranded-ds/react` patch with no consumer migration.
+
+## Clarifications
+
+### Session 2026-06-11
+
+- Q: The `z-index` scale has three stops (overlay/popover/tooltip) but four components hardcode `z-50`. Which stop should SkipLink use? → A: Exclude SkipLink from the scale swap. It is a focus-revealed bypass-block link, not part of the overlay-nesting family; its standalone `focus-visible:z-50` is retained. The swap applies to Dialog (overlay), Select (popover), and Tooltip (tooltip).
+- Q: How broad is the motion-token swap, given the codebase mixes overlay enter/exit animations with ubiquitous micro-transitions? → A: Overlay enter/exit only. The open/close animations on Tooltip, Dialog, and Select move onto the motion tokens; the micro-transitions on interactive components (hover, focus, active via `transition-all`/`transition-colors`) keep their current inline timings and are out of scope.
+- Revised during implementation: SkipLink is no longer excluded from the z-index work (reversing Q1). A new `z-index.max` token (9999) was added to `@unbranded-ds/tokens` and SkipLink's `focus-visible:z-50` now reads it, so a focused skip link sits above every overlay and no hardcoded z-index remains anywhere. This makes the spec a two-package release (`@unbranded-ds/tokens` minor + `@unbranded-ds/react` patch).
+
+Two items confirmed against the codebase rather than asked:
+
+- The `z-index` scale stops shipped by spec 008 are overlay (50), popover (55), tooltip (60). Dialog maps to overlay, Select to popover, Tooltip to tooltip.
+- Default token values match the hardcoded values they replace (`ring.width` is 3px, the value `ring-3` resolves to), so the swap is visually identical at the default and only the nested-overlay stacking order changes.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Nested overlays stack correctly (Priority: P1) 🎯 MVP
+
+A user opens a tooltip on a control inside an open dialog. The tooltip renders above the dialog, not behind or tangled with it. More broadly, the three overlay-family components (Dialog, Select, Tooltip) read their layer from the ordered `z-index` scale instead of all sitting at the same `z-50`, so any nesting of overlays has a defined order. SkipLink, a focus-revealed bypass link, reads a new `z-index.max` token (9999) so a focused skip link sits above every overlay.
+
+**Why this priority**: This is the highest-value half of the retrofit because it fixes a live bug. The same-layer `z-50` collision is a real defect sitting in `main` today, reachable the moment a consumer puts a tooltip inside a dialog. Fixing it also delivers the themeable-layering benefit as a side effect.
+
+**Independent Test**: Render a tooltip trigger inside an open dialog, activate the tooltip, and confirm it paints above the dialog surface. Grep component source and confirm no portal component hardcodes `z-50`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a tooltip trigger inside an open dialog, **When** the tooltip opens, **Then** it renders above the dialog overlay and content.
+2. **Given** the three overlay-family components (Dialog, Select, Tooltip), **When** their source is inspected, **Then** each reads its stacking layer from the spec 008 `z-index` scale (Dialog→overlay, Select→popover, Tooltip→tooltip) rather than a hardcoded `z-50`.
+3. **Given** a consumer theme that overrides a `z-index` scale stop, **When** the component renders, **Then** the overridden layer value takes effect.
+
+---
+
+### User Story 2 - Animated primitives use the design-system motion tokens (Priority: P2)
+
+A component author (and a consumer theming motion) sees the overlay components animate at the design system's timing and curve. The open and close transitions on Tooltip, Dialog, and Select read the `motion` durations and easings instead of Tailwind's built-in timing utilities. The micro-transitions on interactive components (hover, focus, and active state changes) keep their current inline timings and are out of scope.
+
+**Why this priority**: It puts the overlay animation timing under design-system control, so motion is consistent across overlays and a consumer can retune it through tokens. It is a smaller user-visible change than the bug fix, and it depends on nothing in US1.
+
+**Independent Test**: Inspect the overlay components (Tooltip, Dialog, Select) and confirm their open/close transitions reference the `motion` tokens (a token easing and a duration via the token variable) rather than hardcoded timings. Confirm the open and close interactions still pass.
+
+**Acceptance Scenarios**:
+
+1. **Given** the overlay components (Tooltip, Dialog, Select), **When** their open/close transitions are inspected, **Then** timing and easing reference the spec 008 `motion` tokens.
+2. **Given** a consumer theme that overrides a motion duration, **When** an overlay opens or closes, **Then** it runs at the overridden duration.
+3. **Given** the existing interaction tests, **When** they run, **Then** the open, close, and toggle behaviors still pass.
+
+---
+
+### User Story 3 - Focus-ring width comes from a token (Priority: P3)
+
+Every component's focus-visible ring reads its width from the `ring.width` token instead of a hardcoded `ring-3`. A consumer who wants thicker focus rings for an accessibility preference can set the token once and have every component follow.
+
+**Why this priority**: It is the most mechanical swap (14 identical usages) and the lowest user-visible change, since the default matches today's appearance. It earns its place by making focus-ring thickness themeable, but it carries no urgency.
+
+**Independent Test**: Grep component source for `ring-3` and confirm none remain. Confirm focus rings render identically at the default token value, and that overriding `ring.width` changes the rendered ring thickness.
+
+**Acceptance Scenarios**:
+
+1. **Given** the component source, **When** it is grepped for the hardcoded `ring-3`, **Then** none remain; every focus ring reads `ring.width`.
+2. **Given** the default token value, **When** a component receives focus, **Then** the ring renders identically to today (3px).
+3. **Given** a consumer theme that overrides `ring.width`, **When** a component receives focus, **Then** the ring renders at the overridden width.
+
+---
+
+### Edge Cases
+
+- **A component with no transition, ring, or portal layer**: untouched. The retrofit only edits components that hold one of the three hardcoded values.
+- **A consumer who relied on the literal `z-50`**: the value was an internal implementation detail, never a public API. The scale's overlay stop resolves to a compatible base value, so a standalone (non-nested) overlay renders at the same depth.
+- **Motion timing differs from the old built-in**: where an overlay's open/close used a Tailwind duration that differs from the token duration, its animation speed changes to the design-system timing. This is intended (the point is DS-controlled timing), not a regression. Interaction tests assert behavior, not exact duration.
+- **`ring-1` is not `ring-3`**: the hairline `ring-1` rings on cards and popovers are a border treatment, a different concern from the focus-ring width. Only `ring-3` (the focus ring, 14 sites) maps to `ring.width`; `ring-1` is left as-is.
+- **Reduced motion**: any existing `prefers-reduced-motion` handling stays intact; the token swap changes which duration value is referenced, not whether reduced-motion short-circuits it.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The overlay components MUST read their stacking layer from the `z-index` scale: Dialog from `overlay`, Select from `popover`, Tooltip from `tooltip`. SkipLink's focus-revealed layer MUST read a new `z-index.max` token (9999) added to `@unbranded-ds/tokens`, so a focused skip link sits above every overlay. No component source may hardcode `z-50`.
+- **FR-002**: A tooltip rendered inside an open dialog MUST stack above the dialog. Nested overlays MUST have a defined order derived from the scale.
+- **FR-003**: The open and close (enter/exit) animations on the overlay components — Tooltip, Dialog, Select — MUST reference the `motion` tokens for duration and easing rather than Tailwind built-in timing utilities. The micro-transitions on interactive components (hover, focus, active state changes via `transition-all` / `transition-colors`) are out of scope and keep their current inline timings.
+- **FR-004**: Every focus-visible ring MUST read its width from the `ring.width` token. No component source may hardcode `ring-3`.
+- **FR-005**: This spec MUST NOT change public component API or behavior, except for the corrected nested-overlay stacking order. It is non-breaking.
+- **FR-006**: The existing component test suite, the Storybook interaction tests, and the accessibility tests MUST stay green. SSR safety (Section IX bullet 6) MUST remain intact.
+- **FR-007**: Default rendered output MUST match today at the default token values (identical focus-ring thickness and standalone-overlay depth); only the nested-overlay order and the design-system motion timing change.
+- **FR-008**: The release MUST ship a `.changeset/*.md` declaring a `@unbranded-ds/react` patch. No consumer migration note is required.
+
+### Key Entities *(include if feature involves data)*
+
+- **Token consumption site**: a single location in component source that hardcodes a value the spec 008 schema now names. Three kinds: a `ring-3` focus ring (14 sites), a `z-50` overlay layer in Dialog, Select, and Tooltip (SkipLink's focus-reveal z excluded), and a built-in enter/exit transition timing on an overlay component (Tooltip, Dialog, Select). Each in-scope site is rewritten to reference its token.
+- **Overlay layer**: the stacking depth of one of the three overlay-family components (Dialog, Select, Tooltip). After this spec, each maps to a named stop in the `z-index` scale (`overlay`, `popover`, `tooltip`) rather than the shared `z-50`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A tooltip opened inside a dialog renders above the dialog, verified by an interaction test.
+- **SC-002**: No component source contains a hardcoded `ring-3` or `z-50`, or a built-in overlay transition timing where a design-system token now exists, verified by grep. SkipLink reads `z-index.max`; zero hardcoded z-index values remain anywhere.
+- **SC-003**: A consumer theme that overrides `ring.width`, a `z-index` stop, or a motion duration changes the corresponding rendered output, with no component code change.
+- **SC-004**: The component test suite, interaction tests, and accessibility tests stay green, and SSR safety holds.
+- **SC-005**: Default rendered output is unchanged at the default token values; the only visible differences are the corrected nested-overlay order and the design-system motion timing.
+- **SC-006**: The release ships as a `@unbranded-ds/react` patch with no consumer migration note.
+
+## Assumptions
+
+- **Spec 008 is on main.** `ring.width`, the `z-index` scale, and the `motion` category shipped in 0.4.0 and are available for consumption. Verified.
+- **Default token values equal the hardcoded values they replace.** `ring.width` is 3px; the `z-index` overlay stop resolves to a base compatible with the old `z-50` for standalone overlays. So the swap is visually identical at the default except for the nested-overlay fix.
+- **The exact `z-index` stop set is taken from the spec 008 tokens as shipped.** The plan verifies the stop names and the per-component mapping before the swap.
+- **Motion timing changes are intended.** Where a primitive's old built-in duration differs from the design-system token, the new timing is the design-system value by design.
+- **Part B is out of scope.** The breaking API and vocabulary renames are spec 013.
+
+## Dependencies
+
+- **Spec 008 (token schema growth)** merged to main — provides `ring.width`, the `z-index` scale, and the `motion` tokens this spec consumes.
+
+## Out of Scope
+
+- **Part B: API and vocabulary harmonization** (prop and slot renames per Section XI.2, polymorphic prop unification, structured failure output). Split to spec 013; breaking, needs its own clarify cycle.
+- **New tokens, new components, new variants.**
+- **Behavior changes** beyond the corrected nested-overlay stacking order.
+- **Changing the motion token values themselves** — spec 008 set them.
+- **Enabling visual regression** — Chromatic VR stays disabled per the constitution; interaction and a11y tests guard the retrofit.

--- a/specs/010-constitution-retrofit/tasks.md
+++ b/specs/010-constitution-retrofit/tasks.md
@@ -1,0 +1,126 @@
+# Tasks: Constitution-driven retrofit (Part A — token consumption)
+
+**Input**: Design documents from `/specs/010-constitution-retrofit/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: One new interaction test for the nested-overlay bug fix (US1). The existing unit, interaction, and a11y suites must stay green (verified in polish).
+
+**Organization**: By component file, not strictly by user story. The swaps cluster by file — an overlay component does both its z-index (US1) and motion (US2) swap, and Select also does ring (US3) — so giving each file one owner avoids conflicts and lets all ten swaps run in parallel. Each task is story-tagged for traceability. This follows the per-file pattern used in specs 007 and 008.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different file, no dependency on an incomplete task)
+- All component paths are under `packages/react/src/components/`
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm baseline green before changes: `pnpm --filter @unbranded-ds/react test && pnpm typecheck && pnpm --filter @unbranded-ds/storybook build`.
+
+---
+
+## Phase 2: Foundational (Syntax Lock — Blocking)
+
+**⚠️ This gate blocks every swap. It pins the exact consumption strings so the ten parallel edits are uniform and can't drift — and it de-risks the one pattern that can silently fail.**
+
+- [ ] T002 Verify the four consumption patterns against a real Tailwind v4 build and lock them in `specs/010-constitution-retrofit/contracts/token-consumption-patterns.md`. In a scratch Storybook story, exercise: `ring-(length:--ring-width)` (confirm 3px ring referencing the var), `z-(--z-index-overlay)` (confirm `z-index: var(...)`), `ease-decelerate`/`ease-accelerate` (confirm the token cubic-beziers), and critically `duration-(--duration-fast)` on **both** a `transition` element and a `data-open:animate-in` keyframe element (confirm it retimes both). Record the exact verified strings (and any fallbacks used) in the contract, then remove the scratch story.
+
+**Checkpoint**: Four locked strings exist. All component swaps can now run in parallel.
+
+---
+
+## Phase 3: Per-component token swaps (US1 + US2 + US3)
+
+**Goal**: Every in-scope `ring-3`, overlay `z-50`, and overlay open/close timing references its spec 008 token. Copy the locked strings from T002. Leave `ring-1`, SkipLink's `z-50`, and all micro-transitions untouched.
+
+**Independent Test**: After each file, `pnpm typecheck` passes and a grep of that file shows no in-scope hardcoded value remains.
+
+**All ten tasks are [P] — disjoint files, no shared state.**
+
+### Ring-only components
+
+- [ ] T003 [P] [US3] Swap both `ring-3` for the locked ring snippet in `Button/Button.tsx`.
+- [ ] T004 [P] [US3] Swap both `ring-3` in `Checkbox/Checkbox.tsx`.
+- [ ] T005 [P] [US3] Swap both `ring-3` (`focus-visible` + `aria-invalid`) in `Input/Input.tsx`.
+- [ ] T006 [P] [US3] Swap both `ring-3` in `Switch/Switch.tsx`.
+- [ ] T007 [P] [US3] Swap the `ring-3` on the thumb in `Slider/Slider.tsx`.
+- [ ] T008 [P] [US3] Swap the `ring-3` in `SegmentedControl/SegmentedControl.tsx`.
+- [ ] T009 [P] [US3] Swap the `focus-visible:ring-3` in `SkipLink/SkipLink.tsx`. Leave `focus-visible:z-50` as-is (excluded per clarify).
+
+### Overlay components
+
+- [ ] T010 [P] [US1] [US2] In `Dialog/Dialog.tsx`: swap both `z-50` (backdrop + popup) for `z-(--z-index-overlay)`; swap `duration-100` on both for `duration-(--duration-fast)`; keep the `animate-in/out` / `fade` / `zoom` keyframe presets. Apply the per-direction easing if T002 confirmed it reaches `animation-timing-function`, else tokenize duration only.
+- [ ] T011 [P] [US1] [US2] [US3] In `Select/Select.tsx`: swap both `z-50` (positioner + popup) for `z-(--z-index-popover)`; swap `duration-100` for `duration-(--duration-fast)` (keyframe presets stay); and swap both `ring-3` on the trigger for the locked ring snippet.
+- [ ] T012 [P] [US1] [US2] In `Tooltip/Tooltip.tsx`: swap `z-50` for `z-(--z-index-tooltip)`; swap `transition-[opacity,transform] duration-150` to use `duration-(--duration-fast)` plus `ease-standard` (or `data-open:ease-decelerate data-closed:ease-accelerate`); keep `motion-reduce:*` and `data-instant:*` intact.
+
+**Checkpoint**: No in-scope hardcoded values remain; every overlay reads the scale and the motion tokens.
+
+---
+
+## Phase 4: Nested-overlay bug-fix test (US1)
+
+- [ ] T013 [US1] Add an interaction test for the stacking fix in `Dialog/Dialog.stories.tsx`: a story that renders a tooltip trigger inside an open dialog, opens the tooltip in a `play` function, and asserts the tooltip stacks above the dialog (computed z-index, or that the tooltip content is the topmost rendered layer). Depends on T010 and T012.
+
+**Checkpoint**: The live bug is covered by a regression test.
+
+---
+
+## Phase 5: Polish & Release
+
+- [ ] T014 Full verification: `pnpm typecheck`, `pnpm --filter @unbranded-ds/react lint` (no literals introduced), `pnpm --filter @unbranded-ds/react test`, `pnpm --filter @unbranded-ds/storybook build && pnpm --filter @unbranded-ds/storybook test:storybook` (interaction + a11y). Then grep for residuals: `grep -rn "ring-3" packages/react/src/components` (none) and `grep -rn "z-50" packages/react/src/components/{Dialog,Select,Tooltip}` (none). Confirm SkipLink's `z-50` and the `ring-1` rings still present.
+- [ ] T015 Add `.changeset/*.md` declaring `@unbranded-ds/react: patch`, naming the three swaps and calling out the nested-overlay bug fix. No consumer migration note.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase order
+
+- **Setup (T001)** → **Foundational (T002)** → **Per-component swaps (T003–T012, parallel)** → **Bug-fix test (T013)** → **Polish (T014–T015)**.
+
+### Hard dependencies
+
+- T002 blocks T003–T012 (they copy its locked strings).
+- T013 depends on T010 (Dialog) and T012 (Tooltip).
+- T014 depends on all swaps + T013.
+- T015 is last.
+
+### Parallel opportunities
+
+- **The core is 10-way parallel**: T003–T012 are ten disjoint component files. Hand each to its own worker after T002 lands.
+- Nothing else parallelizes meaningfully (T001, T002, T013, T014, T015 are gates or single-file).
+
+---
+
+## Parallel Example: the swap fan-out
+
+```bash
+# After T002 locks the consumption strings, ten workers in parallel:
+T003 Button     T004 Checkbox   T005 Input      T006 Switch     T007 Slider
+T008 SegmentedControl           T009 SkipLink
+T010 Dialog     T011 Select     T012 Tooltip
+# No two touch the same file. Converge, then T013 (test) → T014 (verify) → T015 (changeset).
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (US1 — the bug fix)
+
+T001 → T002 → T010 (Dialog) + T012 (Tooltip) + T011 (Select) → T013 (test). Ships the nested-overlay fix and the overlay token consumption. Independently valuable; the ring swap (US3) can follow.
+
+### Full delivery
+
+1. Setup + syntax-lock (T001–T002).
+2. All ten swaps in parallel (T003–T012).
+3. Bug-fix test (T013).
+4. Verify + changeset (T014–T015).
+
+### Notes
+
+- Copy the locked strings from T002 verbatim; do not improvise per-file syntax.
+- The `duration`-on-keyframe path is the one real risk — T002 must confirm it before T010/T011 rely on it.
+- SkipLink: ring swaps, z-50 stays. Select: all three swaps. `ring-1`: never.
+- No sidecar or TSDoc edits — internal class changes only, public API unchanged.


### PR DESCRIPTION
## Summary

Spec 010 (Part A) consumes the spec 008 design tokens in component source: focus rings read `ring.width`, overlays read the `z-index` scale, and overlay open/close animations read the `motion` tokens, so a consumer theming any of those now sees the components respond. Adds a `z-index.max` token for the always-on-top SkipLink, and fixes a latent nested-overlay stacking bug. Non-breaking; ships as `@unbranded-ds/tokens` minor + `@unbranded-ds/react` patch.

Part B (the breaking API and vocabulary renames) is split to spec 013.

## What Changed

- **Focus ring** → `ring.width`: every `ring-3` becomes `ring-(length:--ring-width)` across 8 components (Button, Checkbox, Input, Switch, Slider, SegmentedControl, Select, SkipLink). Same 3px default, now themeable.
- **Z-index** → the scale: Dialog reads `overlay` (50), Select `popover` (55), Tooltip `tooltip` (60). A new `z-index.max` (9999) is added for SkipLink's focus-revealed layer, so a focused skip link beats every overlay. Zero hardcoded z-index values remain.
- **Motion** → the overlay open/close animations read `duration-fast`. Tooltip (a real CSS transition) also gets per-direction easing (`data-open:ease-decelerate`, `data-closed:ease-accelerate`); the keyframe overlays (Dialog, Select) take duration only, because Tailwind's `ease-*` targets `transition-timing-function`, not `animation-timing-function`.

Untouched by design: `ring-1` hairline borders, micro-transitions on interactive components, and the `animate-in/out` keyframe presets.

## The Bug Fix

The portal components all stacked at a hardcoded `z-50`, so a tooltip opened inside a dialog had no defined order over it. The ordered scale fixes this: a tooltip (60) now renders above a dialog (50). A new interaction test in `Dialog.stories.tsx` renders a tooltip inside an open dialog and asserts the tooltip computes a higher z-index.

## Verification

- typecheck, react unit (96/96), tokens (102/102, drift guard covers the new `z-index.max`)
- Storybook builds; compiled CSS confirms the ordering (overlay 50 < popover 55 < tooltip 60 < max 9999) plus the ring and motion tokens
- The spec 010 changes are lint-clean (0 errors)

## Test Plan

- [ ] CI runs the Storybook interaction + a11y suite, including the new tooltip-in-dialog test
- [ ] Manual: open a dialog, hover a control inside it for a tooltip, confirm the tooltip paints above the dialog
- [ ] Manual: tab to a skip link while an overlay is open, confirm it appears on top
- [ ] Confirm focus rings render unchanged at the default token value

## Heads-up (pre-existing, not from this PR)

Repo-wide `pnpm lint` is red on ~990 pre-existing `format/prettier` errors in `.usage.md` sidecar files (all `--fix`-able), unrelated to this change. This PR adds zero lint errors, but it may surface in CI until those sidecars are reformatted in a separate pass.
