### PR TITLE
spec 013: API & vocabulary harmonization (XI.2 made compat-first, zero renames)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,20 +1,23 @@
 <!--
 SYNC IMPACT REPORT
 ==================
-Version change:  1.1.1 → 1.2.0  [MINOR — Section III theming contract expanded]
-Bump rationale:  Names the per-axis theme composition API (spec 009) and carves
-                 out theme-extension tokens as a documented escape hatch from the
-                 build-time schema lock. Both are new, materially expanded guidance
-                 in an existing principle, not a backward-incompatible redefinition:
-                 single-axis `data-theme` and the schema lock both still hold. New
-                 guidance in a standing section is a MINOR bump per Section X.
+Version change:  1.2.0 → 1.3.0  [MINOR — Section XI.2 made compat-first]
+Bump rationale:  Reframes the API-shape vocabulary as compatibility-first (spec
+                 013): where a component wraps shadcn/ui or Base UI, its public
+                 prop and slot names follow the upstream convention, and the
+                 shared vocabulary governs only props/slots the design system
+                 introduces. Encodes the polymorphic-by-lineage rule (asChild for
+                 shadcn Slot triggers, render for Base UI, as for leaf primitives)
+                 and drops the separate `intent` prop (folded into `variant`,
+                 shadcn-style). New and corrected guidance in a standing section,
+                 not a backward-incompatible redefinition, so a MINOR bump.
 
 Modified principles:
-  - Section III (Theming contract): Adds the recognized theme axes, aesthetic
-    (`data-theme`) and density (`data-density`), and the rule that density
-    overrides aesthetic on a token collision. Clarifies that the build-time
-    schema lock binds the CANONICAL token set, and names per-theme extension
-    tokens as a documented escape hatch that lives outside the locked schema.
+  - Section XI.2 (API shape): Compatibility with shadcn/ui and Base UI is the
+    higher rule; the shared vocabulary applies to introduced props/slots only.
+    Variant axes use shadcn's `variant`/`size` (no separate `intent`); compound
+    slots follow the upstream public-API names; polymorphic rendering follows
+    lineage (asChild / render / as) rather than one unified prop.
 
 Added sections:       N/A.
 Removed sections:     N/A.
@@ -25,6 +28,8 @@ Templates audited:
   ✅ .specify/templates/tasks-template.md  — No change required.
 
 Prior amendments:
+  - 1.2.0 (2026-06-12): Expanded Section III with the per-axis theme composition
+    API and theme-extension tokens. Per spec 009.
   - 1.1.1 (2026-05-16): Extended Section VIII's MCP entry with
     `@modelcontextprotocol/sdk` as the runtime for local stdio MCP servers.
     Per spec 005.
@@ -235,13 +240,13 @@ Every piece of written content — story descriptions, autodoc strings, README f
 
 ### XI.2 API shape
 
-Component APIs are predictable from analogy:
+Component APIs are predictable from analogy, and they stay compatible with the upstream libraries they wrap (shadcn/ui and Base UI). Compatibility is the higher rule: where a component wraps an upstream library, its public prop and slot names follow that library's convention, so a consumer or agent who knows shadcn/Base UI predicts ours. The shared vocabulary below governs props and slots the design system introduces, not ones inherited from upstream.
 
-- Compound components use the `<Component.Slot>` pattern consistently. A `*.Trigger` on one component means the same thing as a `*.Trigger` on any other, and the same holds for `*.Root`, `*.Content`, `*.Item`, and any future slot name.
-- Variant axes use a small shared vocabulary: `variant`, `size`, `intent`, `disabled`. No bespoke synonyms across components.
-- Polymorphic rendering, when present, uses one prop name across the codebase.
+- Compound slots follow the upstream convention the public API uses. Our shadcn-style compounds expose shadcn's public slot names (`Content`, `Trigger`, `Item`, and so on), built on Base UI's internal anatomy (`Popup`, `Positioner`), which stays internal. A compound that follows neither upstream uses the generic `*.Root` / `*.Trigger` / `*.Content` / `*.Item` pattern consistently.
+- Variant axes use shadcn's vocabulary: `variant` (with shadcn's flat value set, where a semantic treatment like `destructive` is a variant value) and `size`. There is no separate `intent` prop, and no bespoke synonyms (`tone`, `appearance`, `kind`).
+- Polymorphic rendering follows lineage, because the upstream idioms differ and solve different problems. A shadcn-style Slot trigger uses `asChild`; a Base-UI-backed component uses `render`; a leaf element-swap primitive the design system owns uses `as`. These are distinct mechanisms, not synonyms, so they are documented rather than collapsed into one prop.
 
-An agent who has read one component should be able to guess the prop surface of the next one and be right.
+An agent who has read one component, and knows shadcn/Base UI, should be able to guess the prop surface of the next one and be right.
 
 ### XI.3 Documentation surfaces
 
@@ -269,4 +274,4 @@ The rule from Section V — "if a behavior is not exercised in a story, it is no
 
 ---
 
-**Version**: 1.2.0 | **Ratified**: TODO(RATIFICATION_DATE): set to original adoption date | **Last Amended**: 2026-06-12
+**Version**: 1.3.0 | **Ratified**: TODO(RATIFICATION_DATE): set to original adoption date | **Last Amended**: 2026-06-12

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ Auto-generated from all feature plans. Last updated: 2026-06-12
 - Filesystem only. DTCG theme sources under `packages/tokens/themes/<axis>/`; built artifacts under `packages/tokens/dist/`. (009-theming-system-expansion)
 - TypeScript 5.x, strict mode, no `any` + Style Dictionary v4 (made the single resolver for bundled themes), Zod (schema/validation, unchanged), `@modelcontextprotocol/sdk` (the MCP, repointed) (014-resolution-unification)
 - Filesystem only. New per-theme resolved-delta artifacts and the generated defaults baseline under `packages/tokens/dist/` and `packages/tokens/src/` respectively. (014-resolution-unification)
+- TypeScript 5.x, strict mode, no `any` + `@base-ui-components/react`, `class-variance-authority`, Storybook 10.3 (interaction + a11y), the `warn()` helper (`lib/warn.ts`), jscodeshift (NEW, for the rename codemods) (013-api-vocabulary-harmonization)
+- N/A (component library) (013-api-vocabulary-harmonization)
 
 - TypeScript 5.x, strict mode, no `any` (Constitution Section VIII) (004-primitive-set-expansion)
 - N/A (component library; no persisted data) (004-primitive-set-expansion)
@@ -43,9 +45,9 @@ npm test && npm run lint
 TypeScript 5.x, strict mode, no `any` (EVER): Follow standard conventions
 
 ## Recent Changes
+- 013-api-vocabulary-harmonization: Added TypeScript 5.x, strict mode, no `any` + `@base-ui-components/react`, `class-variance-authority`, Storybook 10.3 (interaction + a11y), the `warn()` helper (`lib/warn.ts`), jscodeshift (NEW, for the rename codemods)
 - 014-resolution-unification: Added TypeScript 5.x, strict mode, no `any` + Style Dictionary v4 (made the single resolver for bundled themes), Zod (schema/validation, unchanged), `@modelcontextprotocol/sdk` (the MCP, repointed)
 - 009-theming-system-expansion: Added TypeScript 5.x, strict mode, no `any` + Style Dictionary v4 (DTCG build), Zod (theme schema + validation), Tailwind CSS v4 (`@theme` preset + cascade `@layer`), `@modelcontextprotocol/sdk` (token-query MCP)
-- 010-constitution-retrofit: Added TypeScript 5.x, strict mode, no `any` + Tailwind CSS v4 (`@theme` preset consumption), `@base-ui-components/react`, `class-variance-authority`, Storybook 10.3 (interaction + a11y test runner)
 
 
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,3 +33,15 @@ Spec 009 shipped composition on a resolution stack that already had more than on
 Spec 014 paid it. Style Dictionary already computed each theme's resolved set for the CSS, so it now emits that set as data too, and the MCP, the validator, and the defaults read it instead of re-resolving. Build-time themes resolve in exactly one engine; runtime consumer themes keep the JS resolver as the one isolated second context. The 009 parity oracle retired to a thin wiring canary, and the defaults drift guard became a regenerate-and-diff check. This is the foundation the derived-token entry above wants, since a single resolver stage is what derived tokens slot into.
 
 **Decision that holds regardless:** the boundary stays typed. Even after the engines collapse, `ResolvedTokens` stays a branded type distinct from raw DTCG, so the runtime resolver can never silently accept the wrong shape.
+
+## Richer Variant Model (Orthogonal variant and intent)
+
+**Status:** parked. Surfaced during spec 013's clarify on 2026-06-12.
+
+Today the components use shadcn's flat variant set (default, secondary, destructive, outline, ghost, link), one axis that conflates visual treatment with semantic intent. shadcn does this on purpose, and spec 013 keeps it for upstream compatibility. The cost is that you cannot express the off-diagonal cells: an outlined destructive button, a ghost success action. A consumer who wants "outline plus destructive" composes it by hand with className.
+
+A richer model would split the axis back into two orthogonal props, a treatment (solid/outline/ghost) and an intent (default/destructive/success/warning), so the full grid becomes first-class API. The cost is divergence from shadcn's flat convention, so it needs a deliberate call on how a `variant`-only shadcn consumer migrates and whether the flat values stay as shorthand.
+
+This is add-expressiveness work (new API surface), which is why spec 013 (harmonization moves names, not semantics) left it out. It belongs in its own spec if the flat set ever feels too limiting in practice.
+
+**Decision that holds regardless:** if it lands, the flat shadcn values stay valid, as shorthand or aliases, so the upstream-compat constraint spec 013 established is never broken.

--- a/specs/013-api-vocabulary-harmonization/audit.md
+++ b/specs/013-api-vocabulary-harmonization/audit.md
@@ -1,0 +1,65 @@
+# XI.2 API & vocabulary audit (spec 013, US1)
+
+**Date:** 2026-06-12 · **Status:** for review (the gate; no rename starts until this is approved)
+
+The discovery audit for spec 013, under the non-negotiable constraint that the API stay compatible with shadcn/ui and Base UI. Scope: every component, four drift kinds (prop vocabulary, compound slots, polymorphic prop, prose-only failures). Canonical names default to the upstream name; only the design system's own drift is in scope.
+
+## Headline
+
+The library is **already compliant** on three of the four kinds, because it was built faithfully to shadcn/Base UI:
+
+- **Prop vocabulary**: no bespoke variant-axis synonym anywhere. Components use shadcn's `variant` (flat value set) and `size`. No separate `intent`/`tone`/`appearance` prop exists.
+- **Compound slots**: every compound exposes shadcn's public slot names (`Content`, `Trigger`, ...) or Base UI's (`Root`, `Track`, `Thumb`), built on Base UI internals. No public slot drifts.
+- **Prose-only failures**: none in component source. The two components that warn (SegmentedControl, Slider) already use the structured `warn()` helper.
+
+The **polymorphic prop** is the only finding, and it is not a rename list; it is a decision the clarify's "unify on `render`" answer cannot survive contact with the code (see below).
+
+## Per-component result
+
+| Component | Prop vocab | Slots | Polymorphic | Failures | Status |
+|---|---|---|---|---|---|
+| Button | `variant`/`size` ✓ | n/a | n/a | none ✓ | compliant |
+| Card | ✓ | shadcn slots ✓ | n/a | none ✓ | compliant |
+| Checkbox | ✓ | Base UI passthrough ✓ | none | none ✓ | compliant |
+| Dialog | ✓ | shadcn `Content`/`Trigger` ✓ | `render` passthrough | none ✓ | compliant |
+| Input | ✓ | n/a | n/a | none ✓ | compliant |
+| Label | ✓ | n/a | n/a | none ✓ | compliant |
+| SegmentedControl | `variant`/`size` ✓ | ✓ | none | `warn()` ✓ | compliant |
+| Select | ✓ | shadcn `Content`/`Trigger` ✓ | `render` passthrough | none ✓ | compliant |
+| SkipLink | ✓ | n/a | none | none ✓ | compliant |
+| Slider | ✓ | Base UI `Root`/`Track`/`Thumb` ✓ | none | `warn()` ✓ | compliant |
+| Switch | ✓ | Base UI passthrough ✓ | none | none ✓ | compliant |
+| Tabs | `variant` (`default`/`line`) ✓ | shadcn slots ✓ | none | none ✓ | compliant |
+| Tooltip | ✓ | shadcn `Trigger`/`Content` ✓ | **`asChild`** (shadcn) | none ✓ | compliant; see finding |
+| VisuallyHidden | ✓ | n/a | **`as`** (element-type) | none ✓ | flagged; see finding |
+
+## The one finding: the polymorphic prop is three distinct mechanisms
+
+The brief and the clarify (Q4: "unify on `render`, deprecate `as`") assumed one polymorphic prop split across `as` and `render`. The code has **three patterns that do different things**:
+
+- **`as`** (VisuallyHidden): polymorphic *element type*; render as a `div` instead of a `span`. A leaf-primitive concern.
+- **`asChild`** (Tooltip): the *Slot / merge* pattern; attach the trigger's behavior to an existing child, no wrapper. This is **shadcn's (Radix's) idiom**, and a shadcn user expects it.
+- **`render`** (the Base UI compounds): Base UI's prop, inherited by passthrough. This is **Base UI's idiom**.
+
+They are not interchangeable. You cannot rename `as` to `asChild` (one swaps the element, the other merges onto a child), and renaming Tooltip's `asChild` to `render` would **break shadcn compatibility**; exactly the non-negotiable this spec is built to protect.
+
+So "unify on `render`" is rejected by the compat constraint:
+
+- `asChild` (Tooltip) is shadcn's convention → **keep** (not drift).
+- `render` (Base UI compounds) is Base UI's convention → **keep** (not drift).
+- `as` (VisuallyHidden) follows neither upstream, because Base UI does not back VisuallyHidden; it is our own primitive. It is the only candidate for "our own drift," and even it is a widely understood React pattern for a leaf element-swap.
+
+## Recommendation
+
+**Zero renames.** Instead:
+
+1. **Document the polymorphic conventions by lineage** (in the constitution amendment and the relevant sidecars): shadcn-style Slot triggers use `asChild`; Base-UI-backed components use `render`; a simple element-swap primitive uses `as`. This is the deliberate "documented split" the clarify offered as the alternative to unification, and the compat constraint forces it.
+2. **Decide VisuallyHidden's `as`** (the only genuinely open item): keep `as` (recommended; it is the right mechanism for a leaf element-swap primitive and reads naturally), or align it to the shared rule. There is no upstream to defer to here, so it is a house-style call.
+3. **The structured-failure pass, the prop-vocabulary renames, and the slot renames are no-ops**; the audit records them compliant.
+
+The substantive deliverable of spec 013 therefore reduces to: this audit (the compliance record), the **Section XI.2 amendment** (compat-first, which now must also encode the polymorphic-by-lineage rule), and the VisuallyHidden `as` decision.
+
+## Open questions for the review gate
+
+- Accept "zero renames, document the polymorphic split by lineage" over the clarify's "unify on `render`"? (Recommended; "unify on `render`" would break shadcn's `asChild`.)
+- VisuallyHidden's `as`: keep, or change? (Recommended: keep.)

--- a/specs/013-api-vocabulary-harmonization/checklists/requirements.md
+++ b/specs/013-api-vocabulary-harmonization/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: API and vocabulary harmonization
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- **Clarify session 2026-06-12 resolved seven decisions under one non-negotiable constraint: shadcn/ui + Base UI compatibility.** Upstream conventions win conflicts with XI.2 (and this spec amends XI.2 to be compat-first); slots match Base UI's anatomy; polymorphism unifies on `render`; the rename scope is only the design system's own drift; deprecation uses a window. Two questions (folding `intent`, flattening `variant`) turned out **moot**: a clarify-time audit preview found the components already on shadcn's flat `variant`/`size`, with no `intent`/`tone`/`appearance` prop. The richer 2D variant model is parked on the ROADMAP. The net effect: 013 shrinks to the `as`→`render` unification, slot alignment to Base UI, structured failures, and the XI.2 amendment, with the prop-vocabulary renames likely empty pending the formal audit.
+- **The exact rename list is deliberately not in the spec.** This is a discovery-first spec: US1 (the audit) is the gating P1 deliverable that produces the bounded per-component list, and every rename FR is scoped to "every entry the audit flags" rather than a hard-coded set. That is the brief's central discipline ("no rename starts before the list is reviewed"), not an omission.
+- **The spec names concrete vocabulary** (`variant`/`size`/`intent`/`disabled`, the `*.Root`/`*.Trigger`/`*.Content`/`*.Item` slots, the `as`/`render` props, the `{ code, path, message }` shape). These are the existing API surface and Constitution Section XI.2's canonical set, not implementation choices being made here.
+- **Forced to spec number 013** (not the sequential 011) to match the brief and keep 011 (theme-toggle) and 012 (example-app) reserved for those queued briefs. Done out of numeric order, after 014, per the post-009 ranking.
+- **This is the breaking half of the constitution retrofit** (Part B). Part A (token consumption, non-breaking) shipped as spec 010. The split keeps the breaking API redesign in its own release.

--- a/specs/013-api-vocabulary-harmonization/contracts/audit-format.md
+++ b/specs/013-api-vocabulary-harmonization/contracts/audit-format.md
@@ -4,14 +4,14 @@ The first deliverable, and the gate every rename traces to. No rename starts bef
 
 ## Output
 
-One reviewed document (e.g. `packages/react/AUDIT-xi2.md`), a table of audit entries covering EVERY component, so the audit is provably complete.
+One reviewed document (e.g. `specs/013-api-vocabulary-harmonization/audit.md`), a table of audit entries covering EVERY component, so the audit is provably complete.
 
 ```
 | component | kind        | current         | canonical (upstream-default) | blast radius                  | codemod    | disposition | status    |
 |-----------|-------------|-----------------|------------------------------|-------------------------------|------------|-------------|-----------|
 | Tooltip   | polymorphic | as              | render                       | Tooltip.tsx, .usage.md, story | mechanical | deprecate   | flagged   |
-| Button    | prop        | (variant)       | (variant)                    | —                             | —          | —           | compliant |
-| Dialog    | slot        | (Content)       | (Content)                    | —                             | —          | —           | compliant |
+| Button    | prop        | (variant)       | (variant)                    | n/a                             | n/a          | n/a           | compliant |
+| Dialog    | slot        | (Content)       | (Content)                    | n/a                             | n/a          | n/a           | compliant |
 | ...       | ...         | ...             | ...                          | ...                           | ...        | ...         | ...       |
 ```
 

--- a/specs/013-api-vocabulary-harmonization/contracts/audit-format.md
+++ b/specs/013-api-vocabulary-harmonization/contracts/audit-format.md
@@ -1,0 +1,27 @@
+# Contract: The discovery audit (US1, the gate)
+
+The first deliverable, and the gate every rename traces to. No rename starts before this is reviewed and approved.
+
+## Output
+
+One reviewed document (e.g. `packages/react/AUDIT-xi2.md`), a table of audit entries covering EVERY component, so the audit is provably complete.
+
+```
+| component | kind        | current         | canonical (upstream-default) | blast radius                  | codemod    | disposition | status    |
+|-----------|-------------|-----------------|------------------------------|-------------------------------|------------|-------------|-----------|
+| Tooltip   | polymorphic | as              | render                       | Tooltip.tsx, .usage.md, story | mechanical | deprecate   | flagged   |
+| Button    | prop        | (variant)       | (variant)                    | —                             | —          | —           | compliant |
+| Dialog    | slot        | (Content)       | (Content)                    | —                             | —          | —           | compliant |
+| ...       | ...         | ...             | ...                          | ...                           | ...        | ...         | ...       |
+```
+
+## Rules the audit follows
+
+- **Canonical defaults to upstream.** A flagged entry's `canonical` is shadcn/Base UI's name for that concept; XI.2's generic name is the fallback only where upstream is silent.
+- **Only our own drift is flagged.** A prop/slot inherited unchanged from upstream is `compliant`, never flagged. Public slots that already follow shadcn (`Content`/`Trigger`/`Item`) are `compliant`; Base UI's internal `Popup`/`Positioner` are not public slots and are out of scope.
+- **Conflicts resolve to one canonical name** before any rename, so the vocabulary stays internally consistent (FR-003).
+- **Every component appears**, compliant or flagged, so coverage is verifiable.
+
+## The review gate
+
+Approval is recorded before any rename lands. The renames in Phase B draw ONLY from `flagged` + approved entries. Grounding suggests the flagged set is small (the polymorphic `as` tail, plus any drift the audit surfaces); the audit's job is to prove that rather than assume it.

--- a/specs/013-api-vocabulary-harmonization/contracts/deprecation-and-codemod.md
+++ b/specs/013-api-vocabulary-harmonization/contracts/deprecation-and-codemod.md
@@ -1,0 +1,41 @@
+# Contract: Deprecation window + codemods
+
+How a breaking rename reaches consumers softly (FR-010, FR-011).
+
+## Deprecation window (the default disposition)
+
+For one minor, a renamed prop accepts BOTH names. The old name is mapped onto the new one and emits a structured warning; it is removed the next minor.
+
+```ts
+// per-component alias, at the top of the component body
+if (oldName !== undefined) {
+  warn({
+    code: 'deprecated-prop',
+    path: 'Tooltip.as',
+    message: '`as` is deprecated; use `render`. It will be removed next minor.',
+  });
+  newName ??= oldName; // the new name wins if both are passed
+}
+```
+
+- The warning uses the existing `warn()` helper (`{ code, path, message }`), so a deprecation notice is machine-parseable, not prose.
+- Both-passed: the new name wins (a consumer mid-migration is not broken).
+- The audit may pick `hard-break` for a specific rename where a soft landing is impractical; then there is no alias, and the migration note + codemod carry the consumer.
+
+## Codemods (the mechanical renames)
+
+One jscodeshift transform per mechanical rename, under `codemods/`, so a consumer migrates with one command.
+
+```
+codemods/
+├── as-to-render.ts          # JSX attribute rename: as= → render=  (where it maps cleanly)
+└── <other-mechanical>.ts    # one per flagged mechanical entry
+```
+
+- Each transform is tested against a sample consumer snippet (before → after).
+- A `manual`-flagged entry (a non-mechanical change) gets a documented migration step in the note instead of a codemod.
+- The migration note (changeset + CHANGELOG) enumerates every rename old→new, and points at the codemod command for the mechanical ones.
+
+## Invariant
+
+A consumer can migrate every mechanical rename with one codemod command; during the deprecation window the old name still works and warns (structured); after it, only the new name works. No rename changes behavior beyond the name.

--- a/specs/013-api-vocabulary-harmonization/data-model.md
+++ b/specs/013-api-vocabulary-harmonization/data-model.md
@@ -1,0 +1,60 @@
+# Data Model: API and vocabulary harmonization
+
+**Phase 1 output** | **Date**: 2026-06-12
+
+No persisted data. The "model" is the audit's structured output and the artifacts each rename produces.
+
+## Entities
+
+### Audit entry
+
+One flagged drift from the shared/upstream vocabulary. The audit is a list of these; the approved list is the exact scope of every rename.
+
+| Field | Meaning |
+| --- | --- |
+| `component` | the component the entry belongs to |
+| `kind` | `prop` \| `slot` \| `polymorphic` \| `failure` |
+| `current` | the current name (or the prose-only failure site) |
+| `canonical` | the proposed name, defaulting to the upstream (shadcn/Base UI) name |
+| `blastRadius` | the stories, sidecars, TSDoc blocks, tests, and example-app sites that move with it |
+| `codemod` | `mechanical` (a codemod covers it) \| `manual` (a documented step) |
+| `disposition` | `deprecate` (window) \| `hard-break`, per the audit's recommendation |
+| `status` | `compliant` (no change) \| `flagged` |
+
+A component with no drift is recorded `compliant`, not omitted, so the audit is provably complete.
+
+### Rename
+
+A single name change drawn from an approved `flagged` entry: a prop, a slot, or the polymorphic prop. Carries its lockstep doc and test updates, its codemod (if mechanical), and its deprecation alias (if `deprecate`).
+
+### Deprecation alias
+
+The shim that keeps a renamed prop's old name working for one minor. Maps the old prop onto the new one and emits a structured `warn()` payload (`{ code: 'deprecated-prop', path, message }`). Removed the next minor.
+
+### Codemod
+
+A jscodeshift transform under `codemods/`, one per mechanical rename, that rewrites a consumer's old prop/import to the new name. Tested against a sample snippet.
+
+### Structured failure
+
+A `warn()` `{ code, path, message }` payload replacing a prose-only warning or throw the audit flagged (US5), including the deprecation warnings.
+
+## The shared vocabulary (the target names)
+
+- **Variant axes**: `variant` (shadcn's flat value set), `size`. No separate `intent` prop (shadcn folds it into `variant`).
+- **Compound slots**: shadcn's public names (`Content`, `Trigger`, `Item`, ...) for shadcn-style compounds; Base UI's `Popup`/`Positioner` stay internal. XI.2's generic pattern only where a compound follows neither upstream.
+- **Polymorphic**: Base UI's `render`. `as` is the deprecated alias.
+
+## Rules
+
+- A canonical name MUST default to the upstream name; XI.2's generic name is the fallback only where upstream is silent.
+- A prop/slot inherited unchanged from upstream is never renamed (only our own drift is in scope).
+- Each rename's sidecar, TSDoc, stories, and tests move in the same change; no in-repo doc or test references a stale name after its rename ships.
+- A rename does not change component behavior beyond the name (semantics stay put).
+
+## Invariants after the change
+
+- Every component's variant-axis props and public slot names track shadcn/Base UI; a consumer who knows upstream predicts ours.
+- The polymorphic prop is `render` library-wide; `as` works only as the deprecated alias during its window.
+- Every flagged prose-only failure emits a structured `{ code, path, message }`.
+- Section XI.2 reads compat-first; the constitution matches the practice.

--- a/specs/013-api-vocabulary-harmonization/plan.md
+++ b/specs/013-api-vocabulary-harmonization/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: API and vocabulary harmonization
+
+**Branch**: `013-api-vocabulary-harmonization` | **Date**: 2026-06-12 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/013-api-vocabulary-harmonization/spec.md`
+
+## Summary
+
+Bring the pre-XI.2 components onto a predictable API, under one non-negotiable constraint: stay compatible with shadcn/ui and Base UI. The work is discovery-gated. The audit (US1) runs first and no rename starts before it is reviewed.
+
+Grounding during clarify and planning dissolved most of the assumed rename surface, because the library was built faithfully to shadcn/Base UI from the start:
+
+- **Prop vocabulary**: already shadcn-flat (`variant` with shadcn's value set, `size`); no `intent`/`tone`/`appearance` prop exists. Expected near-empty.
+- **Slots**: the compounds already expose shadcn's public slot names (`Content`/`Trigger`/`Item`), with Base UI's `Popup`/`Positioner` internal. Expected near-empty.
+- **Polymorphic**: only **Tooltip** declares its own `as`; the Base-UI components inherit `render` by passthrough. A short tail (Tooltip, VisuallyHidden, maybe SkipLink), not ten components.
+- **Structured failures**: the `warn()` helper (`lib/warn.ts`) already models the XI.4 shape, so this is applying it where prose-only warnings or throws remain.
+
+So the substantive deliverables are the **audit** (which mostly confirms compliance and finds the short tail), the **Section XI.2 amendment** (compat-first, the lasting change), the **structured-failure pass**, and the **deprecation + codemod machinery** for whatever short tail the audit finds.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, strict mode, no `any`
+**Primary Dependencies**: `@base-ui-components/react`, `class-variance-authority`, Storybook 10.3 (interaction + a11y), the `warn()` helper (`lib/warn.ts`), jscodeshift (NEW, for the rename codemods)
+**Storage**: N/A (component library)
+**Testing**: Vitest (unit), Storybook Test addon (interaction + a11y). Renamed components re-run their existing suites; the deprecation path and codemods get their own tests.
+**Target Platform**: React components consumed in browser + SSR
+**Project Type**: monorepo component library (`packages/react`)
+**Constraints**: shadcn/ui + Base UI compatibility is non-negotiable (FR-015). Breaking changes ship behind a deprecation window (FR-011). Sidecars (XI.3) and TSDoc move in lockstep with each rename (FR-007). All prose through the humanizer (FR-013).
+**Scale/Scope**: Audit covers every component. The actual renames are a short, audit-determined tail (polymorphic `as`→`render` plus any slot/prop drift the audit finds). One constitution amendment. One codemod per mechanical rename.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **Section I/II (Repository shape)** — all work in `packages/react` (+ the constitution amendment and a migration note). No new package.
+- [⚠] **Section XI.2 (Shared vocabulary)** — **this spec amends Section XI.2** (FR-016) to be compat-first: the shared vocabulary governs props/slots the design system introduces; props/slots inherited from a wrapped library follow the upstream name. A sanctioned MINOR amendment via the Section X procedure, shipped in this PR with its rationale. Not a violation; the amendment is the point.
+- [x] **Section V (Stories are source of truth)** — each renamed component's stories move with the rename; the audit lists the stories in each entry's blast radius.
+- [x] **Section VI (Testing, three layers)** — renamed components re-run unit + interaction + a11y; the deprecation alias and the codemods get dedicated tests.
+- [x] **Section VII (Chromatic / VR disabled)** — unchanged; renames are API-surface, not visual.
+- [x] **Section IX (Definition of Done)** — every renamed component re-satisfies stories, a11y, SSR-safety, and rendered autodocs (FR-012).
+- [x] **Section X (Governance / changeset)** — a `@unbranded-ds/react` minor (pre-1.0 breaking) with a migration note enumerating every rename, codemods for the mechanical ones, and the XI.2 amendment in the same PR.
+- [x] **Section XI.3 (Sidecars)** — each rename updates its sidecar in the same change (FR-007), so no sidecar describes a stale API.
+- [x] **Section XI.4 (Structured failures)** — the structured-failure pass routes prose-only warnings/throws through `warn()`'s `{ code, path, message }` shape, including the deprecation warnings.
+
+No violations. One governed amendment (Section XI.2), versioned and shipped in-PR.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-api-vocabulary-harmonization/
+├── plan.md              # This file
+├── research.md          # Phase 0: deprecation-window pattern, codemod tooling, the audit method, the XI.2 wording
+├── data-model.md        # Phase 1: the audit-entry schema, the rename + deprecation + codemod entities
+├── contracts/
+│   ├── audit-format.md          # the per-component audit table the gate produces
+│   └── deprecation-and-codemod.md   # how old+new names coexist and warn; the codemod interface
+├── quickstart.md        # Phase 1: audit → review → rename (lockstep) → codemod → migrate → verify
+└── tasks.md             # Phase 2 (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+packages/react/
+├── AUDIT-xi2.md (or specs/013/.../audit.md)   # the discovery audit deliverable (US1 gate)
+├── src/components/<Component>/                 # the audit-determined short tail of renames:
+│   ├── <Component>.tsx                         #   the prop/slot rename + the deprecation alias
+│   ├── <Component>.usage.md                    #   sidecar, in lockstep (XI.3)
+│   └── <Component>.stories.tsx                 #   stories, in lockstep (V)
+├── src/lib/warn.ts                             # reused for the structured-failure pass + deprecation warnings
+└── codemods/                                   # NEW — one jscodeshift transform per mechanical rename
+.changeset/<name>.md                            # @unbranded-ds/react minor + the migration note (old→new)
+.specify/memory/constitution.md                 # Section XI.2 amendment (minor bump)
+```
+
+**Structure Decision**: All component work in `packages/react`. The audit is the gating artifact; the renames are a short audit-determined tail; the codemods live in a new `codemods/` dir; the XI.2 amendment and the migration note ship in the same PR.
+
+## The execution shape (audit-gated)
+
+This spec has a hard internal gate, so the plan is two-phase, not a flat fan-out.
+
+**Phase A — The audit (US1, the gate).** Enumerate, per component, each prop/slot that drifts from the shared/upstream vocabulary, with the proposed canonical name (defaulting to the upstream name), the blast radius (stories, sidecars, TSDoc, tests), codemod feasibility, and a hard-break-or-deprecate recommendation. **No rename starts until this is reviewed and approved.** The audit can fan out per-component (each component read independently), then converge into one reviewed list. Given the grounding, the audit is expected to confirm broad compliance and surface a short tail.
+
+**Phase B — Execute the approved list (after the gate).**
+- **The renames (parallel, per-component).** Each audit entry's rename, with its sidecar, TSDoc, stories, and tests moving in the same change. Disjoint component files, so the tail runs in parallel. Each ships the deprecation alias (old name accepted, warns via `warn()`).
+- **The structured-failure pass.** Route any prose-only warning/throw the audit flagged through `warn()`'s `{ code, path, message }` shape.
+- **The codemods.** One jscodeshift transform per mechanical rename (a prop or import rename), so a consumer migrates with one command.
+
+**Phase C — Migration + governance + verify.** The migration note (every rename old→new) in the changeset and CHANGELOG, the Section XI.2 amendment, then full verification (renamed components green across unit/interaction/a11y, the codemods tested against a sample, the deprecation warnings fire).
+
+So: **audit (gate) → reviewed list → parallel per-component renames + structured failures + codemods → migration note + XI.2 amendment → verify.** The parallel width is the size of the audit's tail, which grounding suggests is small.
+
+## Research Summary
+
+See [research.md](research.md). Grounded against the code:
+
+- **The three rename categories are near-empty.** Prop vocab is already shadcn-flat; slots already use shadcn's public names; the polymorphic `as` is essentially Tooltip (the Base-UI components passthrough `render`). The audit confirms; the plan does not assume a large rename.
+- **The slot target is shadcn's public names, not Base UI's raw anatomy.** Our `Dialog.Content` wraps Base UI's internal `Popup`; renaming the public slot to `Popup` would break shadcn compat. The audit aligns public slots to shadcn (which they already follow) and leaves Base UI internal.
+- **`warn()` exists** (`lib/warn.ts`, `WarnPayload`), so the structured-failure pass and the deprecation warnings reuse it rather than inventing a shape.
+- **Deprecation window**: accept both the old and new prop name for one minor, warn on the old via `warn()`, remove the next. The research settles the prop-alias mechanism (a small wrapper that maps the deprecated prop and emits the structured warning).
+- **Codemod tooling**: jscodeshift is the standard for React prop/import renames; it is added as a dev dependency, with one transform per mechanical rename.
+
+## Complexity Tracking
+
+> No constitution violations to justify. The Section XI.2 change is a governed amendment, tracked above.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| — | — | — |

--- a/specs/013-api-vocabulary-harmonization/plan.md
+++ b/specs/013-api-vocabulary-harmonization/plan.md
@@ -50,6 +50,7 @@ No violations. One governed amendment (Section XI.2), versioned and shipped in-P
 ```text
 specs/013-api-vocabulary-harmonization/
 ├── plan.md              # This file
+├── audit.md             # US1 deliverable: the discovery audit (the gate). A spec record, not a package doc.
 ├── research.md          # Phase 0: deprecation-window pattern, codemod tooling, the audit method, the XI.2 wording
 ├── data-model.md        # Phase 1: the audit-entry schema, the rename + deprecation + codemod entities
 ├── contracts/
@@ -63,7 +64,6 @@ specs/013-api-vocabulary-harmonization/
 
 ```text
 packages/react/
-├── AUDIT-xi2.md (or specs/013/.../audit.md)   # the discovery audit deliverable (US1 gate)
 ├── src/components/<Component>/                 # the audit-determined short tail of renames:
 │   ├── <Component>.tsx                         #   the prop/slot rename + the deprecation alias
 │   ├── <Component>.usage.md                    #   sidecar, in lockstep (XI.3)

--- a/specs/013-api-vocabulary-harmonization/quickstart.md
+++ b/specs/013-api-vocabulary-harmonization/quickstart.md
@@ -1,0 +1,55 @@
+# Quickstart: API and vocabulary harmonization
+
+How to implement and verify spec 013. Discovery-gated: the audit runs first, and no rename starts before it is reviewed.
+
+## Prerequisites
+
+- Branch `013-api-vocabulary-harmonization` off `main`
+- Baseline green: `pnpm --filter @unbranded-ds/react test && pnpm typecheck`
+- Read the spec's Clarifications: shadcn/Base UI compat is non-negotiable; upstream names win; only our own drift is in scope.
+
+## Order of work
+
+### 1. The audit (the gate — do this first, no renames yet)
+
+Produce `packages/react/AUDIT-xi2.md` per `contracts/audit-format.md`: every component, each flagged drift with its canonical (upstream-default) name, blast radius, codemod feasibility, and disposition. Mark compliant components compliant. **Get it reviewed and approved before touching a component.** Grounding says expect broad compliance and a short tail (the polymorphic `as`, plus anything the audit surfaces). Run the audit prose through the humanizer.
+
+### 2. The renames (parallel, per-component, only after approval)
+
+For each approved `flagged` entry, in the component's own change:
+
+- rename the prop/slot to the canonical name;
+- add the deprecation alias (old name accepted, warns via `warn()`) unless the disposition is hard-break;
+- update the sidecar, TSDoc, stories, and tests in the SAME change (no stale references);
+- write the codemod (mechanical) or the documented manual step.
+
+Disjoint component files, so the tail runs in parallel.
+
+### 3. Structured failures
+
+Route any prose-only warning/throw the audit flagged through `warn()`'s `{ code, path, message }`.
+
+### 4. Migration + governance
+
+- Migration note in the changeset and CHANGELOG: every rename old→new, with the codemod command for the mechanical ones.
+- Amend Constitution Section XI.2 to be compat-first (minor bump); update the Sync Impact Report.
+- `pnpm changeset` → `@unbranded-ds/react` minor.
+
+### 5. Verify
+
+```bash
+pnpm --filter @unbranded-ds/react test          # renamed components green (unit + interaction + a11y)
+pnpm typecheck
+pnpm --filter @unbranded-ds/react lint
+pnpm --filter @unbranded-ds/storybook build && pnpm --filter @unbranded-ds/storybook test:storybook
+# the deprecation path: old name still works and warns; the codemods transform a sample snippet
+# grep for stale names: no in-repo doc/story/test references a renamed old name
+```
+
+## Watch-outs
+
+- **The audit is the gate.** No rename before it is reviewed. Every rename traces to an approved entry.
+- **Upstream names win.** Default canonical names to shadcn/Base UI; never rename a prop/slot we inherit unchanged from upstream. Public slots already follow shadcn (`Content`) — leave them; Base UI's `Popup`/`Positioner` are internal, not public slots.
+- **Lockstep docs.** A rename that ships without its sidecar/TSDoc update violates XI.3 and FR-007.
+- **Names, not semantics.** A rename must not change behavior beyond the name.
+- **The XI.2 amendment ships in this PR**, with its rationale (the compat-first reframe). It is the lasting change here.

--- a/specs/013-api-vocabulary-harmonization/quickstart.md
+++ b/specs/013-api-vocabulary-harmonization/quickstart.md
@@ -12,7 +12,7 @@ How to implement and verify spec 013. Discovery-gated: the audit runs first, and
 
 ### 1. The audit (the gate — do this first, no renames yet)
 
-Produce `packages/react/AUDIT-xi2.md` per `contracts/audit-format.md`: every component, each flagged drift with its canonical (upstream-default) name, blast radius, codemod feasibility, and disposition. Mark compliant components compliant. **Get it reviewed and approved before touching a component.** Grounding says expect broad compliance and a short tail (the polymorphic `as`, plus anything the audit surfaces). Run the audit prose through the humanizer.
+Produce `specs/013-api-vocabulary-harmonization/audit.md` per `contracts/audit-format.md`: every component, each flagged drift with its canonical (upstream-default) name, blast radius, codemod feasibility, and disposition. Mark compliant components compliant. **Get it reviewed and approved before touching a component.** Grounding says expect broad compliance and a short tail (the polymorphic `as`, plus anything the audit surfaces). Run the audit prose through the humanizer.
 
 ### 2. The renames (parallel, per-component, only after approval)
 

--- a/specs/013-api-vocabulary-harmonization/research.md
+++ b/specs/013-api-vocabulary-harmonization/research.md
@@ -1,0 +1,53 @@
+# Research: API and vocabulary harmonization
+
+**Phase 0 output** | **Date**: 2026-06-12 | Grounded against `packages/react` and the clarify session.
+
+## D1 — Compatibility is the canonical authority; XI.2 is amended to say so
+
+**Decision**: A component's prop/slot names mirror the upstream library its public API follows (shadcn/ui, on Base UI internals). The XI.2 shared vocabulary governs only props/slots the design system introduces. Section XI.2 is amended to be compat-first (a minor bump).
+
+**Rationale**: The non-negotiable constraint is that a consumer or agent who knows shadcn/Base UI can predict our API. That only holds if our names track upstream. XI.2 as originally written prescribed a bespoke vocabulary, which conflicts with upstream in two places (a separate `intent` prop shadcn does not have; generic `Content` vs Base UI's `Popup`). The amendment resolves the conflict in upstream's favor and makes the constitution match the practice.
+
+**Alternatives**: keep XI.2 as written and override case-by-case (rejected — leaves the constitution inconsistent with reality); rename to XI.2's bespoke names (rejected by the constraint).
+
+## D2 — The three rename categories are near-empty (grounding)
+
+**Decision**: The plan does not assume a large rename. The audit (US1) confirms compliance and surfaces a short tail.
+
+**Findings**:
+
+- **Prop vocabulary**: Button already uses shadcn's flat `variant` set (`default | destructive | outline | secondary | ghost | link`) and `size`; Tabs uses `variant`; SegmentedControl uses `variant`/`size`. No `intent`/`tone`/`appearance` prop exists. The "bespoke synonym" class the brief assumed is not present.
+- **Slots**: the compounds expose shadcn's public slot names (`Dialog.Content`, etc.), built on Base UI's internal `Popup`/`Positioner`/`Portal`/`Backdrop`. They already follow the shadcn convention.
+- **Polymorphic**: only Tooltip declares its own `as`; the Base-UI-backed components inherit Base UI's `render` by passthrough. The `as`→`render` rename is a short tail (Tooltip, VisuallyHidden, possibly SkipLink).
+
+**Rationale**: The library was built faithfully to shadcn/Base UI. This is the discovery-first discipline paying off: the bounded list is small, and the spec's value is the audit proving it plus the lasting XI.2 amendment, not a sweeping rename.
+
+## D3 — The slot target is shadcn's public names, not Base UI's raw anatomy
+
+**Decision**: Align public compound slots to shadcn's convention (which they already use). Base UI's `Popup`/`Positioner` stay internal and are never re-exposed as renamed public slots.
+
+**Rationale**: `Dialog.Content` (public, shadcn) wraps Base UI's `Popup` (internal). Renaming the public slot to `Popup` would break shadcn compat and rename a slot we name correctly, contradicting "only our own drift." This corrects the clarify's first reading of Q3 ("match Base UI's anatomy"), which would have been backwards.
+
+**Alternatives**: rename public slots to Base UI's anatomy (rejected — breaks shadcn compat, large unnecessary break).
+
+## D4 — Reuse `warn()` for structured failures and deprecation warnings
+
+**Decision**: The structured-failure pass (US5) and the deprecation warnings both route through the existing `warn()` helper (`lib/warn.ts`, `WarnPayload` = `{ code, path, message }`). No new failure shape.
+
+**Rationale**: XI.4's model already ships. The work is applying it where prose-only warnings/throws remain (the audit flags them), and using it for the deprecation-alias warning, so a deprecation notice is itself machine-parseable.
+
+## D5 — Deprecation window via a prop-alias wrapper
+
+**Decision**: Each renamed prop accepts both the old and new name for one minor. A small per-component alias maps the deprecated prop onto the new one and emits a structured `warn()` payload (code like `deprecated-prop`, path naming the component and old prop). Removed the next minor. The audit recommends a hard break only where a soft landing is impractical.
+
+**Rationale**: Softest for consumers and for the in-repo consumers (stories, sidecars, the future example app). The structured warning lets an agent detect the deprecation programmatically.
+
+**Alternatives**: hard-break every rename (rejected as the default; harsher, though the audit may pick it for a specific rename).
+
+## D6 — Codemods via jscodeshift
+
+**Decision**: Add jscodeshift as a dev dependency; one transform per mechanical rename (a prop or import rename), under a new `codemods/` directory, each tested against a sample consumer snippet.
+
+**Rationale**: jscodeshift is the standard for React prop/import codemods. A mechanical rename (`as`→`render`, a prop synonym) is a clean transform; a non-mechanical change (a semantic shift) gets a documented manual step instead, per the audit's codemod-feasibility call.
+
+**Alternatives**: hand-written find-replace scripts (rejected — fragile on JSX/TS); no codemods (rejected — FR-010 requires them for mechanical renames).

--- a/specs/013-api-vocabulary-harmonization/spec.md
+++ b/specs/013-api-vocabulary-harmonization/spec.md
@@ -1,0 +1,198 @@
+# Feature Specification: API and vocabulary harmonization
+
+**Feature Branch**: `013-api-vocabulary-harmonization`
+**Created**: 2026-06-12
+**Status**: Draft
+**Input**: User description: "API and vocabulary harmonization: a discovery-first audit then breaking renames that bring the pre-XI.2 components onto the shared prop/slot vocabulary, with codemods, a deprecation window, and sidecars/TSDoc updated in lockstep." (brief at `docs/workshops/2026-06-11/spec-013-api-vocabulary-harmonization.md`)
+
+## Background
+
+Constitution Section XI.2 says component APIs must be predictable by analogy: variant axes draw from a small shared vocabulary (`variant`, `size`, `intent`, `disabled`), compound slots use the `*.Root` / `*.Trigger` / `*.Content` / `*.Item` pattern consistently, and polymorphic rendering uses one prop name across the library. The components shipped before XI.2 was ratified (spec 005) were written without that constraint. Specs 005, 006, and 007 audited prose and docs but were explicitly forbidden from renaming props or slots; each recorded the API-shape issues it found and deferred them here (005 FR-030, 006 FR-015, 007 FR-013).
+
+Spec 010 (Part A) already took the non-breaking half of the constitution retrofit: token consumption. This spec is Part B, the breaking half, the actual renames that bring the pre-XI components into XI.2 compliance. Keeping the two apart means a mechanical internal retrofit and a breaking API redesign land in separate releases, so the changeset, the review, and the migration note each stay coherent.
+
+The work is gated on discovery. No one has enumerated the real violations yet, and no rename starts before that list exists and is reviewed. The audit is what turns "harmonize the API" from a direction into a bounded set of changes with a known migration cost.
+
+## Clarifications
+
+**One constraint overrides everything in this spec: the API must stay compatible with shadcn/ui and Base UI conventions, now and as they evolve.** This is non-negotiable. Where the constitution's XI.2 shared vocabulary and upstream conventions conflict, upstream wins, and this spec amends XI.2 to say so. The point of harmonizing is that a consumer or agent who knows shadcn/Base UI can predict our API, which only holds if our names track upstream rather than a bespoke set.
+
+### Session 2026-06-12
+
+- Q: When XI.2's shared vocabulary conflicts with shadcn/Base UI conventions, which is canonical? → A: Upstream wins. A component's prop/slot names mirror the library it wraps; XI.2's shared vocabulary governs only props/slots WE introduce. This spec amends Section XI.2 to be compat-first (a minor constitution bump).
+- Q: shadcn folds semantic intent into variant (`variant="destructive"`); what happens to a separate `intent` prop? → A: Moot. A clarify-time audit preview found no `intent`/`tone`/`appearance` prop in the code: Button already uses shadcn's flat variant set, Tabs uses `variant`, SegmentedControl uses `variant`/`size`. The components are already shadcn-aligned on this axis; there is nothing to fold.
+- Q: Folding into variant, what is the resulting value set? → A: Moot, nothing to flatten. A richer orthogonal variant-and-intent model would be new API surface; it is parked as a future spec (see ROADMAP), out of this spec's harmonization scope.
+- Q: Base UI names compound slots Portal/Positioner/Popup/Backdrop, not the generic Content; which naming do our compounds use? → A: Match the upstream convention our PUBLIC API follows. Grounding showed our shadcn-style compounds already expose shadcn's public slot names (Content/Trigger/Item) and keep Base UI's Popup/Positioner internal, which is correct for both shadcn and Base UI compat; we keep that. (An earlier reading, "rename our slots to Base UI's raw anatomy," was rejected: it would break shadcn compat and rename slots we name correctly.) XI.2's generic pattern applies only to a compound that follows neither upstream.
+- Q: Base UI uses the `render` prop for polymorphism; unify on which? → A: **Reversed by the US1 audit.** The audit found three distinct mechanisms in use — `asChild` (Tooltip, shadcn's Slot idiom), `render` (Base UI compounds, by passthrough), and `as` (VisuallyHidden, a leaf element-swap primitive) — not one prop split across `as`/`render`. Unifying on `render` would break shadcn's `asChild` and conflate different mechanisms. Resolution: document the split by lineage in Section XI.2, rename nothing, keep VisuallyHidden's `as`.
+- Q: Which names does this spec touch? → A: Only our own drift. Rename props/slots WE introduced that diverge from the shared or upstream vocabulary; anything inherited from shadcn/Base UI keeps upstream's name untouched.
+- Q: How do the breaking renames reach consumers? → A: A deprecation window by default (old and new coexist for one minor, the old warns with a structured XI.4 payload, removed the next), with the audit recommending a hard break only where a soft landing is impractical.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The discovery audit (Priority: P1) 🎯 MVP
+
+A maintainer produces, for every component, the props and slots that break XI.2, each entry carrying the current name and the proposed canonical name, the blast radius (which stories, sidecars, TSDoc blocks, tests, and the example app move with the rename), whether a codemod can cover it or it needs a manual touch, and a recommendation to hard-break or deprecate. The list is reviewed and approved before any rename begins.
+
+**Why this priority**: It is the gate. Every other story is scoped by this list, and the brief is explicit that no rename starts before it is reviewed. It is independently valuable on its own: even if the renames slipped, the audit is the bounded inventory of the library's API debt and its migration cost, which is the thing no one has today.
+
+**Independent Test**: Produce the audit for the current component set and confirm every component appears, each flagged violation has a proposed canonical name, a blast radius, a codemod-or-manual call, and a break-or-deprecate recommendation. Confirm the list was reviewed and approved before any rename landed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the current component library, **When** the audit runs, **Then** it lists every prop and slot that violates XI.2, each with its current name, proposed canonical name, blast radius, codemod feasibility, and a break-or-deprecate recommendation.
+2. **Given** the completed audit, **When** it is reviewed, **Then** approval is recorded before any rename is implemented; the renames in later stories draw only from this approved list.
+3. **Given** a component already compliant with XI.2, **When** the audit runs, **Then** it is recorded as compliant (no false renames invented for components that already conform).
+
+---
+
+### User Story 2 - Prop vocabulary harmonization (Priority: P2)
+
+A consumer reads any component's props and finds shadcn's axis names everywhere: visual treatment is `variant` (shadcn's flat value set, where a semantic treatment like `destructive` is a variant value, not a separate prop), scale is `size`. Any bespoke synonym the audit flags (`tone`, `appearance`, `kind`, `color`-as-variant) is renamed to that set, with the sidecar, TSDoc, stories, and tests moving in the same change and a codemod for the mechanical cases.
+
+**Why this priority**: It is the class spec 007 flagged, and the most consumer-visible axis when it drifts. The clarify preview found the current components already on this convention (Button's flat variant set, Tabs and SegmentedControl on `variant`/`size`), so the value here is mostly the audit confirming there is no drift rather than a large rename. If drift surfaces, this fixes it; if not, the story is satisfied by the confirmation.
+
+**Independent Test**: For each component the audit flagged for a prop rename, confirm the canonical name is in place, the old name is handled per the deprecation decision, and the sidecar, TSDoc, stories, and tests reference only the new name. Confirm the codemod migrates a sample consumer call.
+
+**Acceptance Scenarios**:
+
+1. **Given** a component with a bespoke variant-axis prop the audit flagged, **When** the rename ships, **Then** the prop uses the shared vocabulary name and the sidecar, TSDoc, stories, and tests reference only it.
+2. **Given** a consumer using the old prop name, **When** they upgrade, **Then** the codemod (for mechanical cases) renames their usage, or the deprecation path accepts the old name with a warning per the chosen policy.
+
+---
+
+### User Story 3 - Slot consistency (Priority: P3)
+
+A consumer composing any compound finds shadcn's public slot names (`Content`, `Trigger`, `Item`, and the like) that the components already expose, built on Base UI's internal anatomy (`Popup`, `Positioner`). Where a compound's PUBLIC slot drifted from shadcn's convention, it is renamed back, with docs and tests in lockstep. Grounding found the compounds already follow shadcn's slot names, so this story is mostly the audit confirming compliance rather than a rename.
+
+**Why this priority**: Slot names are how a consumer reasons about composition. Consistent slots let the same mental model carry across every compound, which is the composition half of XI.2. It is lower than prop vocabulary only because compounds are a smaller share of the API surface.
+
+**Independent Test**: For each compound the audit flagged for a slot rename, confirm the slot uses the shared role name, the sidecar/TSDoc/stories/tests reference only it, and a codemod or documented manual step covers the consumer migration.
+
+**Acceptance Scenarios**:
+
+1. **Given** a compound with a slot named off-pattern, **When** the rename ships, **Then** the slot uses the shared role name and the compound's docs and tests reference only it.
+2. **Given** the full compound set, **When** a consumer inspects any two, **Then** the same role uses the same slot name in both.
+
+---
+
+### User Story 4 - Polymorphic prop conventions (Priority: P4)
+
+A consumer rendering a component polymorphically finds the idiom that matches the component's lineage, documented and consistent: `asChild` on shadcn-style Slot triggers (Tooltip), `render` on Base-UI-backed components (by passthrough), and `as` on the design system's own leaf element-swap primitives (VisuallyHidden). The split is documented in Section XI.2 rather than collapsed into one prop.
+
+**Why this priority**: It is the one place the API was thought inconsistent. The audit (US1) established that the three are distinct mechanisms, not synonyms, and that unifying on one prop would break shadcn's `asChild`. Resolving it means writing the by-lineage rule into the constitution so the convention is predictable, not renaming anything.
+
+**Independent Test**: Confirm Section XI.2 documents the polymorphic-by-lineage rule, that each component's polymorphic prop matches its lineage (Tooltip `asChild`, Base-UI compounds `render`, VisuallyHidden `as`), and that no polymorphic rename ships.
+
+**Acceptance Scenarios**:
+
+1. **Given** the audit's polymorphic finding, **When** the rule is written into Section XI.2, **Then** a reader learns which idiom applies to which lineage, and the components already match it.
+2. **Given** a shadcn user, **When** they reach for `asChild` on a Slot trigger, **Then** it works, because the spec did not rename it to `render`.
+
+---
+
+### User Story 5 - Structured failure output (Priority: P5)
+
+A consumer (or agent) that hits a component or helper warning or error receives a structured `{ code, path, message }` payload, with the human-readable string layered on top, matching the Section XI.4 shape the `warn()` helper and `validateTheme` already model. Prose-only warnings and throws are converted.
+
+**Why this priority**: It is a distinct concern from the renames (failure shape, not naming), and a smaller surface, so it lands last. It matters for the agent-legibility differentiator: a structured failure is machine-parseable where a prose string is not.
+
+**Independent Test**: For each component or helper the audit flagged with a prose-only failure, confirm it now emits `{ code, path, message }` and that the human-readable message is still present.
+
+**Acceptance Scenarios**:
+
+1. **Given** a component or helper that warned or threw with a prose-only message, **When** the failure path runs after this change, **Then** it emits a structured `{ code, path, message }` payload with the readable string layered on.
+2. **Given** the structured payload, **When** an agent inspects it, **Then** it can branch on `code` and `path` without parsing prose.
+
+---
+
+### Edge Cases
+
+- **A component is already XI.2-compliant**: the audit records it as compliant; no rename is invented for it.
+- **A rename is not mechanical** (a prop whose meaning shifts, not just its name): the audit flags it manual; it gets a documented migration step rather than a codemod, and the spec does not change the prop's semantics beyond the rename.
+- **A consumer is mid-migration when a name is in its deprecation window**: both the old and new name work, and the old one warns, so a partial migration still runs.
+- **The example app (spec 012) or a theme (spec 009) consumes a renamed prop or slot**: it updates in lockstep with the rename, in the same change, so no in-repo consumer references a stale name.
+- **Two components disagree on a "canonical" name** (the audit proposes different names for the same role): the audit resolves it to one canonical name before any rename, so the shared vocabulary stays internally consistent.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**The audit (US1, gating)**
+
+- **FR-001**: The first deliverable MUST be a discovery audit enumerating, for every component, each prop and slot that drifts from the shared or upstream vocabulary, with the current name, the proposed canonical name, the blast radius (stories, sidecars, TSDoc, tests, example app), codemod feasibility, and a hard-break-or-deprecate recommendation. The proposed canonical name MUST default to shadcn/Base UI's name for that concept; XI.2's generic name is used only where upstream is silent.
+- **FR-002**: No rename MUST be implemented before the audit is reviewed and approved. Every rename in FR-004 through FR-007 MUST trace to an approved audit entry.
+- **FR-003**: The audit MUST resolve any conflict where the same role is proposed different canonical names, so the shared vocabulary is internally consistent before renames begin.
+
+**The renames (US2, US3, US4)**
+
+- **FR-004**: Any bespoke variant-axis prop the audit flags MUST be renamed to shadcn's vocabulary: visual treatment to `variant`, scale to `size`. Semantic intent stays folded into `variant` (shadcn's convention, `variant="destructive"`), not a separate prop. The clarify preview found the current components already on this convention (Button's flat variant set, Tabs and SegmentedControl using `variant`/`size`), so this category is expected to be minimal or empty; the audit confirms.
+- **FR-005**: Compound slot names MUST match the upstream convention the component's PUBLIC API follows. Our shadcn-style compounds keep shadcn's public slot names (`Content`, `Trigger`, `Item`, and the like), which they already use; Base UI's internal anatomy (`Popup`, `Positioner`, `Portal`, `Backdrop`) stays internal and is NOT re-exposed as a renamed public slot. XI.2's generic pattern applies only to a compound that follows neither upstream. The audit flags only a public slot that drifts from the shadcn convention.
+- **FR-006**: Polymorphic rendering MUST follow lineage rather than unify on one prop. A shadcn-style Slot trigger uses `asChild` (shadcn's convention); a Base-UI-backed component uses `render` (Base UI's, by passthrough); a leaf element-swap primitive the design system owns uses `as` (VisuallyHidden). The audit (US1) established these are distinct mechanisms, not synonyms, and that forcing one prop would break shadcn's `asChild`. The result is **documented in Section XI.2, not renamed** — there is no polymorphic rename.
+- **FR-007**: Each rename MUST move the component's sidecar (XI.3), TSDoc (the spec 007 surface), stories, and tests in the same change, so no in-repo doc or test references a stale name.
+
+**Structured failures (US5)**
+
+- **FR-008**: Every component or helper the audit flags with a prose-only warning or throw MUST emit a structured `{ code, path, message }` payload per Section XI.4, with the human-readable string layered on top.
+
+**Migration**
+
+- **FR-009**: The change MUST ship a migration note in the changeset and CHANGELOG enumerating every rename (old name to new name).
+- **FR-010**: Where a rename is mechanical (a prop or import rename), a codemod MUST be provided so a consumer migrates with one command.
+- **FR-011**: The deprecation policy MUST follow the clarify decision: by default a deprecation window (old and new accepted for one minor, old warns, removed the next), with hard breaks only where the audit recommends.
+
+**Constitution compliance**
+
+- **FR-012**: Every renamed component MUST re-satisfy the Section IX Definition of Done (stories, a11y, SSR-safety, rendered autodocs).
+- **FR-013**: All audit prose, the migration note, and any new doc copy MUST pass through the humanizer, with no three-item lists.
+- **FR-014**: This spec MUST NOT change component behavior beyond what a rename strictly requires; it moves names, not semantics.
+
+**Upstream compatibility (the overriding constraint)**
+
+- **FR-015**: The harmonization MUST keep the API compatible with shadcn/ui and Base UI conventions. A prop or slot inherited unchanged from a wrapped library MUST keep the upstream name; the rename scope is the design system's own drift from the upstream or shared vocabulary, never the upstream conventions themselves.
+- **FR-016**: This spec MUST amend Constitution Section XI.2 to be compat-first: the shared vocabulary governs the props and slots the design system introduces, while props and slots inherited from a wrapped library follow the upstream name. This is a MINOR constitution bump.
+
+### Key Entities *(include if feature involves data)*
+
+- **Audit entry**: one flagged violation. Carries the component, the current name, the proposed canonical name, the blast radius, codemod feasibility, and a hard-break-or-deprecate recommendation. The approved set of entries is the exact scope of every rename.
+- **Shared vocabulary**: the XI.2 canonical names. Variant axes (`variant`, `size`, `intent`, `disabled`), the compound slot roles (`Root`, `Trigger`, `Content`, `Item`), and the one polymorphic prop. The target every rename moves toward.
+- **Rename**: a single name change (a prop, a slot, or the polymorphic prop), with its lockstep doc and test updates, its codemod (if mechanical), and its deprecation treatment.
+- **Structured failure**: the `{ code, path, message }` payload a warning or throw emits, with the readable message layered on.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The audit enumerates every XI.2 violation across the component library; each entry has a canonical name, a blast radius, a codemod-or-manual call, and a break-or-deprecate recommendation. It is reviewed and approved before any rename.
+- **SC-002**: After the renames, every component's variant-axis props use shadcn's vocabulary (`variant` with the flat value set, `size`), and no bespoke synonym (`tone`, `kind`, `appearance`, `color`-as-variant) or separate `intent` prop remains.
+- **SC-003**: Every compound's public slots follow shadcn's convention (which they already use), so a shadcn user predicts ours; Base UI's internal anatomy is not exposed as a renamed public slot.
+- **SC-004**: Polymorphic rendering follows lineage and is documented in Section XI.2 (`asChild` for shadcn Slot triggers, `render` for Base UI, `as` for leaf primitives); no polymorphic rename ships, and shadcn's `asChild` keeps working.
+- **SC-005**: A consumer can migrate every mechanical rename with a single codemod command, and the migration note enumerates every rename old-to-new.
+- **SC-006**: During the deprecation window, an old name still works and warns; after it, only the new name works.
+- **SC-007**: No in-repo doc, story, or test references a renamed prop or slot's old name once its rename has shipped.
+- **SC-008**: Every flagged failure path emits a structured `{ code, path, message }` payload an agent can branch on without parsing prose.
+- **SC-009**: An agent or consumer who knows shadcn/ui and Base UI can predict a component's variant-axis props and compound slot names, because our names track upstream's rather than a bespoke set.
+
+## Assumptions
+
+- **shadcn/ui and Base UI compatibility is non-negotiable (decided).** The canonical vocabulary IS upstream's where it exists; the shared XI.2 vocabulary applies only to props/slots the design system introduces. This overrides XI.2 where they conflict, and this spec amends XI.2 to match.
+- **The discovery audit defines the exact rename list.** This spec names the categories and the canonical vocabulary; the precise per-component renames come from the approved audit, so the FRs are scoped to "every entry the audit flags" rather than a hard-coded list. The canonical name an audit entry proposes defaults to the upstream name.
+- **The prop-vocabulary category is likely minimal or empty (preview).** A clarify-time scan found no bespoke variant-synonym or `intent` prop: the components already use shadcn's flat `variant` set and `size`. The audit confirms this rather than assuming a large rename.
+- **Polymorphic prop unifies on `render` (decided).** `as` becomes the deprecated alias. Ten components carry a polymorphic prop today, so this is the largest concrete rename.
+- **Deprecation window is the default (decided).** Old and new names coexist for one minor, the old warns with a structured XI.4 payload, removed the next; hard breaks only where the audit recommends.
+- **A breaking change ships as a pre-1.0 minor**, with a migration note and codemods, per the brief.
+- **Specs 005, 006, 007, and 010 Part A are shipped**, having surfaced the API issues and completed the non-breaking token retrofit. Verified.
+- **The example app (012) does not exist yet**, so it is a lockstep consumer only if it lands before this spec; today the in-repo consumers are stories, sidecars, TSDoc, and tests.
+
+## Dependencies
+
+- **Specs 005, 006, 007** — surfaced and recorded the API-shape issues this spec resolves (005 FR-030, 006 FR-015, 007 FR-013).
+- **Spec 010 Part A** — the non-breaking token retrofit; this spec deliberately follows it so the breaking and non-breaking changes stay in separate releases.
+- **Constitution Section XI.2** — the shared vocabulary this spec enforces; Section XI.3 (sidecars) and XI.4 (structured failures) set the lockstep doc and failure-shape rules.
+
+## Out of Scope
+
+- **Part A (token consumption)** — spec 010's scope, already shipped.
+- **New components, new tokens, new variants** — this spec moves names, not surface area.
+- **A richer orthogonal variant model** (splitting `variant` back into treatment and `intent` axes for the full grid) — adds expressiveness, so it is new API surface, parked as a future spec (see ROADMAP). This spec keeps shadcn's flat `variant` set for upstream compatibility.
+- **Behavior changes beyond what a rename strictly requires** — semantics stay put; only names move.
+- **Theme work (009) and the example app (012)** — except as downstream consumers that update in lockstep with each rename.

--- a/specs/013-api-vocabulary-harmonization/tasks.md
+++ b/specs/013-api-vocabulary-harmonization/tasks.md
@@ -35,9 +35,9 @@
 
 **Goal**: The bounded list of every drift, reviewed and approved, before any rename.
 
-**Independent Test**: `AUDIT-xi2.md` covers every component (compliant or flagged); each flagged entry has a canonical (upstream-default) name, blast radius, codemod feasibility, and disposition. Approval is recorded before any rename lands.
+**Independent Test**: `audit.md` covers every component (compliant or flagged); each flagged entry has a canonical (upstream-default) name, blast radius, codemod feasibility, and disposition. Approval is recorded before any rename lands.
 
-- [X] T004 [US1] Produce the discovery audit at `packages/react/AUDIT-xi2.md` per `contracts/audit-format.md`: audit EVERY component for prop-vocabulary, slot, polymorphic, and prose-only-failure drift from the shared/upstream (shadcn/Base UI) vocabulary. Canonical names default to the upstream name; public slots already on shadcn (`Content`/`Trigger`/`Item`) are compliant; Base UI's internal `Popup`/`Positioner` are out of scope. Record compliant components as compliant. Run the audit prose through the `humanizer`. (Can fan out per-component, then converge.)
+- [X] T004 [US1] Produce the discovery audit at `specs/013-api-vocabulary-harmonization/audit.md` per `contracts/audit-format.md`: audit EVERY component for prop-vocabulary, slot, polymorphic, and prose-only-failure drift from the shared/upstream (shadcn/Base UI) vocabulary. Canonical names default to the upstream name; public slots already on shadcn (`Content`/`Trigger`/`Item`) are compliant; Base UI's internal `Popup`/`Positioner` are out of scope. Record compliant components as compliant. Run the audit prose through the `humanizer`. (Can fan out per-component, then converge.)
 - [X] T005 [US1] Review and approve the audit; record approval. Resolve any conflict where one role is proposed different canonical names (FR-003). **This gate blocks every rename below** — Phase 4+ draws only from approved `flagged` entries.
 
 **Checkpoint**: the rename scope is known and approved.

--- a/specs/013-api-vocabulary-harmonization/tasks.md
+++ b/specs/013-api-vocabulary-harmonization/tasks.md
@@ -1,0 +1,137 @@
+# Tasks: API and vocabulary harmonization
+
+**Input**: Design documents from `/specs/013-api-vocabulary-harmonization/`
+**Prerequisites**: plan.md, spec.md, research.md (6 decisions), data-model.md, contracts/
+
+**Tests**: Required. Renamed components re-run their existing unit + interaction + a11y suites unchanged (a rename moves names, not behavior); the deprecation path and the codemods get dedicated tests.
+
+**Organization**: Discovery-gated. The audit (US1) is a HARD GATE: it produces the bounded rename list and must be reviewed before any rename starts. The post-audit rename stories (US2–US5) are therefore **templated by what the audit flags** rather than hard-enumerated; grounding suggests a short tail (the polymorphic `as`, with prop-vocab and slots already compliant). All component paths are under `packages/react/`.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]** = parallelizable: a different file, no dependency on an incomplete task.
+- Every rename task is **conditional on its audit entry existing and being approved** (US1). If the audit records a category compliant, that story is satisfied by the confirmation.
+
+---
+
+## Phase 1: Setup
+
+- [X] T001 Confirm baseline green: `pnpm --filter @unbranded-ds/react test && pnpm typecheck && pnpm --filter @unbranded-ds/storybook build`.
+- [ ] T002 Add `jscodeshift` (+ types) as a dev dependency and create `packages/react/codemods/` for the rename transforms.
+
+---
+
+## Phase 2: Foundational (the shared deprecation mechanism — blocks the rename stories)
+
+**⚠️ Establish the pattern once so every rename applies it uniformly.**
+
+- [ ] T003 Establish the deprecation-alias + structured-warn convention (per `contracts/deprecation-and-codemod.md`): a per-component shim accepts the old prop name, emits a structured `warn({ code: 'deprecated-prop', path, message })` via the existing `lib/warn.ts`, and lets the new name win when both are passed. Document the convention so each rename copies it; no audit dependency (the mechanism is generic).
+
+**Checkpoint**: the deprecation mechanism + codemod scaffolding exist. The audit can begin.
+
+---
+
+## Phase 3: The discovery audit (US1 — the GATE) 🎯 MVP
+
+**Goal**: The bounded list of every drift, reviewed and approved, before any rename.
+
+**Independent Test**: `AUDIT-xi2.md` covers every component (compliant or flagged); each flagged entry has a canonical (upstream-default) name, blast radius, codemod feasibility, and disposition. Approval is recorded before any rename lands.
+
+- [X] T004 [US1] Produce the discovery audit at `packages/react/AUDIT-xi2.md` per `contracts/audit-format.md`: audit EVERY component for prop-vocabulary, slot, polymorphic, and prose-only-failure drift from the shared/upstream (shadcn/Base UI) vocabulary. Canonical names default to the upstream name; public slots already on shadcn (`Content`/`Trigger`/`Item`) are compliant; Base UI's internal `Popup`/`Positioner` are out of scope. Record compliant components as compliant. Run the audit prose through the `humanizer`. (Can fan out per-component, then converge.)
+- [X] T005 [US1] Review and approve the audit; record approval. Resolve any conflict where one role is proposed different canonical names (FR-003). **This gate blocks every rename below** — Phase 4+ draws only from approved `flagged` entries.
+
+**Checkpoint**: the rename scope is known and approved.
+
+---
+
+## Phase 4: Prop vocabulary (US2 — expected near-empty)
+
+**Goal**: Any bespoke variant-axis prop the audit flagged uses shadcn's vocabulary (`variant`/`size`); intent stays folded into `variant`.
+
+- [ ] T006 [US2] For each approved audit entry of `kind=prop`, rename to shadcn's vocabulary, add the deprecation alias (T003 pattern), move the sidecar/TSDoc/stories/tests in the same change, and add a codemod. **Grounding expects zero entries** (Button/Tabs/SegmentedControl already shadcn-flat, no `intent` prop); if so, this story is satisfied by the audit's compliant record.
+
+**Checkpoint**: no bespoke variant-synonym remains; confirmed by the audit.
+
+---
+
+## Phase 5: Slot consistency (US3 — expected near-empty)
+
+**Goal**: Every compound's PUBLIC slots follow shadcn's convention (which they already use).
+
+- [ ] T007 [US3] For each approved audit entry of `kind=slot`, rename the public slot to shadcn's convention, with lockstep docs/tests and a codemod. Do NOT re-expose Base UI's internal `Popup`/`Positioner` as renamed public slots. **Grounding expects zero entries** (the compounds already expose `Content`/`Trigger`/`Item`); if so, the audit's compliant record satisfies the story.
+
+**Checkpoint**: public slots follow shadcn; Base UI internals stay internal.
+
+---
+
+## Phase 6: Polymorphic prop unification (US4 — the real tail)
+
+**Goal**: Render-as uses Base UI's `render` everywhere; `as` is the deprecated alias.
+
+- [ ] T008 [P] [US4] In `Tooltip/Tooltip.tsx`: rename the `as` prop to `render` (or remove it in favor of Base UI's passthrough `render`), add the `as`→`render` deprecation alias (T003), and move `Tooltip.usage.md`, the TSDoc, the stories, and the tests in the same change.
+- [ ] T009 [P] [US4] For each OTHER approved audit entry of `kind=polymorphic` (expected: VisuallyHidden, possibly SkipLink), apply the same `as`→`render` rename + alias + lockstep docs in that component's files.
+- [ ] T010 [US4] Add the `as-to-render` jscodeshift transform in `codemods/as-to-render.ts` and a test asserting it rewrites `as=` to `render=` on a sample consumer snippet. (Depends on T008/T009 settling the rename.)
+
+**Checkpoint**: `render` is the one polymorphic prop; `as` works only via the warned alias.
+
+---
+
+## Phase 7: Structured failure output (US5)
+
+- [ ] T011 [US5] For each approved audit entry of `kind=failure`, route the prose-only warning or throw through `warn()`'s `{ code, path, message }` shape, keeping the human-readable string. Add a test asserting the structured payload. (The deprecation warnings from T003 already use this shape.)
+
+**Checkpoint**: every flagged failure path is machine-parseable.
+
+---
+
+## Phase 8: Polish, migration & governance
+
+- [ ] T012 Add the migration note to the changeset and `CHANGELOG`: every rename old→new, with the codemod command for the mechanical ones. Run the prose through the `humanizer`.
+- [X] T013 Amend Constitution Section XI.2 to be compat-first (the shared vocabulary governs props/slots the design system introduces; props/slots inherited from a wrapped library follow the upstream name). Minor bump; update the Sync Impact Report. Run the prose through the `humanizer`.
+- [X] T014 Full verification: `pnpm --filter @unbranded-ds/react test` (renamed components green; deprecation + codemod tests pass), `pnpm typecheck`, `pnpm --filter @unbranded-ds/react lint`, `pnpm --filter @unbranded-ds/storybook build && pnpm --filter @unbranded-ds/storybook test:storybook`. Grep for stale names: no in-repo doc/story/test references a renamed old name.
+- [ ] T015 Add `.changeset/*.md`: `@unbranded-ds/react` minor (pre-1.0 breaking), referencing the migration note and the XI.2 amendment.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase order
+
+**Setup (T001–T002) → Foundational (T003) → US1 audit + review (T004–T005, the GATE) → US2/US3/US4/US5 renames (T006–T011, scoped by the approved audit) → Polish (T012–T015).**
+
+### Hard dependencies
+
+- **T005 (audit approval) blocks every rename (T006–T011).** No rename starts before the audit is reviewed.
+- T003 (the deprecation pattern) is reused by every rename.
+- T010 (the codemod) depends on T008/T009 settling the rename.
+- T012–T015 depend on all renames + the structured-failure pass.
+
+### Parallel opportunities
+
+- **The audit (T004)** can fan out per-component, then converge.
+- **The rename tail (T008, T009)** is per-component and parallel — but small (grounding: mostly Tooltip).
+- T006/T007 are expected to be no-ops (compliant), confirmed by the audit.
+
+---
+
+## Implementation Strategy
+
+### MVP (US1 — the audit)
+
+T001–T005. Ships the bounded, reviewed inventory of the library's XI.2/upstream compliance and its (short) rename tail. Independently valuable even if the renames slipped: it is the API-debt map no one has today, and grounding suggests it largely confirms compliance.
+
+### Full delivery
+
+1. Setup + the deprecation mechanism (T001–T003).
+2. The audit + review gate (T004–T005).
+3. The renames the audit approved (T006–T011), mostly the polymorphic tail.
+4. Migration note + XI.2 amendment + verify (T012–T015).
+
+### Notes
+
+- **The audit gates everything.** Treat T005 as a hard stop; no rename before approval.
+- **Upstream names win.** Never rename a prop/slot inherited unchanged from shadcn/Base UI; public slots already on shadcn stay.
+- **Lockstep docs.** Every rename moves its sidecar + TSDoc + stories + tests in the same change (XI.3, FR-007).
+- **Names, not semantics.** A rename must not change behavior; the existing suites pass unchanged.
+- **The XI.2 amendment (T013) is the lasting change** — it writes the compat-first principle into the constitution.
+- **All prose through the humanizer** (T004 audit, T012 migration note, T013 amendment).


### PR DESCRIPTION
## Summary

Spec 013 is the breaking half of the constitution retrofit (Part B to spec 010's Part A): bring the components onto a predictable, XI.2-compliant API, under one non-negotiable constraint, that they stay compatible with shadcn/ui and Base UI. It is discovery-gated: an audit runs first, and no rename starts before it is reviewed.

The audit found the library was already built faithfully to shadcn/Base UI. There was nothing to rename. So this ships as a **docs and governance PR**: the audit (the compliance record) and a constitution amendment that makes Section XI.2 compat-first. No `packages/react` code changed, and there is no `@unbranded-ds/react` release.

## What The Audit Found

All 14 components are compliant on three of the four drift kinds:

- **Prop vocabulary**: no bespoke synonym; everything uses shadcn's flat `variant` and `size`. No `intent`/`tone`/`appearance` prop exists.
- **Slots**: every compound exposes shadcn's public slot names (`Content`, `Trigger`), built on Base UI's internal anatomy.
- **Structured failures**: none prose-only; the two warning sites already use the `warn()` helper.

The full per-component table is at `specs/013-api-vocabulary-harmonization/audit.md`.

## The One Finding (and the reversal it forced)

The clarify had decided "unify polymorphic rendering on `render`." The audit showed the code has **three distinct mechanisms**, not one prop to unify:

- `as` (VisuallyHidden) is a polymorphic element-type
- `asChild` (Tooltip) is shadcn's Slot idiom
- `render` (Base UI compounds) is Base UI's, by passthrough

Unifying on `render` would have **broken shadcn's `asChild`**, the exact compatibility this spec exists to protect. Reversed at the gate: document the split by lineage, keep all three, rename nothing.

## What Changed

- `specs/013-api-vocabulary-harmonization/` — the spec-kit set and the audit deliverable
- `.specify/memory/constitution.md` — Section XI.2 made compat-first; the polymorphic-by-lineage rule; `intent` dropped from the shared vocabulary (1.2.0 to 1.3.0)
- `ROADMAP.md` — parked the richer 2D variant model the clarify surfaced

No component renames, no codemods, no deprecation window, no changeset.

## Test Plan

- [ ] CI: `@unbranded-ds/react` tests pass **unchanged** (96) and typecheck is green, confirming zero behavior change
- [ ] The audit at `specs/.../audit.md` is the reviewable evidence behind "renamed nothing"
- [ ] Constitution reads 1.3.0 with the Sync Impact Report and prior-amendments list updated
