### PR TITLE
ci: skip changeset-check on the Changesets release PR

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -8,6 +8,10 @@ jobs:
   changeset-check:
     name: Verify changeset present for package changes
     runs-on: ubuntu-latest
+    # Skip the Changesets release PR. It deletes the .changeset/*.md files by design
+    # when it versions packages, so the "needs a changeset" gate below would always
+    # misfire on it. Every real contributor PR is still gated.
+    if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The `changeset-check` gate ("Verify changeset present for package changes") fails on the Changesets release PR (`changeset-release/*`), because that PR deletes the `.changeset/*.md` files when it versions the packages. The gate is meant for contributor PRs (enforce that a changeset accompanies a package change), not the release PR that consumes them. This guards the job with `github.head_ref` so the bot's release PR skips it while every real PR stays gated.

## Why

- `changeset-check.yml` runs `changeset status`, which errors when packages changed with no changeset present.
- The release PR's whole job is to remove the changesets and apply version bumps, so it legitimately has none. The gate misfires on it (the failing run was job 80915104325 on PR #106).
- This is not part of versioning or publishing. Those run in `release.yml` via `changesets/action`. Skipping the check on the release PR costs no release capability.

## Effect

- Real contributor PRs: unchanged, still must include a changeset.
- The `changeset-release/*` PR: `changeset-check` skips, so it can go green and be merged to publish.