### PR TITLE
feat: theme controls (useTheme, ThemeProvider, ThemeToggle, DensityToggle)

### DIFF
--- a/.changeset/theme-controls.md
+++ b/.changeset/theme-controls.md
@@ -1,0 +1,6 @@
+---
+"@unbranded-ds/react": minor
+"@unbranded-ds/tokens": minor
+---
+
+Add theme controls: a `ThemeProvider`, the axis-aware `useTheme()` hook, and the `<ThemeToggle>` and `<DensityToggle>` sibling controls. The tokens package gains a browser-safe `themesForAxis()` registry export and now also exports the `Axis` type, `AXIS_ATTRIBUTE`, and the storage-key constants (including a new `THEME_PREFERENCE_STORAGE_KEY`) that the hook reads for its per-axis value lists and flash-free `system` persistence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ Every shipped component has a `<Component>.usage.md` sidecar next to its source.
 | Button           | Token-styled button with variant, size, and an asChild render slot.                                  | [Button.usage.md](./packages/react/src/components/Button/Button.usage.md)                               |
 | Card             | Container surface with rounded corners and shadow tokens.                                            | [Card.usage.md](./packages/react/src/components/Card/Card.usage.md)                                     |
 | Checkbox         | Token-styled checkbox built on Base UI's Checkbox primitive.                                         | [Checkbox.usage.md](./packages/react/src/components/Checkbox/Checkbox.usage.md)                         |
+| DensityToggle    | Density-axis control, data-driven from the theme registry; pairs with ThemeToggle.                  | [DensityToggle.usage.md](./packages/react/src/components/DensityToggle/DensityToggle.usage.md)          |
 | Dialog           | Modal dialog with title, description, and action slots.                                              | [Dialog.usage.md](./packages/react/src/components/Dialog/Dialog.usage.md)                               |
 | Input            | Single-line text input.                                                                              | [Input.usage.md](./packages/react/src/components/Input/Input.usage.md)                                  |
 | Label            | Form label, pairs with Input.                                                                        | [Label.usage.md](./packages/react/src/components/Label/Label.usage.md)                                  |
@@ -106,8 +107,18 @@ Every shipped component has a `<Component>.usage.md` sidecar next to its source.
 | Slider           | Numeric range input supporting single-value and range modes with pointer, keyboard, and touch input. | [Slider.usage.md](./packages/react/src/components/Slider/Slider.usage.md)                               |
 | Switch           | Token-styled toggle switch.                                                                          | [Switch.usage.md](./packages/react/src/components/Switch/Switch.usage.md)                               |
 | Tabs             | Tab-style navigation with panel content keyed by value.                                              | [Tabs.usage.md](./packages/react/src/components/Tabs/Tabs.usage.md)                                     |
+| ThemeToggle      | Light/system/dark color-scheme control wired to useTheme; the for-coleman pattern.                   | [ThemeToggle.usage.md](./packages/react/src/components/ThemeToggle/ThemeToggle.usage.md)                |
 | Tooltip          | Contextual hover and focus tooltip; supports asChild for inline-element wrapping (citation pattern). | [Tooltip.usage.md](./packages/react/src/components/Tooltip/Tooltip.usage.md)                            |
 | VisuallyHidden   | Polymorphic component for screen-reader-only content.                                                | [VisuallyHidden.usage.md](./packages/react/src/components/VisuallyHidden/VisuallyHidden.usage.md)       |
+
+## Hook index
+
+Theme state is read and set through a hook plus its provider, rather than a component. Both ship a sidecar like the components do.
+
+| Export | Summary | Sidecar |
+| --- | --- | --- |
+| useTheme | Multi-axis theme hook: per-axis preference, resolved, forced, available, and one set(partial). The next-themes analog. | [useTheme.usage.md](./packages/react/src/hooks/useTheme/useTheme.usage.md) |
+| ThemeProvider | Single source of truth for theme state; the home for defaults and forced. | [useTheme.usage.md](./packages/react/src/hooks/useTheme/useTheme.usage.md) |
 
 ## Sidecar convention
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,9 @@
 # heliostat Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-06-12
+Auto-generated from all feature plans. Last updated: 2026-06-15
 
 ## Active Technologies
+
 - TypeScript 5.x in `tsx`-tagged code blocks only (validated via `tsc --noEmit` per spec 005's compile validator). Sidecar prose is plain CommonMark. + All shipped in spec 005. The template at `packages/react/src/components/_template/Component.usage.md`, the validator at `scripts/validate-sidecars.ts`, the `AGENTS.md` component index, and the CI step that wires the validator into the verify job. (006-sidecar-retrofit)
 - Filesystem only. 14 `<Component>.usage.md` files co-located with their `.tsx` source. One running inbox file: `specs/006-sidecar-retrofit/spec-007-inbox.md`. 15 `.changeset/*.md` files (14 component + 1 backfill). (006-sidecar-retrofit)
 - TypeScript 5.x, strict mode, no `any` + `@base-ui-components/react`, `class-variance-authority`, Storybook 10.3 (`@storybook/react-vite`), react-docgen (Storybook-bundled) (007-autodoc-audit)
@@ -16,6 +17,8 @@ Auto-generated from all feature plans. Last updated: 2026-06-12
 - Filesystem only. New per-theme resolved-delta artifacts and the generated defaults baseline under `packages/tokens/dist/` and `packages/tokens/src/` respectively. (014-resolution-unification)
 - TypeScript 5.x, strict mode, no `any` + `@base-ui-components/react`, `class-variance-authority`, Storybook 10.3 (interaction + a11y), the `warn()` helper (`lib/warn.ts`), jscodeshift (NEW, for the rename codemods) (013-api-vocabulary-harmonization)
 - N/A (component library) (013-api-vocabulary-harmonization)
+- TypeScript 5.x, strict mode, no `any` + React (peer; uses `useSyncExternalStore`), `@base-ui-components/react` (peer, reached via SegmentedControl), `lucide-react` ^1.8.0 (Sun/SunMoon/Moon icons, existing dep), `class-variance-authority` + `cn()` (existing), the `SegmentedControl` primitive (spec 004), `@unbranded-ds/tokens` runtime (storage-key constants, the `Axis` union, and a NEW "themes per axis" registry export). No `next-themes` runtime dependency (vocabulary alignment only). (011-theme-toggle)
+- `localStorage`. Existing keys `unbranded-ds-theme` (now always holds a concrete theme) and `unbranded-ds-density`, plus one NEW companion key for the color-scheme `system` intent (working name `unbranded-ds-theme-preference`). Sidecars are markdown files on disk. (011-theme-toggle)
 
 - TypeScript 5.x, strict mode, no `any` (Constitution Section VIII) (004-primitive-set-expansion)
 - N/A (component library; no persisted data) (004-primitive-set-expansion)
@@ -45,11 +48,12 @@ npm test && npm run lint
 TypeScript 5.x, strict mode, no `any` (EVER): Follow standard conventions
 
 ## Recent Changes
+
+- 011-theme-toggle: Added TypeScript 5.x, strict mode, no `any` + React (peer; uses `useSyncExternalStore`), `@base-ui-components/react` (peer, reached via SegmentedControl), `lucide-react` ^1.8.0 (Sun/SunMoon/Moon icons, existing dep), `class-variance-authority` + `cn()` (existing), the `SegmentedControl` primitive (spec 004), `@unbranded-ds/tokens` runtime (storage-key constants, the `Axis` union, and a NEW "themes per axis" registry export). No `next-themes` runtime dependency (vocabulary alignment only).
 - 013-api-vocabulary-harmonization: Added TypeScript 5.x, strict mode, no `any` + `@base-ui-components/react`, `class-variance-authority`, Storybook 10.3 (interaction + a11y), the `warn()` helper (`lib/warn.ts`), jscodeshift (NEW, for the rename codemods)
 - 014-resolution-unification: Added TypeScript 5.x, strict mode, no `any` + Style Dictionary v4 (made the single resolver for bundled themes), Zod (schema/validation, unchanged), `@modelcontextprotocol/sdk` (the MCP, repointed)
-- 009-theming-system-expansion: Added TypeScript 5.x, strict mode, no `any` + Style Dictionary v4 (DTCG build), Zod (theme schema + validation), Tailwind CSS v4 (`@theme` preset + cascade `@layer`), `@modelcontextprotocol/sdk` (token-query MCP)
-
-
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->
+
+`

--- a/packages/react/src/components/DensityToggle/DensityToggle.stories.tsx
+++ b/packages/react/src/components/DensityToggle/DensityToggle.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { registerTheme } from '@unbranded-ds/tokens/runtime';
+
+import { ThemeProvider } from '../../hooks/useTheme';
+import { DensityToggle } from './DensityToggle';
+
+const meta = {
+	title: 'Components/DensityToggle',
+	component: DensityToggle,
+	tags: ['autodocs'],
+	decorators: [
+		(Story) => (
+			<ThemeProvider>
+				<Story />
+			</ThemeProvider>
+		),
+	],
+} satisfies Meta<typeof DensityToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Segments are data-driven from the tokens registry (`themesForAxis(\'density\')`), so comfortable and compact appear automatically. No `system` segment, because density has no OS signal.',
+			},
+		},
+	},
+};
+
+export const Sizes: Story = {
+	render: () => (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', alignItems: 'flex-start' }}>
+			<DensityToggle size="sm" />
+			<DensityToggle size="md" />
+			<DensityToggle size="lg" />
+		</div>
+	),
+};
+
+export const Orientations: Story = {
+	render: () => (
+		<div style={{ display: 'flex', gap: '1.5rem', alignItems: 'flex-start' }}>
+			<DensityToggle orientation="horizontal" />
+			<DensityToggle orientation="vertical" />
+		</div>
+	),
+};
+
+export const Forced: Story = {
+	decorators: [
+		(Story) => (
+			<ThemeProvider forced={{ density: 'compact' }}>
+				<Story />
+			</ThemeProvider>
+		),
+	],
+	parameters: {
+		docs: { description: { story: 'A pinned density axis renders the toggle disabled.' } },
+	},
+};
+
+export const CustomLabelsAndIcons: Story = {
+	args: {
+		labels: { comfortable: 'Roomy', compact: 'Tight' },
+	},
+};
+
+// A self-consistent AA-passing color block. A partial theme inherits the
+// canonical default colors, which sit just under 4.5:1 on a couple of pairs and
+// would fail the contrast gate, so a runtime theme supplies its own passing set.
+/* eslint-disable custom-rules/no-hardcoded-colors -- demo theme data for a runtime registerTheme example, not component styling; the values must be concrete hex to clear the contrast gate */
+const PASSING_COLORS = {
+	'background': '#f8f9fa',
+	'foreground': '#212529',
+	'primary': '#0d6efd',
+	'primary-foreground': '#ffffff',
+	'muted': '#e9ecef',
+	'muted-foreground': '#495057',
+	'border': '#dee2e6',
+	'ring': '#0d6efd',
+	'destructive': '#dc3545',
+	'destructive-foreground': '#ffffff',
+};
+/* eslint-enable custom-rules/no-hardcoded-colors */
+
+export const DataDrivenValues: Story = {
+	beforeEach: () => {
+		registerTheme(
+			{
+				name: 'cozy',
+				displayName: 'Cozy',
+				tokens: { color: PASSING_COLORS, spacing: { 4: '0.9rem' } },
+			},
+			'density',
+		);
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Registering a density theme at runtime (`registerTheme(theme, \'density\')`) adds a "Cozy" segment with no change to the component; the toggle is data-driven from the registry.',
+			},
+		},
+	},
+};

--- a/packages/react/src/components/DensityToggle/DensityToggle.test.tsx
+++ b/packages/react/src/components/DensityToggle/DensityToggle.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { themesForAxis } from '@unbranded-ds/tokens/client';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ThemeProvider, useTheme } from '../../hooks/useTheme';
+import { DensityToggle } from './DensityToggle';
+
+function DensityProbe() {
+	const { resolved } = useTheme();
+	return <span data-testid="density">{resolved.density}</span>;
+}
+
+describe('densityToggle', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		document.documentElement.removeAttribute('data-density');
+		window.matchMedia = ((query: string) =>
+			({
+				matches: false,
+				media: query,
+				addEventListener() {},
+				removeEventListener() {},
+			}) as unknown as MediaQueryList) as typeof window.matchMedia;
+	});
+	afterEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+	});
+
+	it('renders one segment per available density value, data-driven from the registry', () => {
+		const { getAllByRole, getByText } = render(
+			<ThemeProvider>
+				<DensityToggle />
+			</ThemeProvider>,
+		);
+		expect(getAllByRole('radio')).toHaveLength(themesForAxis('density').length);
+		expect(getByText('Comfortable')).toBeInTheDocument();
+		expect(getByText('Compact')).toBeInTheDocument();
+	});
+
+	it('has no system segment', () => {
+		const { queryByText } = render(
+			<ThemeProvider>
+				<DensityToggle />
+			</ThemeProvider>,
+		);
+		expect(queryByText('System')).toBeNull();
+	});
+
+	it('routes a selection to set() and updates the applied density', () => {
+		const { getByText, getByTestId } = render(
+			<ThemeProvider>
+				<DensityToggle />
+				<DensityProbe />
+			</ThemeProvider>,
+		);
+		fireEvent.click(getByText('Compact'));
+		expect(getByTestId('density')).toHaveTextContent('compact');
+	});
+
+	it('renders disabled when the density axis is forced', () => {
+		const { getByRole } = render(
+			<ThemeProvider forced={{ density: 'compact' }}>
+				<DensityToggle />
+			</ThemeProvider>,
+		);
+		expect(getByRole('radiogroup').getAttribute('aria-disabled')).toBe('true');
+	});
+
+	it('exposes an accessible group name', () => {
+		const { getByRole } = render(
+			<ThemeProvider>
+				<DensityToggle />
+			</ThemeProvider>,
+		);
+		expect(getByRole('radiogroup', { name: 'Density' })).toBeInTheDocument();
+	});
+});

--- a/packages/react/src/components/DensityToggle/DensityToggle.tsx
+++ b/packages/react/src/components/DensityToggle/DensityToggle.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { themesForAxis } from '@unbranded-ds/tokens/client';
+import * as React from 'react';
+
+import { AxisToggle } from '../_internal/AxisToggle';
+
+export interface DensityToggleProps {
+	/** Per-value label overrides, keyed by density value; English defaults otherwise. */
+	'labels'?: Record<string, string>;
+	/** Per-value icons, keyed by density value; none by default (density has no canonical icon). */
+	'icons'?: Record<string, ReactNode>;
+	'size'?: 'sm' | 'md' | 'lg';
+	'orientation'?: 'horizontal' | 'vertical';
+	'aria-label'?: string;
+	'className'?: string;
+	'id'?: string;
+}
+
+// English defaults for the built-in values. A value with no entry (a custom
+// runtime theme) falls back to its raw name in AxisToggle.
+const DEFAULT_LABELS: Record<string, string> = {
+	comfortable: 'Comfortable',
+	compact: 'Compact',
+	expanded: 'Expanded',
+};
+
+/**
+ * The density control: a segmented control over the density axis of
+ * `useTheme()`. Unlike `<ThemeToggle>`, its segments are data-driven from the
+ * tokens registry (`themesForAxis('density')`), so a newly authored density
+ * value appears with no change here. There is no `system` segment, because
+ * density has no OS signal. Must run inside a `<ThemeProvider>`.
+ *
+ * @example
+ * ```tsx
+ * import { ThemeProvider, DensityToggle } from '@unbranded-ds/react';
+ *
+ * <ThemeProvider>
+ *   <DensityToggle />
+ * </ThemeProvider>
+ * ```
+ *
+ * @see {@link useTheme} for the per-axis API and the next-themes vocabulary mapping.
+ */
+export function DensityToggle({
+	labels,
+	icons,
+	...rest
+}: DensityToggleProps): React.JSX.Element {
+	return (
+		<AxisToggle
+			axis="density"
+			values={themesForAxis('density')}
+			groupLabel="Density"
+			labels={{ ...DEFAULT_LABELS, ...labels }}
+			icons={icons}
+			{...rest}
+		/>
+	);
+}

--- a/packages/react/src/components/DensityToggle/DensityToggle.usage.md
+++ b/packages/react/src/components/DensityToggle/DensityToggle.usage.md
@@ -1,0 +1,53 @@
+# DensityToggle
+
+A segmented control over the density axis of `useTheme()`. Its segments are data-driven from the tokens registry, so a newly authored density value appears with no change here. There is no `system` segment, because density has no OS signal.
+
+If you know next-themes, this is its mode-toggle pattern applied to a second axis through the multi-axis [useTheme](../../hooks/useTheme/useTheme.usage.md), where the full vocabulary mapping lives.
+
+## When to use
+
+Drop `<DensityToggle>` beside a `<ThemeToggle>` to expose the second theming axis. The two are independent, so a combination like vaporwave plus compact is simply the product of both controls rather than a bespoke variant. Must render inside a `<ThemeProvider>`.
+
+## Import
+
+```tsx
+import { DensityToggle, ThemeProvider } from '@unbranded-ds/react';
+```
+
+## Props
+
+| Prop          | Type                         | Default           | Description                                                                                            |
+| ------------- | ---------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------ |
+| `labels`      | `Record<string, string>`     | English per value | Per-value label overrides, keyed by density value.                                                     |
+| `icons`       | `Record<string, ReactNode>`  | none              | Per-value icons, keyed by density value. Density has no canonical icon, so labels are text by default. |
+| `size`        | `'sm' \| 'md' \| 'lg'`       | `'md'`            | Forwarded to the underlying SegmentedControl.                                                          |
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'`    | Forwarded to the underlying SegmentedControl.                                                          |
+| `aria-label`  | `string`                     | `'Density'`       | Accessible name for the radiogroup.                                                                    |
+| `className`   | `string`                     | —                 | Merged onto the root.                                                                                  |
+| `id`          | `string`                     | —                 | Forwarded to the radiogroup root.                                                                      |
+
+## Common patterns
+
+### Beside a color-scheme toggle
+
+```tsx
+import { DensityToggle, ThemeProvider, ThemeToggle } from '@unbranded-ds/react';
+
+export function ThemeControls() {
+	return (
+		<ThemeProvider>
+			<ThemeToggle />
+			<DensityToggle />
+		</ThemeProvider>
+	);
+}
+```
+
+## Accessibility
+
+The control renders a `radiogroup` named "Density" (override with `aria-label`) and one `radio` per available value, inheriting the SegmentedControl keyboard model. It shows no selected segment until mounted, then reflects the stored preference. When the density axis is forced by the provider, the control renders disabled.
+
+## Related
+
+- [ThemeToggle](../ThemeToggle/ThemeToggle.usage.md) — the color-scheme sibling; render it beside this one to compose axes.
+- [SegmentedControl](../SegmentedControl/SegmentedControl.usage.md) — the primitive both toggles wrap.

--- a/packages/react/src/components/DensityToggle/index.ts
+++ b/packages/react/src/components/DensityToggle/index.ts
@@ -1,0 +1,2 @@
+export { DensityToggle } from './DensityToggle';
+export type { DensityToggleProps } from './DensityToggle';

--- a/packages/react/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/react/src/components/SegmentedControl/SegmentedControl.tsx
@@ -84,20 +84,20 @@ interface SegmentedControlRootProps {
 	 * from `onValueChange` for the selection to visually change. Pair with
 	 * `onValueChange`; omit `defaultValue` when using `value`.
 	 */
-	value?: string;
+	'value'?: string;
 	/**
 	 * Seeds the selected value for uncontrolled usage. Reach for it when no
 	 * external code needs to react to or drive the selection — the component
 	 * then manages state internally. Ignored once `value` is set.
 	 */
-	defaultValue?: string;
+	'defaultValue'?: string;
 	/**
 	 * Fires with the newly selected value when the user picks an item by click
 	 * or keyboard. The callback receives only the new value as a string. In
 	 * controlled mode this is where you commit the change to whatever owns the
 	 * state.
 	 */
-	onValueChange?: (value: string) => void;
+	'onValueChange'?: (value: string) => void;
 	/**
 	 * Visual size of each segment. Drives item height, horizontal padding, and
 	 * label font scale across the whole group. Use `'sm'` in dense toolbars
@@ -107,7 +107,7 @@ interface SegmentedControlRootProps {
 	 *
 	 * @defaultValue `'md'`
 	 */
-	size?: 'sm' | 'md' | 'lg';
+	'size'?: 'sm' | 'md' | 'lg';
 	/**
 	 * Layout axis of the segment strip. `'horizontal'` lays items in a row —
 	 * the right fit for toolbars and view switchers; `'vertical'` lays them in
@@ -122,7 +122,7 @@ interface SegmentedControlRootProps {
 	 *
 	 * @defaultValue `'horizontal'`
 	 */
-	orientation?: 'horizontal' | 'vertical';
+	'orientation'?: 'horizontal' | 'vertical';
 	/**
 	 * When `true`, the entire control is non-interactive. The Root sets
 	 * `aria-disabled="true"` and pointer events are suppressed. Use this when
@@ -132,18 +132,28 @@ interface SegmentedControlRootProps {
 	 *
 	 * @defaultValue `false`
 	 */
-	disabled?: boolean;
+	'disabled'?: boolean;
 	/**
 	 * One or more `<SegmentedControl.Item>` children. A dev-mode warning fires
 	 * if the Root has no children — empty groups are usually a bug.
 	 */
-	children: React.ReactNode;
+	'children': React.ReactNode;
 	/**
 	 * Merged with the Root's CVA classes via `cn()`. Reach for it when a
 	 * one-off spacing or layout override is needed without forking the
 	 * component.
 	 */
-	className?: string;
+	'className'?: string;
+	/**
+	 * Accessible name for the radiogroup, forwarded to the underlying element.
+	 * Provide it when the group has no visible label, as an icon-driven control
+	 * usually does.
+	 */
+	'aria-label'?: string;
+	/** Id of an element labeling the group, as an alternative to `aria-label`. */
+	'aria-labelledby'?: string;
+	/** Forwarded to the radiogroup root element. */
+	'id'?: string;
 }
 
 interface SegmentedControlItemProps {

--- a/packages/react/src/components/ThemeToggle/ThemeToggle.stories.tsx
+++ b/packages/react/src/components/ThemeToggle/ThemeToggle.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { expect, userEvent, within } from 'storybook/test';
+
+import { ThemeProvider } from '../../hooks/useTheme';
+import { ThemeToggle } from './ThemeToggle';
+
+const meta = {
+	title: 'Components/ThemeToggle',
+	component: ThemeToggle,
+	tags: ['autodocs'],
+	decorators: [
+		(Story) => (
+			<ThemeProvider>
+				<Story />
+			</ThemeProvider>
+		),
+	],
+} satisfies Meta<typeof ThemeToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function checkedLabel(canvasElement: HTMLElement): string | null | undefined {
+	return within(canvasElement)
+		.getAllByRole('radio')
+		.find((radio) => radio.getAttribute('aria-checked') === 'true')
+		?.textContent;
+}
+
+export const Default: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Three fixed segments (light, system, dark) wired to the aesthetic axis. Selecting one persists it and applies `data-theme` to the document root.',
+			},
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByText('Dark'));
+		expect(checkedLabel(canvasElement)).toBe('Dark');
+	},
+};
+
+export const SystemFollowing: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Selecting **System** follows the OS via `prefers-color-scheme`. The live OS-change path (the resolved value flipping when the OS theme changes) is exercised deterministically in the unit suite, `themeStore.test.ts`.',
+			},
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByText('System'));
+		expect(checkedLabel(canvasElement)).toBe('System');
+	},
+};
+
+export const Sizes: Story = {
+	render: () => (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', alignItems: 'flex-start' }}>
+			<ThemeToggle size="sm" />
+			<ThemeToggle size="md" />
+			<ThemeToggle size="lg" />
+		</div>
+	),
+	parameters: {
+		docs: { description: { story: 'The three sizes, forwarded to the underlying SegmentedControl.' } },
+	},
+};
+
+export const Orientations: Story = {
+	render: () => (
+		<div style={{ display: 'flex', gap: '1.5rem', alignItems: 'flex-start' }}>
+			<ThemeToggle orientation="horizontal" />
+			<ThemeToggle orientation="vertical" />
+		</div>
+	),
+	parameters: {
+		docs: { description: { story: 'Horizontal and vertical layouts.' } },
+	},
+};
+
+export const Forced: Story = {
+	decorators: [
+		(Story) => (
+			<ThemeProvider forced={{ aesthetic: 'dark' }}>
+				<Story />
+			</ThemeProvider>
+		),
+	],
+	parameters: {
+		docs: {
+			description: {
+				story: 'A pinned aesthetic axis (`forced={{ aesthetic: \'dark\' }}`) renders the toggle disabled.',
+			},
+		},
+	},
+};
+
+export const AestheticIsBrand: Story = {
+	decorators: [
+		(Story) => (
+			<ThemeProvider defaults={{ aesthetic: 'brand' }}>
+				<Story />
+			</ThemeProvider>
+		),
+	],
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'When the aesthetic value is `brand` or `vaporwave` (neither light nor dark), no segment is selected and the control stays enabled. Color-scheme is not yet its own axis.',
+			},
+		},
+	},
+};
+
+export const CustomLabelsAndIcons: Story = {
+	args: {
+		labels: { light: 'Día', system: 'Auto', dark: 'Noche' },
+	},
+	parameters: {
+		docs: { description: { story: 'Per-segment `labels` (and `icons`) overrides.' } },
+	},
+};

--- a/packages/react/src/components/ThemeToggle/ThemeToggle.test.tsx
+++ b/packages/react/src/components/ThemeToggle/ThemeToggle.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { THEME_STORAGE_KEY } from '@unbranded-ds/tokens/runtime';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ThemeProvider, useTheme } from '../../hooks/useTheme';
+import { ThemeToggle } from './ThemeToggle';
+
+function SchemeProbe() {
+	const { resolved } = useTheme();
+	return <span data-testid="scheme">{resolved.aesthetic}</span>;
+}
+
+describe('themeToggle', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		document.documentElement.removeAttribute('data-theme');
+		window.matchMedia = ((query: string) =>
+			({
+				matches: false,
+				media: query,
+				addEventListener() {},
+				removeEventListener() {},
+			}) as unknown as MediaQueryList) as typeof window.matchMedia;
+	});
+	afterEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+	});
+
+	it('renders three color-scheme segments with an accessible group name', () => {
+		const { getByRole, getAllByRole } = render(
+			<ThemeProvider>
+				<ThemeToggle />
+			</ThemeProvider>,
+		);
+		expect(getByRole('radiogroup', { name: 'Color scheme' })).toBeInTheDocument();
+		expect(getAllByRole('radio')).toHaveLength(3);
+	});
+
+	it('routes a selection to set() and updates the applied scheme', () => {
+		const { getByText, getByTestId } = render(
+			<ThemeProvider>
+				<ThemeToggle />
+				<SchemeProbe />
+			</ThemeProvider>,
+		);
+		fireEvent.click(getByText('Dark'));
+		expect(getByTestId('scheme')).toHaveTextContent('dark');
+	});
+
+	it('shows no selection but stays enabled when the aesthetic value is brand/vaporwave', () => {
+		localStorage.setItem(THEME_STORAGE_KEY, 'vaporwave');
+		const { getByRole, getAllByRole } = render(
+			<ThemeProvider>
+				<ThemeToggle />
+			</ThemeProvider>,
+		);
+		const checked = getAllByRole('radio').filter(
+			(radio) => radio.getAttribute('aria-checked') === 'true',
+		);
+		expect(checked).toHaveLength(0);
+		expect(getByRole('radiogroup').getAttribute('aria-disabled')).not.toBe('true');
+	});
+
+	it('renders disabled when the aesthetic axis is forced', () => {
+		const { getByRole } = render(
+			<ThemeProvider forced={{ aesthetic: 'dark' }}>
+				<ThemeToggle />
+			</ThemeProvider>,
+		);
+		expect(getByRole('radiogroup').getAttribute('aria-disabled')).toBe('true');
+	});
+
+	it('accepts custom labels', () => {
+		const { getByText } = render(
+			<ThemeProvider>
+				<ThemeToggle labels={{ light: 'Día' }} />
+			</ThemeProvider>,
+		);
+		expect(getByText('Día')).toBeInTheDocument();
+	});
+});

--- a/packages/react/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/packages/react/src/components/ThemeToggle/ThemeToggle.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { Moon, Sun, SunMoon } from 'lucide-react';
+import * as React from 'react';
+
+import { AxisToggle } from '../_internal/AxisToggle';
+
+type ColorScheme = 'light' | 'system' | 'dark';
+
+export interface ThemeToggleProps {
+	/** Per-segment label overrides; English defaults otherwise. */
+	'labels'?: Partial<Record<ColorScheme, string>>;
+	/** Per-segment icon overrides; lucide Sun / SunMoon / Moon otherwise. */
+	'icons'?: Partial<Record<ColorScheme, ReactNode>>;
+	'size'?: 'sm' | 'md' | 'lg';
+	'orientation'?: 'horizontal' | 'vertical';
+	'aria-label'?: string;
+	'className'?: string;
+	'id'?: string;
+}
+
+const DEFAULT_LABELS: Record<ColorScheme, string> = {
+	light: 'Light',
+	system: 'System',
+	dark: 'Dark',
+};
+
+/**
+ * The drop-in color-scheme control: a fixed light / system / dark
+ * {@link SegmentedControl} wired to the aesthetic axis of `useTheme()`. Persisted,
+ * system-aware, keyboard-navigable, and accessible. Must run inside a `<ThemeProvider>`.
+ *
+ * @remarks
+ * The three segments are fixed, not derived from the registry. Color-scheme is
+ * not yet its own axis, so when the aesthetic value is `brand` or `vaporwave`
+ * (neither light nor dark) no segment is selected and the control stays enabled;
+ * choosing a segment overwrites the aesthetic value (spec 011 FR-010). For an
+ * explicit two-state light/dark control with no `system`, compose on `useTheme()`
+ * directly; see the sidecar recipe.
+ *
+ * @example
+ * ```tsx
+ * import { ThemeProvider, ThemeToggle } from '@unbranded-ds/react';
+ *
+ * <ThemeProvider>
+ *   <ThemeToggle />
+ * </ThemeProvider>
+ * ```
+ *
+ * @see {@link useTheme} for the per-axis API and the next-themes vocabulary mapping.
+ */
+export function ThemeToggle({
+	labels,
+	icons,
+	...rest
+}: ThemeToggleProps): React.JSX.Element {
+	const mergedIcons: Record<string, ReactNode> = {
+		light: icons?.light ?? <Sun aria-hidden />,
+		system: icons?.system ?? <SunMoon aria-hidden />,
+		dark: icons?.dark ?? <Moon aria-hidden />,
+	};
+
+	return (
+		<AxisToggle
+			axis="aesthetic"
+			values={['light', 'system', 'dark']}
+			groupLabel="Color scheme"
+			labels={{ ...DEFAULT_LABELS, ...labels }}
+			icons={mergedIcons}
+			{...rest}
+		/>
+	);
+}

--- a/packages/react/src/components/ThemeToggle/ThemeToggle.usage.md
+++ b/packages/react/src/components/ThemeToggle/ThemeToggle.usage.md
@@ -1,0 +1,78 @@
+# ThemeToggle
+
+A drop-in color-scheme control: a fixed light / system / dark segmented control wired to the aesthetic axis of `useTheme()`. Persisted, system-aware, keyboard-navigable, and accessible.
+
+If you know next-themes' mode toggle, this is the same idea built on the multi-axis [useTheme](../../hooks/useTheme/useTheme.usage.md), where the full next-themes vocabulary mapping lives.
+
+## When to use
+
+Reach for `ThemeToggle` when an app wants the familiar light / system / dark switch and you would otherwise rebuild it: localStorage persistence, an `auto`-style `system` option that follows the OS, and a flash-free first paint when paired with the spec-002 bootstrap. It must render inside a `<ThemeProvider>`, which owns the state.
+
+For a second axis (density), drop a `<DensityToggle>` beside it; the two compose, so a combination like vaporwave plus compact falls out of two independent controls rather than a bespoke variant. For any other shape (a switch, a dropdown, a two-state light/dark control with no `system`), compose on `useTheme()` directly; the recipe below shows the two-state case.
+
+## Import
+
+```tsx
+import { ThemeProvider, ThemeToggle } from '@unbranded-ds/react';
+```
+
+## Props
+
+| Prop          | Type                                                        | Default              | Description                                   |
+| ------------- | ----------------------------------------------------------- | -------------------- | --------------------------------------------- |
+| `labels`      | `Partial<Record<'light' \| 'system' \| 'dark', string>>`    | English              | Per-segment label overrides.                  |
+| `icons`       | `Partial<Record<'light' \| 'system' \| 'dark', ReactNode>>` | Sun / SunMoon / Moon | Per-segment icon overrides (lucide defaults). |
+| `size`        | `'sm' \| 'md' \| 'lg'`                                      | `'md'`               | Forwarded to the underlying SegmentedControl. |
+| `orientation` | `'horizontal' \| 'vertical'`                                | `'horizontal'`       | Forwarded to the underlying SegmentedControl. |
+| `aria-label`  | `string`                                                    | `'Color scheme'`     | Accessible name for the radiogroup.           |
+| `className`   | `string`                                                    | —                    | Merged onto the root.                         |
+| `id`          | `string`                                                    | —                    | Forwarded to the radiogroup root.             |
+
+## Common patterns
+
+### Drop-in
+
+The control owns nothing; state lives in the provider. Pair the provider with `themeBootstrapScript` (spec 002) for a flash-free reload.
+
+```tsx
+import { ThemeProvider, ThemeToggle } from '@unbranded-ds/react';
+
+export function App() {
+	return (
+		<ThemeProvider>
+			<ThemeToggle />
+		</ThemeProvider>
+	);
+}
+```
+
+### Two-state light/dark (no system)
+
+`<ThemeToggle>` always includes a `system` segment. When you want an explicit light/dark control with no `system`, compose on `useTheme()` (about five lines).
+
+```tsx
+import { SegmentedControl, useTheme } from '@unbranded-ds/react';
+
+export function LightDarkToggle() {
+	const { resolved, set } = useTheme();
+	return (
+		<SegmentedControl.Root
+			aria-label="Color scheme"
+			value={resolved.aesthetic}
+			onValueChange={(value) => set({ aesthetic: value })}
+		>
+			<SegmentedControl.Item value="light">Light</SegmentedControl.Item>
+			<SegmentedControl.Item value="dark">Dark</SegmentedControl.Item>
+		</SegmentedControl.Root>
+	);
+}
+```
+
+## Accessibility
+
+The control renders a `radiogroup` with an accessible name (`aria-label`, defaulting to "Color scheme") and one `radio` per segment, inheriting the SegmentedControl keyboard model (arrow keys on-axis, Home/End, Space to select). Until the component mounts it shows no selected segment, so the server render and the first client render agree and there is no layout shift; the selected segment appears on mount. When the aesthetic axis is forced by the provider, the control renders disabled.
+
+## Related
+
+- [DensityToggle](../DensityToggle/DensityToggle.usage.md) — the sibling control for the density axis; render it beside this one to compose axes.
+- [SegmentedControl](../SegmentedControl/SegmentedControl.usage.md) — the primitive both toggles wrap, and the base for custom controls built on `useTheme()`.

--- a/packages/react/src/components/ThemeToggle/index.ts
+++ b/packages/react/src/components/ThemeToggle/index.ts
@@ -1,0 +1,2 @@
+export { ThemeToggle } from './ThemeToggle';
+export type { ThemeToggleProps } from './ThemeToggle';

--- a/packages/react/src/components/_internal/AxisToggle.tsx
+++ b/packages/react/src/components/_internal/AxisToggle.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import type { Axis } from '@unbranded-ds/tokens/client';
+import type { ReactNode } from 'react';
+
+import * as React from 'react';
+
+import { useTheme } from '../../hooks/useTheme';
+import { SegmentedControl } from '../SegmentedControl';
+
+export interface AxisToggleProps {
+	/** The theme axis this control drives. */
+	'axis': Axis;
+	/** Segment values, in display order. */
+	'values': string[];
+	/** Default accessible group name, used when no `aria-label` is supplied. */
+	'groupLabel': string;
+	/** Per-value visible labels; a value with no entry falls back to the raw value. */
+	'labels'?: Record<string, string>;
+	/** Per-value icons rendered inline before the label. */
+	'icons'?: Record<string, ReactNode>;
+	'size'?: 'sm' | 'md' | 'lg';
+	'orientation'?: 'horizontal' | 'vertical';
+	'aria-label'?: string;
+	'className'?: string;
+	'id'?: string;
+}
+
+/**
+ * Private shared shell behind `<ThemeToggle>` and `<DensityToggle>`. Wires a
+ * `<SegmentedControl>` to one axis of `useTheme()`: the selected segment tracks
+ * the stated `preference`, selecting one routes to `set()`, a forced axis renders
+ * disabled, and the control stays unresolved (no segment selected) until mounted
+ * so the server and first client render agree (spec 011 FR-008, FR-013, FR-014).
+ * Not exported from the package.
+ */
+export function AxisToggle({
+	axis,
+	values,
+	groupLabel,
+	labels,
+	icons,
+	size,
+	orientation,
+	className,
+	id,
+	'aria-label': ariaLabel,
+}: AxisToggleProps): React.JSX.Element {
+	const { preference, forced, set } = useTheme();
+
+	// Unresolved until mounted: an empty value matches no segment, so the server
+	// and the first client render show no selection (no hydration mismatch, no
+	// layout shift). The selected segment appears once mounted.
+	const [mounted, setMounted] = React.useState(false);
+	React.useEffect(() => {
+		setMounted(true);
+	}, []);
+
+	const onValueChange = (next: string): void => {
+		const update: Partial<Record<Axis, string>> = {};
+		update[axis] = next;
+		set(update);
+	};
+
+	return (
+		<SegmentedControl.Root
+			aria-label={ariaLabel ?? groupLabel}
+			id={id}
+			className={className}
+			size={size}
+			orientation={orientation}
+			disabled={forced[axis] != null}
+			value={mounted ? preference[axis] : ''}
+			onValueChange={onValueChange}
+		>
+			{values.map((value) => (
+				<SegmentedControl.Item key={value} value={value}>
+					{icons?.[value]}
+					{labels?.[value] ?? value}
+				</SegmentedControl.Item>
+			))}
+		</SegmentedControl.Root>
+	);
+}

--- a/packages/react/src/hooks/useTheme/ThemeProvider.tsx
+++ b/packages/react/src/hooks/useTheme/ThemeProvider.tsx
@@ -1,0 +1,47 @@
+/* eslint-disable react-refresh/only-export-components -- the ThemeStore context is co-located with its ThemeProvider, the only place it is created */
+'use client';
+
+import type { ThemeStore } from './themeStore';
+import type { ThemeProviderProps } from './types';
+
+import * as React from 'react';
+
+import { createThemeStore } from './themeStore';
+
+/**
+ * Holds the {@link ThemeStore} for the subtree. `null` outside a provider, which
+ * is how {@link useTheme} detects a missing ancestor and throws.
+ */
+export const ThemeStoreContext = React.createContext<ThemeStore | null>(null);
+
+/**
+ * The single source of truth for theme state, and the home for `defaults` and
+ * `forced` configuration. Mirrors `next-themes`' provider: one wraps the app (or
+ * a subtree). Every `useTheme()` below it reads one shared store, so sibling
+ * controls never disagree.
+ *
+ * @remarks
+ * Does not inject the first-paint bootstrap; the consumer still inlines
+ * `themeBootstrapScript` from `@unbranded-ds/tokens/runtime` (spec 002). This
+ * provider reconciles to storage on mount and never reads `window` during
+ * render, so it is SSR-safe. Config (`defaults`, `forced`, `root`) is read once
+ * when the store is created.
+ *
+ * @see {@link useTheme} for the per-axis API and the next-themes vocabulary mapping.
+ */
+export function ThemeProvider({
+	children,
+	defaults = {},
+	forced = {},
+	root,
+}: ThemeProviderProps): React.JSX.Element {
+	// One store per provider instance, created lazily so it is stable across
+	// renders rather than recreated each time.
+	const [store] = React.useState(() => createThemeStore({ defaults, forced, root }));
+
+	return (
+		<ThemeStoreContext.Provider value={store}>
+			{children}
+		</ThemeStoreContext.Provider>
+	);
+}

--- a/packages/react/src/hooks/useTheme/Theming.stories.tsx
+++ b/packages/react/src/hooks/useTheme/Theming.stories.tsx
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { DensityToggle } from '../../components/DensityToggle';
+import { ThemeToggle } from '../../components/ThemeToggle';
+import { ThemeProvider } from './ThemeProvider';
+import { useTheme } from './useTheme';
+
+// This group surfaces the hook and provider in Storybook (and therefore the
+// published MCP), so they are not visible only in the offline sidecar. (FR-024)
+const meta = {
+	title: 'Theming',
+	tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj;
+
+function PlaygroundDemo() {
+	const { preference, resolved, set } = useTheme();
+	return (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', fontSize: '0.875rem' }}>
+			<div>
+				resolved:
+				{' '}
+				<code>{`${resolved.aesthetic} / ${resolved.density}`}</code>
+			</div>
+			<div>
+				preference:
+				{' '}
+				<code>{`${preference.aesthetic} / ${preference.density}`}</code>
+			</div>
+			<div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+				<button type="button" onClick={() => set({ aesthetic: 'light' })}>light</button>
+				<button type="button" onClick={() => set({ aesthetic: 'dark' })}>dark</button>
+				<button type="button" onClick={() => set({ aesthetic: 'system' })}>system</button>
+				<button type="button" onClick={() => set({ aesthetic: 'vaporwave' })}>vaporwave</button>
+				<button type="button" onClick={() => set({ density: 'comfortable' })}>comfortable</button>
+				<button type="button" onClick={() => set({ density: 'compact' })}>compact</button>
+			</div>
+		</div>
+	);
+}
+
+export const Playground: Story = {
+	render: () => (
+		<ThemeProvider>
+			<PlaygroundDemo />
+		</ThemeProvider>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'`useTheme()` read and set, in one object. The buttons each call `set({ axis: value })`; `resolved` and `preference` update live.',
+			},
+		},
+	},
+};
+
+function CompositionDemo() {
+	const { resolved } = useTheme();
+	return (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', alignItems: 'flex-start' }}>
+			<div style={{ display: 'flex', gap: '1rem' }}>
+				<ThemeToggle />
+				<DensityToggle />
+			</div>
+			<div style={{ fontSize: '0.875rem' }}>
+				Applied:
+				{' '}
+				<code>{`${resolved.aesthetic} + ${resolved.density}`}</code>
+			</div>
+		</div>
+	);
+}
+
+export const Composition: Story = {
+	render: () => (
+		<ThemeProvider>
+			<CompositionDemo />
+		</ThemeProvider>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'A color-scheme toggle beside a density toggle, over one provider. The two axes are independent, so a combination like vaporwave + compact is just the product of the two controls, not a composite variant.',
+			},
+		},
+	},
+};
+
+export const ProviderConfig: Story = {
+	render: () => (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', fontSize: '0.875rem' }}>
+			<ThemeProvider defaults={{ aesthetic: 'dark' }}>
+				<div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+					<span>defaults dark:</span>
+					<ThemeToggle />
+				</div>
+			</ThemeProvider>
+			<ThemeProvider forced={{ density: 'compact' }}>
+				<div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+					<span>forced compact:</span>
+					<DensityToggle />
+				</div>
+			</ThemeProvider>
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story: '`defaults` seed a starting value; `forced` pins an axis and disables its toggle.',
+			},
+		},
+	},
+};

--- a/packages/react/src/hooks/useTheme/errors.ts
+++ b/packages/react/src/hooks/useTheme/errors.ts
@@ -1,0 +1,22 @@
+/**
+ * Stable failure codes for the theme hook (spec 011 FR-017, Constitution
+ * Section XI.4). An agent matches on these. The first three are recoverable and
+ * warned through the `warn()` helper (no-op); `THEME_NO_PROVIDER` is thrown.
+ */
+export const THEME_INVALID_VALUE = 'THEME_INVALID_VALUE';
+export const THEME_AXIS_FORCED = 'THEME_AXIS_FORCED';
+export const THEME_NO_SYSTEM_SOURCE = 'THEME_NO_SYSTEM_SOURCE';
+export const THEME_NO_PROVIDER = 'THEME_NO_PROVIDER';
+
+/**
+ * Thrown when `useTheme()` runs with no `<ThemeProvider>` ancestor. There is no
+ * usable state to return, so a structured throw surfaces the wiring mistake at
+ * once rather than masking it with fabricated defaults (clarify Q6).
+ */
+export class ThemeProviderError extends Error {
+	readonly code = THEME_NO_PROVIDER;
+	constructor(message: string) {
+		super(message);
+		this.name = 'ThemeProviderError';
+	}
+}

--- a/packages/react/src/hooks/useTheme/forced.test.tsx
+++ b/packages/react/src/hooks/useTheme/forced.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { DENSITY_STORAGE_KEY } from '@unbranded-ds/tokens/client';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DensityToggle } from '../../components/DensityToggle';
+import { ThemeProvider } from './ThemeProvider';
+import { useTheme } from './useTheme';
+
+// End-to-end pinning (US4): the `forced` plumbing lives in the provider/store
+// (US1) and AxisToggle (US2); this exercises the whole journey together.
+function Harness() {
+	const { resolved, forced, set } = useTheme();
+	return (
+		<div>
+			<span data-testid="density">{resolved.density}</span>
+			<span data-testid="forced">{String(forced.density)}</span>
+			<button type="button" data-testid="try-set" onClick={() => set({ density: 'comfortable' })}>
+				set comfortable
+			</button>
+		</div>
+	);
+}
+
+describe('pin an axis (forced) end to end', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		document.documentElement.removeAttribute('data-density');
+		window.matchMedia = ((query: string) =>
+			({
+				matches: false,
+				media: query,
+				addEventListener() {},
+				removeEventListener() {},
+			}) as unknown as MediaQueryList) as typeof window.matchMedia;
+	});
+	afterEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+	});
+
+	it('forced value wins over storage, disables the toggle, and makes set() a structured no-op', () => {
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		// Storage holds a different value; the forced value must still win.
+		localStorage.setItem(DENSITY_STORAGE_KEY, 'comfortable');
+
+		const { getByTestId, getByRole } = render(
+			<ThemeProvider forced={{ density: 'compact' }}>
+				<DensityToggle />
+				<Harness />
+			</ThemeProvider>,
+		);
+
+		expect(getByTestId('density')).toHaveTextContent('compact');
+		expect(getByTestId('forced')).toHaveTextContent('compact');
+		expect(getByRole('radiogroup').getAttribute('aria-disabled')).toBe('true');
+
+		fireEvent.click(getByTestId('try-set'));
+
+		expect(getByTestId('density')).toHaveTextContent('compact');
+		expect(warnSpy).toHaveBeenCalledWith(
+			'[unbranded-ds]',
+			expect.objectContaining({ code: 'THEME_AXIS_FORCED', axis: 'density' }),
+		);
+	});
+});

--- a/packages/react/src/hooks/useTheme/index.ts
+++ b/packages/react/src/hooks/useTheme/index.ts
@@ -1,0 +1,10 @@
+export {
+	THEME_AXIS_FORCED,
+	THEME_INVALID_VALUE,
+	THEME_NO_PROVIDER,
+	THEME_NO_SYSTEM_SOURCE,
+	ThemeProviderError,
+} from './errors';
+export { ThemeProvider } from './ThemeProvider';
+export type { AxisRecord, PartialAxisRecord, ThemeProviderProps, UseThemeReturn } from './types';
+export { useTheme } from './useTheme';

--- a/packages/react/src/hooks/useTheme/resolve.test.ts
+++ b/packages/react/src/hooks/useTheme/resolve.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolvePreference } from './resolve';
+
+describe('resolvePreference', () => {
+	it('passes a concrete value through unchanged', () => {
+		expect(resolvePreference('dark', undefined)).toBe('dark');
+		expect(resolvePreference('compact', 'dark')).toBe('compact');
+	});
+
+	it('resolves `system` to the supplied OS value', () => {
+		expect(resolvePreference('system', 'dark')).toBe('dark');
+		expect(resolvePreference('system', 'light')).toBe('light');
+	});
+
+	it('falls back to light when `system` has no OS signal', () => {
+		expect(resolvePreference('system', undefined)).toBe('light');
+	});
+});

--- a/packages/react/src/hooks/useTheme/resolve.ts
+++ b/packages/react/src/hooks/useTheme/resolve.ts
@@ -1,0 +1,11 @@
+/**
+ * Resolve a stated preference to an applied value. `system` resolves to the
+ * supplied OS value (falling back to `light` when no signal is available);
+ * every other value is concrete and passes through unchanged.
+ */
+export function resolvePreference(
+	preference: string,
+	systemValue: string | undefined,
+): string {
+	return preference === 'system' ? (systemValue ?? 'light') : preference;
+}

--- a/packages/react/src/hooks/useTheme/ssr.test.tsx
+++ b/packages/react/src/hooks/useTheme/ssr.test.tsx
@@ -1,0 +1,31 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { ThemeProvider } from './ThemeProvider';
+import { useTheme } from './useTheme';
+
+function Probe() {
+	const { resolved } = useTheme();
+	return <span>{`${resolved.aesthetic}/${resolved.density}`}</span>;
+}
+
+describe('useTheme SSR safety (Constitution §IX bullet 6)', () => {
+	it('renders the provider and a useTheme consumer server-side without throwing', () => {
+		expect(() =>
+			renderToString(
+				<ThemeProvider>
+					<Probe />
+				</ThemeProvider>,
+			),
+		).not.toThrow();
+	});
+
+	it('emits the defaults during the server render; reconciliation waits for mount', () => {
+		const html = renderToString(
+			<ThemeProvider>
+				<Probe />
+			</ThemeProvider>,
+		);
+		expect(html).toContain('light/comfortable');
+	});
+});

--- a/packages/react/src/hooks/useTheme/themeStore.test.ts
+++ b/packages/react/src/hooks/useTheme/themeStore.test.ts
@@ -1,0 +1,142 @@
+import {
+	DENSITY_STORAGE_KEY,
+	THEME_PREFERENCE_STORAGE_KEY,
+	THEME_STORAGE_KEY,
+} from '@unbranded-ds/tokens/runtime';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createThemeStore } from './themeStore';
+
+type MediaHandler = (event: MediaQueryListEvent) => void;
+
+// jsdom has no matchMedia, so install a controllable stub. Returns a handle to
+// flip the OS value (firing `change`) and to count listener removals.
+function installMatchMedia(dark: boolean) {
+	const handlers = new Set<MediaHandler>();
+	let matches = dark;
+	let removeCount = 0;
+	const mql = {
+		get matches() {
+			return matches;
+		},
+		media: '(prefers-color-scheme: dark)',
+		addEventListener(_type: string, cb: MediaHandler) {
+			handlers.add(cb);
+		},
+		removeEventListener(_type: string, cb: MediaHandler) {
+			handlers.delete(cb);
+			removeCount += 1;
+		},
+	};
+	window.matchMedia = ((_query: string) =>
+		mql as unknown as MediaQueryList) as typeof window.matchMedia;
+	return {
+		flip(next: boolean) {
+			matches = next;
+			for (const handler of handlers) {
+				handler({ matches: next } as MediaQueryListEvent);
+			}
+		},
+		removeCount: () => removeCount,
+	};
+}
+
+describe('createThemeStore', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		document.documentElement.removeAttribute('data-theme');
+		document.documentElement.removeAttribute('data-density');
+		installMatchMedia(false);
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('server snapshot is the defaults and equals the first client snapshot (no hydration mismatch)', () => {
+		const store = createThemeStore({ defaults: {}, forced: {} });
+		const server = store.getServerSnapshot();
+		expect(server.resolved).toEqual({ aesthetic: 'light', density: 'comfortable' });
+		expect(store.getSnapshot()).toBe(server);
+	});
+
+	it('honors provider defaults before storage loads', () => {
+		const store = createThemeStore({ defaults: { aesthetic: 'dark' }, forced: {} });
+		expect(store.getServerSnapshot().resolved.aesthetic).toBe('dark');
+	});
+
+	it('reconciles per-axis localStorage on the first subscribe and applies the attributes', () => {
+		localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+		localStorage.setItem(DENSITY_STORAGE_KEY, 'compact');
+		const store = createThemeStore({ defaults: {}, forced: {} });
+		store.subscribe(() => {});
+		expect(store.getSnapshot().resolved).toEqual({ aesthetic: 'dark', density: 'compact' });
+		expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+		expect(document.documentElement.getAttribute('data-density')).toBe('compact');
+	});
+
+	it('re-enters `system` from the companion key, resolves against the OS, and follows OS changes without writing storage', () => {
+		const mm = installMatchMedia(true);
+		localStorage.setItem(THEME_PREFERENCE_STORAGE_KEY, 'system');
+		localStorage.setItem(THEME_STORAGE_KEY, 'light');
+		const store = createThemeStore({ defaults: {}, forced: {} });
+		store.subscribe(() => {});
+		expect(store.getSnapshot().preference.aesthetic).toBe('system');
+		expect(store.getSnapshot().resolved.aesthetic).toBe('dark');
+
+		localStorage.removeItem(THEME_STORAGE_KEY);
+		mm.flip(false);
+		expect(store.getSnapshot().resolved.aesthetic).toBe('light');
+		expect(localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+	});
+
+	it('removes the media listener when the last subscriber leaves', () => {
+		const mm = installMatchMedia(false);
+		localStorage.setItem(THEME_PREFERENCE_STORAGE_KEY, 'system');
+		const store = createThemeStore({ defaults: {}, forced: {} });
+		const unsubscribe = store.subscribe(() => {});
+		unsubscribe();
+		expect(mm.removeCount()).toBe(1);
+	});
+
+	it('set() persists only the named axis', () => {
+		const store = createThemeStore({ defaults: {}, forced: {} });
+		store.subscribe(() => {});
+		store.set({ density: 'compact' });
+		expect(localStorage.getItem(DENSITY_STORAGE_KEY)).toBe('compact');
+		expect(localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+		expect(store.getSnapshot().resolved.density).toBe('compact');
+	});
+
+	it('set(system) writes a concrete value to the bootstrap key and `system` to the companion key', () => {
+		installMatchMedia(true);
+		const store = createThemeStore({ defaults: {}, forced: {} });
+		store.subscribe(() => {});
+		store.set({ aesthetic: 'system' });
+		expect(localStorage.getItem(THEME_PREFERENCE_STORAGE_KEY)).toBe('system');
+		expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+	});
+
+	it('warns and no-ops a set() on a forced axis (THEME_AXIS_FORCED)', () => {
+		const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const store = createThemeStore({ defaults: {}, forced: { density: 'compact' } });
+		store.subscribe(() => {});
+		store.set({ density: 'comfortable' });
+		expect(store.getSnapshot().resolved.density).toBe('compact');
+		expect(spy).toHaveBeenCalledWith(
+			'[unbranded-ds]',
+			expect.objectContaining({ code: 'THEME_AXIS_FORCED', axis: 'density' }),
+		);
+	});
+
+	it('warns on an invalid value and on `system` for a no-signal axis', () => {
+		const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const store = createThemeStore({ defaults: {}, forced: {} });
+		store.subscribe(() => {});
+		store.set({ aesthetic: 'not-a-theme' });
+		store.set({ density: 'system' });
+		const codes = spy.mock.calls.map((call) => (call[1] as { code?: string }).code);
+		expect(codes).toContain('THEME_INVALID_VALUE');
+		expect(codes).toContain('THEME_NO_SYSTEM_SOURCE');
+	});
+});

--- a/packages/react/src/hooks/useTheme/themeStore.ts
+++ b/packages/react/src/hooks/useTheme/themeStore.ts
@@ -1,0 +1,300 @@
+'use client';
+
+import type { Axis } from '@unbranded-ds/tokens/client';
+
+import type { AxisRecord, PartialAxisRecord } from './types';
+import {
+	AXES,
+
+	AXIS_ATTRIBUTE,
+	DENSITY_STORAGE_KEY,
+	THEME_PREFERENCE_STORAGE_KEY,
+	THEME_STORAGE_KEY,
+	themesForAxis,
+} from '@unbranded-ds/tokens/client';
+
+import { warn } from '../../lib/warn';
+import { THEME_AXIS_FORCED, THEME_INVALID_VALUE, THEME_NO_SYSTEM_SOURCE } from './errors';
+import { resolvePreference } from './resolve';
+
+// The OS media query each axis follows when its preference is `system`. Only
+// the aesthetic axis has a signal today (`prefers-color-scheme`); density has
+// none. A future axis with an OS source adds an entry here, and the rest of the
+// store treats `system` as valid for it automatically.
+const SYSTEM_MEDIA: Partial<Record<Axis, string>> = {
+	aesthetic: '(prefers-color-scheme: dark)',
+};
+
+// System fallbacks, matching the spec-002 bootstrap's literal defaults.
+const SYSTEM_DEFAULTS: AxisRecord = {
+	aesthetic: 'light',
+	density: 'comfortable',
+};
+
+// The concrete-value storage key per axis. The aesthetic key is the one the
+// spec-002 bootstrap reads, so it must always hold a concrete value.
+const STORAGE_KEY: Record<Axis, string> = {
+	aesthetic: THEME_STORAGE_KEY,
+	density: DENSITY_STORAGE_KEY,
+};
+
+export interface ThemeStoreConfig {
+	defaults: PartialAxisRecord;
+	forced: PartialAxisRecord;
+	root?: HTMLElement;
+}
+
+export interface ThemeSnapshot {
+	preference: AxisRecord;
+	resolved: AxisRecord;
+	system: PartialAxisRecord;
+}
+
+export interface ThemeStore {
+	subscribe: (onChange: () => void) => () => void;
+	getSnapshot: () => ThemeSnapshot;
+	getServerSnapshot: () => ThemeSnapshot;
+	set: (partial: PartialAxisRecord) => void;
+	forced: PartialAxisRecord;
+}
+
+function readStorage(key: string): string | null {
+	try {
+		return localStorage.getItem(key);
+	}
+	catch {
+		// Storage can throw in private mode or with blocked cookies. Treat as absent.
+		return null;
+	}
+}
+
+function writeStorage(key: string, value: string): void {
+	try {
+		localStorage.setItem(key, value);
+	}
+	catch {
+		// Best-effort: a write failure must not break the page.
+	}
+}
+
+function osValue(axis: Axis): string | undefined {
+	const query = SYSTEM_MEDIA[axis];
+	if (query == null || typeof window === 'undefined' || !window.matchMedia) {
+		return undefined;
+	}
+	return window.matchMedia(query).matches ? 'dark' : 'light';
+}
+
+/**
+ * Create the per-provider theme store. Holds the live per-axis state, owns the
+ * localStorage projection and the `matchMedia` subscription, and exposes the
+ * `useSyncExternalStore` triple plus `set`. SSR-safe: the server snapshot and
+ * the first client snapshot are the same defaults-based object, so there is no
+ * hydration mismatch; storage is read only after the first client subscribe.
+ */
+export function createThemeStore(config: ThemeStoreConfig): ThemeStore {
+	const listeners = new Set<() => void>();
+	const system: PartialAxisRecord = {};
+
+	// Stated preference per axis, seeded from forced/defaults (SSR-safe, no
+	// storage), reconciled with localStorage on the first client subscribe.
+	const preference: AxisRecord = { ...SYSTEM_DEFAULTS };
+	for (const axis of AXES) {
+		const forced = config.forced[axis];
+		preference[axis] = forced ?? config.defaults[axis] ?? SYSTEM_DEFAULTS[axis];
+	}
+
+	function computeResolved(): AxisRecord {
+		const out: AxisRecord = { ...SYSTEM_DEFAULTS };
+		for (const axis of AXES) {
+			const pref = config.forced[axis] ?? preference[axis];
+			out[axis] = resolvePreference(pref, system[axis]);
+		}
+		return out;
+	}
+
+	function buildSnapshot(): ThemeSnapshot {
+		return {
+			preference: { ...preference },
+			resolved: computeResolved(),
+			system: { ...system },
+		};
+	}
+
+	// Cached snapshot: getSnapshot must return a stable reference until a real
+	// change, or useSyncExternalStore loops. Server snapshot is frozen to the
+	// initial value so server and first client render agree.
+	let snapshot = buildSnapshot();
+	const serverSnapshot = snapshot;
+
+	function refreshSystem(): void {
+		for (const axis of AXES) {
+			if (SYSTEM_MEDIA[axis] != null) {
+				system[axis] = osValue(axis);
+			}
+		}
+	}
+
+	function applyAttributes(): void {
+		const root
+			= config.root
+				?? (typeof document === 'undefined' ? undefined : document.documentElement);
+		if (root == null) {
+			return;
+		}
+		for (const axis of AXES) {
+			root.setAttribute(AXIS_ATTRIBUTE[axis], snapshot.resolved[axis]);
+		}
+	}
+
+	function commit(): void {
+		snapshot = buildSnapshot();
+		applyAttributes();
+	}
+
+	function notify(): void {
+		for (const listener of listeners) {
+			listener();
+		}
+	}
+
+	function reconcileFromStorage(): void {
+		for (const axis of AXES) {
+			const forced = config.forced[axis];
+			if (forced != null) {
+				preference[axis] = forced;
+				continue;
+			}
+			if (SYSTEM_MEDIA[axis] != null) {
+				// The companion key holds the stated intent (including `system`);
+				// fall back to the concrete key, then the default.
+				preference[axis]
+					= readStorage(THEME_PREFERENCE_STORAGE_KEY)
+						?? readStorage(STORAGE_KEY[axis])
+						?? config.defaults[axis]
+						?? SYSTEM_DEFAULTS[axis];
+			}
+			else {
+				preference[axis]
+					= readStorage(STORAGE_KEY[axis])
+						?? config.defaults[axis]
+						?? SYSTEM_DEFAULTS[axis];
+			}
+		}
+		refreshSystem();
+		commit();
+	}
+
+	function onMediaChange(): void {
+		refreshSystem();
+		commit();
+		notify();
+	}
+
+	let mql: MediaQueryList | undefined;
+	function attachMedia(): void {
+		const query = SYSTEM_MEDIA.aesthetic;
+		if (mql == null && query != null && typeof window !== 'undefined' && window.matchMedia) {
+			mql = window.matchMedia(query);
+			mql.addEventListener('change', onMediaChange);
+		}
+	}
+	function detachMedia(): void {
+		if (mql != null) {
+			mql.removeEventListener('change', onMediaChange);
+			mql = undefined;
+		}
+	}
+
+	function subscribe(onChange: () => void): () => void {
+		const first = listeners.size === 0;
+		listeners.add(onChange);
+		if (first) {
+			// First client subscriber (post-mount): reconcile with storage, then
+			// follow the OS for any `system` axis.
+			reconcileFromStorage();
+			notify();
+			attachMedia();
+		}
+		return () => {
+			listeners.delete(onChange);
+			if (listeners.size === 0) {
+				detachMedia();
+			}
+		};
+	}
+
+	function set(partial: PartialAxisRecord): void {
+		let changed = false;
+		for (const axis of AXES) {
+			const value = partial[axis];
+			if (value == null) {
+				continue;
+			}
+
+			const forced = config.forced[axis];
+			if (forced != null) {
+				warn({
+					component: 'useTheme',
+					issue: 'axis-forced',
+					code: THEME_AXIS_FORCED,
+					axis,
+					value,
+					forced,
+				});
+				continue;
+			}
+
+			const systemCapable = SYSTEM_MEDIA[axis] != null;
+			if (value === 'system' && !systemCapable) {
+				warn({
+					component: 'useTheme',
+					issue: 'no-system-source',
+					code: THEME_NO_SYSTEM_SOURCE,
+					axis,
+					value,
+				});
+				continue;
+			}
+
+			const allowed = themesForAxis(axis);
+			const valid = (systemCapable && value === 'system') || allowed.includes(value);
+			if (!valid) {
+				warn({
+					component: 'useTheme',
+					issue: 'invalid-value',
+					code: THEME_INVALID_VALUE,
+					axis,
+					value,
+					available: allowed,
+				});
+				continue;
+			}
+
+			preference[axis] = value;
+			if (systemCapable) {
+				// Persist the concrete resolved value to the bootstrap key (never
+				// `system`) and the stated intent to the companion key.
+				writeStorage(STORAGE_KEY[axis], resolvePreference(value, system[axis]));
+				writeStorage(THEME_PREFERENCE_STORAGE_KEY, value);
+			}
+			else {
+				writeStorage(STORAGE_KEY[axis], value);
+			}
+			changed = true;
+		}
+
+		if (changed) {
+			commit();
+			notify();
+		}
+	}
+
+	return {
+		subscribe,
+		getSnapshot: () => snapshot,
+		getServerSnapshot: () => serverSnapshot,
+		set,
+		forced: config.forced,
+	};
+}

--- a/packages/react/src/hooks/useTheme/types.ts
+++ b/packages/react/src/hooks/useTheme/types.ts
@@ -1,0 +1,43 @@
+import type { Axis } from '@unbranded-ds/tokens/client';
+import type { ReactNode } from 'react';
+
+/**
+ * A per-axis map of values, keyed by the tokens `Axis` union (`aesthetic` |
+ * `density` today). A future axis (e.g. a split-out color-scheme axis, spec 011
+ * FR-009) adds a key here for free; the hook is axis-agnostic.
+ */
+export type AxisRecord = Record<Axis, string>;
+
+/** A partial per-axis map: used by `set()` and provider config, any subset. */
+export type PartialAxisRecord = Partial<Record<Axis, string>>;
+
+/**
+ * The shape `useTheme()` returns. This is the multi-axis analog of next-themes'
+ * single-value hook; the field-by-field mapping lives in the sidecar and TSDoc
+ * (spec 011 FR-019/FR-020).
+ */
+export interface UseThemeReturn {
+	/** Stated choice per axis. The aesthetic axis may be `'system'`. */
+	preference: AxisRecord;
+	/** Applied value per axis, with `'system'` resolved to `light`/`dark`. */
+	resolved: AxisRecord;
+	/** OS value per axis where a signal exists (the aesthetic axis only, today). */
+	system: PartialAxisRecord;
+	/** Provider-pinned value per axis; an absent key is not forced. */
+	forced: PartialAxisRecord;
+	/** Allowed values per axis, from the tokens registry (incl. file-less defaults). */
+	available: Record<Axis, string[]>;
+	/** Set any subset of axes in one call. */
+	set: (partial: PartialAxisRecord) => void;
+}
+
+/** Props for `<ThemeProvider>`. */
+export interface ThemeProviderProps {
+	children: ReactNode;
+	/** Per-axis starting value, used until storage loads; falls back to tokens defaults. */
+	defaults?: PartialAxisRecord;
+	/** Per-axis pinned value: applied, overrides storage, and cannot change via `set()`. */
+	forced?: PartialAxisRecord;
+	/** Element the `data-*` attributes are written to. Defaults to `document.documentElement`. */
+	root?: HTMLElement;
+}

--- a/packages/react/src/hooks/useTheme/useTheme.test.tsx
+++ b/packages/react/src/hooks/useTheme/useTheme.test.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from 'react';
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ThemeProvider } from './ThemeProvider';
+import { useTheme } from './useTheme';
+
+function wrapper({ children }: { children: ReactNode }) {
+	return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+describe('useTheme', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		document.documentElement.removeAttribute('data-theme');
+		document.documentElement.removeAttribute('data-density');
+		// jsdom has no matchMedia; provide a benign light stub.
+		window.matchMedia = ((query: string) =>
+			({
+				matches: false,
+				media: query,
+				addEventListener() {},
+				removeEventListener() {},
+			}) as unknown as MediaQueryList) as typeof window.matchMedia;
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('throws THEME_NO_PROVIDER when called with no provider', () => {
+		const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		expect(() => renderHook(() => useTheme())).toThrow(/ThemeProvider/);
+		spy.mockRestore();
+	});
+
+	it('returns per-axis resolved/preference/available and a set()', () => {
+		const { result } = renderHook(() => useTheme(), { wrapper });
+		expect(result.current.resolved).toEqual({ aesthetic: 'light', density: 'comfortable' });
+		expect(result.current.available.aesthetic).toContain('vaporwave');
+		expect(result.current.available.density).toEqual(['comfortable', 'compact']);
+		expect(typeof result.current.set).toBe('function');
+	});
+
+	it('set(partial) updates only the named axis', () => {
+		const { result } = renderHook(() => useTheme(), { wrapper });
+		act(() => {
+			result.current.set({ density: 'compact' });
+		});
+		expect(result.current.resolved.density).toBe('compact');
+		expect(result.current.resolved.aesthetic).toBe('light');
+	});
+
+	it('applies a forced value and refuses to change it', () => {
+		const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const forcedWrapper = ({ children }: { children: ReactNode }) => (
+			<ThemeProvider forced={{ density: 'compact' }}>{children}</ThemeProvider>
+		);
+		const { result } = renderHook(() => useTheme(), { wrapper: forcedWrapper });
+		expect(result.current.resolved.density).toBe('compact');
+		expect(result.current.forced.density).toBe('compact');
+		act(() => {
+			result.current.set({ density: 'comfortable' });
+		});
+		expect(result.current.resolved.density).toBe('compact');
+		expect(spy).toHaveBeenCalledWith(
+			'[unbranded-ds]',
+			expect.objectContaining({ code: 'THEME_AXIS_FORCED' }),
+		);
+	});
+});

--- a/packages/react/src/hooks/useTheme/useTheme.ts
+++ b/packages/react/src/hooks/useTheme/useTheme.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import type { Axis } from '@unbranded-ds/tokens/client';
+
+import type { UseThemeReturn } from './types';
+import { AXES, themesForAxis } from '@unbranded-ds/tokens/client';
+import * as React from 'react';
+
+import { ThemeProviderError } from './errors';
+import { ThemeStoreContext } from './ThemeProvider';
+
+/**
+ * Read and update the theme across every axis from one call: the multi-axis
+ * analog of `next-themes`' `useTheme`. Must run inside a {@link ThemeProvider}.
+ *
+ * @remarks
+ * If you know next-themes, the mapping is `theme` to `preference`,
+ * `resolvedTheme` to `resolved`, `systemTheme` to `system`, `forcedTheme` to
+ * `forced`, `themes` to `available`, and `setTheme(value)` to `set(partial)`.
+ * Ours are per-axis maps keyed over the `Axis` union, and `set` takes one object
+ * for any subset of axes. The full table and the rationale live in
+ * `useTheme.usage.md`.
+ *
+ * @throws {@link ThemeProviderError} (code `THEME_NO_PROVIDER`) when called with
+ * no `<ThemeProvider>` ancestor.
+ */
+export function useTheme(): UseThemeReturn {
+	const store = React.useContext(ThemeStoreContext);
+	if (store == null) {
+		throw new ThemeProviderError(
+			'useTheme() must run inside a <ThemeProvider>. Wrap your app (or the subtree using theme controls) in <ThemeProvider>.',
+		);
+	}
+
+	const snapshot = React.useSyncExternalStore(
+		store.subscribe,
+		store.getSnapshot,
+		store.getServerSnapshot,
+	);
+
+	// `available` is non-reactive registry data (built-ins plus runtime
+	// registrations), computed once at mount.
+	const available = React.useMemo(() => {
+		const out = {} as Record<Axis, string[]>;
+		for (const axis of AXES) {
+			out[axis] = themesForAxis(axis);
+		}
+		return out;
+	}, []);
+
+	return {
+		preference: snapshot.preference,
+		resolved: snapshot.resolved,
+		system: snapshot.system,
+		forced: store.forced,
+		available,
+		set: store.set,
+	};
+}

--- a/packages/react/src/hooks/useTheme/useTheme.usage.md
+++ b/packages/react/src/hooks/useTheme/useTheme.usage.md
@@ -1,0 +1,64 @@
+# useTheme
+
+The load-bearing primitive: read and set the theme across every axis from one hook, behind a `<ThemeProvider>`. It is the multi-axis analog of `next-themes`' `useTheme`.
+
+## Import
+
+```tsx
+import { ThemeProvider, useTheme } from '@unbranded-ds/react';
+```
+
+## Return shape
+
+| Field        | Type                            | Description                                                              |
+| ------------ | ------------------------------- | ------------------------------------------------------------------------ |
+| `preference` | `Record<Axis, string>`          | Stated choice per axis; the aesthetic axis may be `'system'`.            |
+| `resolved`   | `Record<Axis, string>`          | Applied value per axis; `'system'` resolved to light or dark.            |
+| `system`     | `Partial<Record<Axis, string>>` | OS value for each axis that has a signal (aesthetic today).              |
+| `forced`     | `Partial<Record<Axis, string>>` | Provider-pinned value per axis; an absent key is not forced.             |
+| `available`  | `Record<Axis, string[]>`        | Allowed values per axis (registry built-ins plus runtime registrations). |
+| `set`        | `(partial) => void`             | Set any subset of axes in one object.                                    |
+
+## If you know next-themes, here is the translation
+
+The vocabulary tracks `next-themes` where a concept maps one-to-one, and renames only where the multi-axis shape forces it. The shape itself, a provider plus a hook, mirrors next-themes.
+
+| Ours           | next-themes       | Difference                                                                                                           |
+| -------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `preference`   | `theme`           | A per-axis map, renamed so a field that looks like next-themes' string is not secretly an object. May be `'system'`. |
+| `resolved`     | `resolvedTheme`   | Per-axis map; same idea.                                                                                             |
+| `system`       | `systemTheme`     | Per-axis; only axes with an OS signal appear.                                                                        |
+| `forced`       | `forcedTheme`     | Per-axis pinned value.                                                                                               |
+| `available`    | `themes`          | Per-axis lists rather than one flat list.                                                                            |
+| `set(partial)` | `setTheme(value)` | One object setting any subset of axes in a single call.                                                              |
+
+## Why multi-axis, and why a provider
+
+Theming here is more than light and dark. Spec 009 added a density axis (`data-density`) alongside the aesthetic axis (`data-theme`), and spec 014 unified how those resolve, so a single-value `theme` cannot represent the state; `useTheme` is keyed over the axes, and a future axis is additive. The `<ThemeProvider>` is the single source of truth and the home for `defaults` and `forced`, mirroring next-themes as a deliberate compat-first choice. First-paint flash is prevented by the spec-002 `themeBootstrapScript`, which this hook stays in lockstep with through shared storage keys.
+
+## Example
+
+```tsx
+import { ThemeProvider, useTheme } from '@unbranded-ds/react';
+
+function ThemeReadout() {
+	const { resolved, set } = useTheme();
+	return (
+		<button type="button" onClick={() => set({ aesthetic: 'dark', density: 'compact' })}>
+			{`${resolved.aesthetic} / ${resolved.density}`}
+		</button>
+	);
+}
+
+export function App() {
+	return (
+		<ThemeProvider>
+			<ThemeReadout />
+		</ThemeProvider>
+	);
+}
+```
+
+## Failure modes
+
+`set()` with a value not in `available[axis]`, a value on a forced axis, or `'system'` on an axis with no OS signal each warn through the `warn()` helper with a stable `code` and no-op. Calling `useTheme()` with no `<ThemeProvider>` ancestor throws `THEME_NO_PROVIDER`.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,6 +2,7 @@
 export * from './components/Button';
 export * from './components/Card';
 export * from './components/Checkbox';
+export * from './components/DensityToggle';
 export * from './components/Dialog';
 export * from './components/Input';
 export * from './components/Label';
@@ -11,8 +12,12 @@ export * from './components/SkipLink';
 export * from './components/Slider';
 export * from './components/Switch';
 export * from './components/Tabs';
+export * from './components/ThemeToggle';
 export * from './components/Tooltip';
 export * from './components/VisuallyHidden';
+
+// Hooks
+export * from './hooks/useTheme';
 
 // Utilities
 export { cn } from './lib/cn';

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -22,6 +22,10 @@
 		},
 		"./dist/json/*": "./dist/json/*",
 		"./preset.css": "./dist/tailwind/preset.css",
+		"./client": {
+			"types": "./dist/ts/client.d.ts",
+			"import": "./dist/ts/client.js"
+		},
 		"./runtime": {
 			"types": "./dist/ts/runtime.d.ts",
 			"import": "./dist/ts/runtime.js"

--- a/packages/tokens/src/axes.ts
+++ b/packages/tokens/src/axes.ts
@@ -1,5 +1,8 @@
+import type { Axis } from './axis-constants.js';
 import { readdirSync } from 'node:fs';
+
 import { join } from 'node:path';
+import { AXES, AXIS_ATTRIBUTE } from './axis-constants.js';
 
 // ---------------------------------------------------------------------------
 // Theme axes (spec 009). The fixed set for this spec: an AESTHETIC axis applied
@@ -12,15 +15,8 @@ import { join } from 'node:path';
 // validator all read, so they can never disagree about a theme's axis.
 // ---------------------------------------------------------------------------
 
-export type Axis = 'aesthetic' | 'density';
-
-export const AXES: readonly Axis[] = ['aesthetic', 'density'];
-
-/** The DOM attribute each axis is applied through. */
-export const AXIS_ATTRIBUTE: Record<Axis, string> = {
-	aesthetic: 'data-theme',
-	density: 'data-density',
-};
+export type { Axis };
+export { AXES, AXIS_ATTRIBUTE };
 
 /**
  * The themes available on each axis, read from `themes/<axis>/*.json`.

--- a/packages/tokens/src/axes.ts
+++ b/packages/tokens/src/axes.ts
@@ -1,4 +1,5 @@
 import type { Axis } from './axis-constants.js';
+import type { ValidationIssue } from './validate.js';
 import { readdirSync } from 'node:fs';
 
 import { join } from 'node:path';
@@ -50,4 +51,37 @@ export function themeAxisEntries(
 /** The axis a theme name belongs to, or `undefined` if it is not a known theme. */
 export function axisOf(themesRoot: string, themeName: string): Axis | undefined {
 	return themeAxisEntries(themesRoot).find((e) => e.name === themeName)?.axis;
+}
+
+// ---------------------------------------------------------------------------
+// checkAxisAssignment — guard each axis slot against a wrong-axis theme (spec
+// 009 FR-004). The realistic mistake is handing a theme to the wrong slot (e.g.
+// the density theme `compact` to the `aesthetic` slot); for each known theme
+// whose declared axis differs from its slot, emit a structured AXIS_CONFLICT.
+// Unknown names are left to completeness/composition.
+//
+// It lives here beside `axisOf`, not in validate.ts, on purpose: it reads themes
+// off disk, and keeping the only `node:fs` caller out of validate.ts is what lets
+// validate.ts (and the `/runtime` entry that re-exports `registerTheme`) bundle
+// for the browser. See browser-safety.test.ts.
+// ---------------------------------------------------------------------------
+
+export function checkAxisAssignment(
+	themesRoot: string,
+	assignment: Partial<Record<Axis, string>>,
+): ValidationIssue[] {
+	const issues: ValidationIssue[] = [];
+	for (const [slot, themeName] of Object.entries(assignment) as Array<
+		[Axis, string]
+	>) {
+		const actualAxis = axisOf(themesRoot, themeName);
+		if (actualAxis && actualAxis !== slot) {
+			issues.push({
+				path: slot,
+				code: 'AXIS_CONFLICT',
+				message: `Theme "${themeName}" is a ${actualAxis} theme but was assigned to the ${slot} slot`,
+			});
+		}
+	}
+	return issues;
 }

--- a/packages/tokens/src/axis-constants.ts
+++ b/packages/tokens/src/axis-constants.ts
@@ -1,0 +1,15 @@
+// Browser-safe axis constants. These used to live in axes.ts alongside the
+// Node-only filesystem theme lister (`node:fs`), which meant importing the
+// constants dragged `node:fs` into the type graph of any browser consumer (the
+// react hook and toggles). They live here with no Node imports; axes.ts
+// re-exports them so existing Node callers are unaffected. (spec 011)
+
+export type Axis = 'aesthetic' | 'density';
+
+export const AXES: readonly Axis[] = ['aesthetic', 'density'];
+
+/** The DOM attribute each axis is applied through. */
+export const AXIS_ATTRIBUTE: Record<Axis, string> = {
+	aesthetic: 'data-theme',
+	density: 'data-density',
+};

--- a/packages/tokens/src/browser-safety.test.ts
+++ b/packages/tokens/src/browser-safety.test.ts
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const SRC = dirname(fileURLToPath(import.meta.url));
+
+// The entries a browser bundles: the react package reaches `./client`, and a
+// story reaches `./runtime` for `registerTheme`. Nothing in their transitive
+// graph may import a Node builtin, or the bundle breaks — and the only thing
+// that used to catch it was the slow Storybook Vite build, where rollup can't
+// find `readdirSync` on its browser-external shim. This guards the invariant at
+// unit speed. (The regression that prompted it: `/runtime` -> validate.ts ->
+// axisOf -> axes.ts -> `node:fs`.)
+const BROWSER_ENTRIES = ['client.ts', 'runtime.ts'];
+
+// `import type`/`export type` are erased before any bundler sees them, so a
+// type-only edge to a node module is harmless and must NOT be followed.
+const FROM_RE = /(?:import|export)\s+(?!type\b)[^'"]*?\sfrom\s*['"]([^'"]+)['"]/g;
+const SIDE_EFFECT_RE = /import\s+['"]([^'"]+)['"]/g;
+
+function stripComments(source: string): string {
+	return source
+		.replace(/\/\*[\s\S]*?\*\//g, '')
+		.replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+function specifiers(source: string): string[] {
+	const clean = stripComments(source);
+	const out: string[] = [];
+	for (const m of clean.matchAll(FROM_RE)) {
+		if (m[1]) out.push(m[1]);
+	}
+	for (const m of clean.matchAll(SIDE_EFFECT_RE)) {
+		if (m[1]) out.push(m[1]);
+	}
+	return out;
+}
+
+// Source imports use `.js` specifiers for `.ts` files (repo convention).
+function resolveSource(fromFile: string, spec: string): string | undefined {
+	const base = resolve(dirname(fromFile), spec);
+	for (const candidate of [base.replace(/\.js$/, '.ts'), base, `${base}.ts`]) {
+		if (existsSync(candidate)) return candidate;
+	}
+	return undefined;
+}
+
+function isNodeBuiltin(spec: string): boolean {
+	return spec.startsWith('node:') || spec === 'fs' || spec === 'path';
+}
+
+function nodeBuiltinsInGraph(entry: string): string[] {
+	const seen = new Set<string>();
+	const hits: string[] = [];
+	const stack = [resolve(SRC, entry)];
+	while (stack.length > 0) {
+		const file = stack.pop();
+		if (!file || seen.has(file)) continue;
+		seen.add(file);
+		for (const spec of specifiers(readFileSync(file, 'utf8'))) {
+			if (isNodeBuiltin(spec)) {
+				hits.push(`${file.slice(SRC.length + 1)} imports ${spec}`);
+			}
+			else if (spec.startsWith('.')) {
+				const target = resolveSource(file, spec);
+				if (target) stack.push(target);
+			}
+		}
+	}
+	return hits;
+}
+
+describe('browser-safe entries stay free of Node builtins', () => {
+	for (const entry of BROWSER_ENTRIES) {
+		it(`${entry} imports no node: builtin transitively`, () => {
+			expect(nodeBuiltinsInGraph(entry)).toEqual([]);
+		});
+	}
+});

--- a/packages/tokens/src/client.ts
+++ b/packages/tokens/src/client.ts
@@ -1,0 +1,22 @@
+// Browser-safe client entry (spec 011). The constants, storage keys, and theme
+// registry the react hook and toggles need, with no transitive `node:fs`.
+//
+// The barrel index re-exports token-map.ts (Node-only) and the `/runtime` entry
+// re-exports `registerTheme`, which pulls in `validate.ts` -> `axisOf` ->
+// axes.ts (`node:fs`). Neither is safe to drag into a browser consumer's type
+// graph, so this entry exposes only the pure pieces. `runtime.ts` imports the
+// storage keys from here, so there is a single source of truth.
+
+export type { Axis } from './axis-constants.js';
+export { AXES, AXIS_ATTRIBUTE } from './axis-constants.js';
+export { themesForAxis } from './registry.js';
+
+export const THEME_STORAGE_KEY = 'unbranded-ds-theme';
+// Density rides its own storage key (spec 009) so an aesthetic and a density
+// selection persist independently; picking one must not clobber the other.
+export const DENSITY_STORAGE_KEY = 'unbranded-ds-density';
+// Companion key (spec 011): the stated color-scheme intent, including `system`.
+// The bootstrap key above always holds a concrete light/dark value so the
+// flash-free bootstrap never sees `system`; this key lets the hook re-enter
+// system-following on mount (FR-006).
+export const THEME_PREFERENCE_STORAGE_KEY = 'unbranded-ds-theme-preference';

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -1,4 +1,9 @@
+export { AXES, AXIS_ATTRIBUTE } from './axis-constants.js';
+export type { Axis } from './axis-constants.js';
+
 export { canonicalDefaultTokens } from './defaults.js';
+
+export { themesForAxis } from './registry.js';
 
 export { composeTokens, resolveTheme } from './resolve.js';
 export type { ResolvedLayer } from './resolve.js';

--- a/packages/tokens/src/registry.test.ts
+++ b/packages/tokens/src/registry.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { registerThemeName, themesForAxis } from './registry.js';
+
+describe('themesForAxis', () => {
+	it('lists the built-in aesthetic themes, default first', () => {
+		expect(themesForAxis('aesthetic')).toEqual([
+			'light',
+			'dark',
+			'brand',
+			'vaporwave',
+		]);
+	});
+
+	it('includes density\'s file-less `comfortable` default and leads with it', () => {
+		// `comfortable` has no override JSON (it is the base token set) but is a
+		// first-class selectable value, so it must appear and lead the list.
+		expect(themesForAxis('density')).toEqual(['comfortable', 'compact']);
+	});
+
+	it('surfaces a runtime-registered theme on its axis, after the built-ins', () => {
+		registerThemeName('density', 'cozy');
+		const names = themesForAxis('density');
+		expect(names).toContain('cozy');
+		expect(names.slice(0, 2)).toEqual(['comfortable', 'compact']);
+		expect(names.at(-1)).toBe('cozy');
+	});
+
+	it('de-duplicates when a registered name repeats a built-in', () => {
+		registerThemeName('aesthetic', 'dark');
+		const darks = themesForAxis('aesthetic').filter((n) => n === 'dark');
+		expect(darks).toHaveLength(1);
+	});
+});

--- a/packages/tokens/src/registry.ts
+++ b/packages/tokens/src/registry.ts
@@ -1,0 +1,53 @@
+import type { Axis } from './axis-constants.js';
+
+// ---------------------------------------------------------------------------
+// Browser-safe theme registry (spec 011). `listThemesByAxis` in axes.ts reads
+// the filesystem and is Node-only (build, MCP, tests). The runtime hook and the
+// data-driven toggles need the value lists in the browser, so the built-in
+// names are maintained here as plain data and runtime registrations are tracked
+// in memory. No `node:fs`, no `document`.
+//
+// A built-in axis includes its file-less default: density's `comfortable` is
+// the base token set with no override JSON, but it is a first-class selectable
+// value, so it appears here and leads the list (spec 011 FR-004, clarify Q4).
+// ---------------------------------------------------------------------------
+
+const BUILT_IN_THEMES: Record<Axis, readonly string[]> = {
+	aesthetic: ['light', 'dark', 'brand', 'vaporwave'],
+	density: ['comfortable', 'compact'],
+};
+
+// Themes added at runtime via `registerTheme`, per axis. `registerTheme` calls
+// `registerThemeName` so a consumer's custom theme shows up in `themesForAxis`
+// (and therefore the toggles) without any extra wiring (clarify Q3).
+const runtimeThemes: Record<Axis, Set<string>> = {
+	aesthetic: new Set(),
+	density: new Set(),
+};
+
+/**
+ * Record a theme name as available on an axis. Called by `registerTheme` after
+ * a theme validates, so the data-driven toggles stay in sync with what is
+ * actually registered.
+ */
+export function registerThemeName(axis: Axis, name: string): void {
+	runtimeThemes[axis].add(name);
+}
+
+/**
+ * The values available on an axis: the built-in names (including the file-less
+ * default, default first) plus anything registered at runtime, de-duplicated
+ * and order-stable. Browser-safe. This is the source of truth for
+ * `useTheme().available` and the data-driven toggles (spec 011 FR-004/FR-012).
+ */
+export function themesForAxis(axis: Axis): string[] {
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const name of [...BUILT_IN_THEMES[axis], ...runtimeThemes[axis]]) {
+		if (!seen.has(name)) {
+			seen.add(name);
+			out.push(name);
+		}
+	}
+	return out;
+}

--- a/packages/tokens/src/runtime.ts
+++ b/packages/tokens/src/runtime.ts
@@ -1,14 +1,15 @@
-import type { Axis } from './axes.js';
+import type { Axis } from './axis-constants.js';
 import type { PartialTheme } from './schema.js';
-import { AXIS_ATTRIBUTE } from './axes.js';
+import { AXIS_ATTRIBUTE } from './axis-constants.js';
+import { DENSITY_STORAGE_KEY, THEME_PREFERENCE_STORAGE_KEY, THEME_STORAGE_KEY } from './client.js';
 import { contrastRatio, hexToOklch, parseColor } from './color.js';
+import { registerThemeName } from './registry.js';
 import { contrastPairs } from './schema.js';
 import { validateTheme } from './validate.js';
 
-const THEME_STORAGE_KEY = 'unbranded-ds-theme';
-// Density rides its own storage key (spec 009) so an aesthetic and a density
-// selection persist independently — picking one must not clobber the other.
-const DENSITY_STORAGE_KEY = 'unbranded-ds-density';
+// The storage keys live in the browser-safe client entry; re-exported here so
+// the bootstrap below and any existing `/runtime` consumers keep working.
+export { DENSITY_STORAGE_KEY, THEME_PREFERENCE_STORAGE_KEY, THEME_STORAGE_KEY };
 
 /**
  * Factory that returns a self-executing JavaScript string with
@@ -198,4 +199,8 @@ export function registerTheme(
 	style.id = existingId;
 	style.textContent = css;
 	document.head.appendChild(style);
+
+	// Record the name so themesForAxis() (spec 011) reflects this runtime theme,
+	// keeping the data-driven toggles in sync with what is actually registered.
+	registerThemeName(axis, theme.name);
 }

--- a/packages/tokens/src/validate.test.ts
+++ b/packages/tokens/src/validate.test.ts
@@ -6,10 +6,10 @@ import extraTokens from './__fixtures__/extra-tokens.json';
 import inheritedPairFail from './__fixtures__/inherited-pair-fail.json';
 import partialTheme from './__fixtures__/partial-theme.json';
 import validCustom from './__fixtures__/valid-custom.json';
+import { checkAxisAssignment } from './axes';
 import { canonicalDefaultTokens } from './defaults.js';
 import type { ResolvedLayer } from './resolve.js';
 import {
-	checkAxisAssignment,
 	checkThemeCompleteness,
 	validateComposedTheme,
 	validateTheme,

--- a/packages/tokens/src/validate.ts
+++ b/packages/tokens/src/validate.ts
@@ -1,8 +1,6 @@
 import type { ZodIssue } from 'zod';
 import type { ResolvedLayer } from './resolve.js';
-import type { Axis } from './axes.js';
 import type { Theme } from './schema.js';
-import { axisOf } from './axes.js';
 import { contrastRatio, parseColor } from './color.js';
 import { composeTokens, resolveTheme } from './resolve.js';
 import { contrastPairs, partialThemeSchema, themeSchema } from './schema.js';
@@ -204,34 +202,4 @@ export function validateComposedTheme(
 	displayName = 'Composed Theme',
 ): ValidationResult {
 	return validateResolved(composeTokens(layers), name, displayName);
-}
-
-// ---------------------------------------------------------------------------
-// checkAxisAssignment — guard each axis slot against a wrong-axis theme (spec
-// 009 FR-004). The assignment is an object keyed by axis slot, so two themes
-// cannot structurally land on one axis; the realistic mistake is assigning a
-// theme to the wrong slot (e.g. the density theme `compact` to `aesthetic`). For
-// each (slot, themeName), if the theme is known and its declared axis differs
-// from the slot it was assigned to, emit a structured AXIS_CONFLICT. Unknown
-// theme names are left alone — completeness/composition surfaces those.
-// ---------------------------------------------------------------------------
-
-export function checkAxisAssignment(
-	themesRoot: string,
-	assignment: Partial<Record<Axis, string>>,
-): ValidationIssue[] {
-	const issues: ValidationIssue[] = [];
-	for (const [slot, themeName] of Object.entries(assignment) as Array<
-		[Axis, string]
-	>) {
-		const actualAxis = axisOf(themesRoot, themeName);
-		if (actualAxis && actualAxis !== slot) {
-			issues.push({
-				path: slot,
-				code: 'AXIS_CONFLICT',
-				message: `Theme "${themeName}" is a ${actualAxis} theme but was assigned to the ${slot} slot`,
-			});
-		}
-	}
-	return issues;
 }

--- a/scripts/validate-sidecars.ts
+++ b/scripts/validate-sidecars.ts
@@ -33,6 +33,7 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, '..');
 const REACT_PKG_ROOT = resolve(REPO_ROOT, 'packages/react');
 const COMPONENTS_ROOT = resolve(REACT_PKG_ROOT, 'src/components');
+const HOOKS_ROOT = resolve(REACT_PKG_ROOT, 'src/hooks');
 
 async function findUsageFiles(root: string): Promise<string[]> {
 	const found: string[] = [];
@@ -267,7 +268,10 @@ function wrapBlock(block: CodeBlock): string {
 
 async function main(): Promise<void> {
 	// --- Sidecar blocks ---
-	const sidecarFiles = await findUsageFiles(COMPONENTS_ROOT);
+	const sidecarFiles = [
+		...(await findUsageFiles(COMPONENTS_ROOT)),
+		...(await findUsageFiles(HOOKS_ROOT)),
+	];
 	const sidecarBlocks: CodeBlock[] = [];
 	for (const file of sidecarFiles) {
 		const content = await readFile(file, 'utf-8');
@@ -275,7 +279,10 @@ async function main(): Promise<void> {
 	}
 
 	// --- TSDoc @example blocks ---
-	const tsxSourceFiles = await findTsxSourceFiles(COMPONENTS_ROOT);
+	const tsxSourceFiles = [
+		...(await findTsxSourceFiles(COMPONENTS_ROOT)),
+		...(await findTsxSourceFiles(HOOKS_ROOT)),
+	];
 	const tsdocBlocks: CodeBlock[] = [];
 	for (const file of tsxSourceFiles) {
 		const content = await readFile(file, 'utf-8');
@@ -320,6 +327,7 @@ async function main(): Promise<void> {
 					'@unbranded-ds/react': ['packages/react/src/index.ts'],
 					'@unbranded-ds/react/*': ['packages/react/src/*'],
 					'@unbranded-ds/tokens': ['packages/tokens/src/index.ts'],
+					'@unbranded-ds/tokens/client': ['packages/tokens/src/client.ts'],
 					'@unbranded-ds/tokens/runtime': ['packages/tokens/src/runtime.ts'],
 				},
 				types: [],

--- a/specs/011-theme-toggle/checklists/requirements.md
+++ b/specs/011-theme-toggle/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Theme controls (provider, hook, and per-axis toggles)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **API names are the contract, not implementation leakage.** The spec names `useTheme`, `ThemeProvider`, `ThemeToggle`, `DensityToggle`, and the `THEME_*` failure codes. For a component library the public API surface *is* the user-facing "what," and the stakeholders are the developers and agents who consume it. This matches how spec 013 and the earlier component specs are written. Success criteria stay outcome-focused and technology-agnostic (no-flash, live update within a frame, keyboard operability, build-fails-on-missing-sidecar), so the "no implementation details" items pass in the sense that matters for this domain.
+- **One acceptance gate is deliberately not automated.** SC-006 (a reader who knows next-themes can predict the API) and FR-020 (the alignment writeup) have a mechanical half that CI enforces (the sidecar validator compiles every `tsx` block, and TSDoc presence is lintable) and a judgment half (is the mapping prose actually clear?) verified by the humanizer pass plus review. The spec states this split rather than implying the clarity is machine-checked.
+- **All clarifications are resolved.** The six forks from the 2026-06-13 brainstorm (variants vs composition, defer the color-scheme split, single-object hook, provider vs provider-less, vocabulary alignment, always-three segments) are recorded in the Clarifications section, so no `[NEEDS CLARIFICATION]` markers remain. Ready for `/speckit.plan`.

--- a/specs/011-theme-toggle/contracts/ThemeProvider.md
+++ b/specs/011-theme-toggle/contracts/ThemeProvider.md
@@ -1,0 +1,39 @@
+# Contract: `<ThemeProvider>`
+
+The single source of truth and the home for theme configuration. Mirrors `next-themes`' provider; one wraps the app (or a subtree).
+
+## Import
+
+```ts
+import { ThemeProvider } from '@unbranded-ds/react';
+```
+
+## Props
+
+```ts
+interface ThemeProviderProps {
+  children: React.ReactNode;
+  /** Per-axis starting value, used until a stored preference loads. Falls back
+   *  to the tokens system constants ('light' aesthetic, 'comfortable' density). */
+  defaults?: Partial<Record<Axis, string>>;
+  /** Per-axis pinned value. A forced axis is applied, overrides any stored
+   *  preference, and cannot change through set() (next-themes' forcedTheme). */
+  forced?: Partial<Record<Axis, string>>;
+  /** Element the data-* attributes are written to. Defaults to
+   *  document.documentElement. */
+  root?: HTMLElement;
+}
+```
+
+## Behavior
+
+- Holds per-axis state and exposes it to every `useTheme()` in the subtree, so sibling controls stay in sync (FR-001).
+- `defaults` seeds state before storage loads; a stored preference (or `forced`) wins once resolved.
+- A `forced` axis is applied and locked: storage is ignored for it, a `set()` on it is a no-op that emits `THEME_AXIS_FORCED`, and a toggle bound to it renders disabled (FR-003, FR-014).
+- Does not inject the first-paint bootstrap; the consumer still inlines `themeBootstrapScript` from `@unbranded-ds/tokens` (spec 002). The provider reconciles to storage on mount and never accesses `window` during render (FR-008).
+- `root` lets a consumer scope theming to a subtree element instead of the document root.
+
+## Notes
+
+- This is a deliberate divergence from the brief's provider-less sketch, chosen so `forced` and shared multi-toggle state have a home, and to match the upstream pattern consumers already know.
+- There is no `next-themes` runtime dependency; the provider is implemented in-repo (see [research.md](../research.md) §5).

--- a/specs/011-theme-toggle/contracts/failures.md
+++ b/specs/011-theme-toggle/contracts/failures.md
@@ -1,0 +1,34 @@
+# Contract: failure modes (Section XI.4)
+
+Four structured failures. Each carries a stable `code` an agent matches on. Three are recoverable and route through the existing non-throwing `warn()` helper (`packages/react/src/lib/warn.ts`); the fourth throws, because there is no usable state to return.
+
+## `warn()` payload shape
+
+`warn()` already exists and emits `{ component, issue, ...payload }` to the console without throwing. These failures add a `code` so the warned and thrown cases match uniformly:
+
+```ts
+warn({ component: 'useTheme', issue: 'invalid-value', code: 'THEME_INVALID_VALUE', axis, value, available });
+```
+
+## The four codes
+
+| Code | Trigger | Behavior | Extra payload |
+|------|---------|----------|---------------|
+| `THEME_INVALID_VALUE` | `set()` given a value not in `available[axis]` and not `system` | warn, no-op | `axis`, `value`, `available` |
+| `THEME_AXIS_FORCED` | `set()` targets a `forced` axis | warn, no-op | `axis`, `value`, `forced` |
+| `THEME_NO_SYSTEM_SOURCE` | `system` set on an axis with no OS signal (e.g. density) | warn, no-op | `axis` |
+| `THEME_NO_PROVIDER` | `useTheme()` called with no `<ThemeProvider>` ancestor | **throw** | `code` on the error |
+
+## The thrown case
+
+```ts
+class ThemeProviderError extends Error {
+  code: 'THEME_NO_PROVIDER';
+}
+```
+
+The message names the fix ("wrap your tree in `<ThemeProvider>`"). Throwing rather than returning fabricated defaults surfaces the wiring bug immediately and avoids masking it (clarify Q6).
+
+## Why this split
+
+The first three are recoverable developer mistakes that should not crash a consumer page, matching the non-throwing `warn()` convention from spec 004. A missing provider is structural: there is no coherent state to hand back, so a hard error is the legible outcome for both a human and an agent.

--- a/specs/011-theme-toggle/contracts/toggles.md
+++ b/specs/011-theme-toggle/contracts/toggles.md
@@ -1,0 +1,59 @@
+# Contract: `<ThemeToggle>` and `<DensityToggle>`
+
+Two thin, named sibling controls over `useTheme()` and `SegmentedControl`. Neither takes `value`/`onChange`: state comes from the provider, the `next-themes` mode-toggle model. Render one, both, or neither.
+
+## Import
+
+```ts
+import { ThemeToggle, DensityToggle } from '@unbranded-ds/react';
+```
+
+## Shared props
+
+Both forward to `SegmentedControl.Root` and accept:
+
+```ts
+interface SharedToggleProps {
+  size?: 'sm' | 'md' | 'lg';                  // forwarded; default 'md'
+  orientation?: 'horizontal' | 'vertical';    // forwarded; default 'horizontal'
+  'aria-label'?: string;                       // accessible group name
+  className?: string;
+  // ...rest spreads onto SegmentedControl.Root
+}
+```
+
+`SegmentedControl` exposes `size` and `orientation` (not `variant`), so the toggles forward those.
+
+## `<ThemeToggle>` (color-scheme, aesthetic axis)
+
+```ts
+type ColorScheme = 'light' | 'system' | 'dark';
+
+interface ThemeToggleProps extends SharedToggleProps {
+  labels?: Partial<Record<ColorScheme, string>>;        // default: Light / System / Dark
+  icons?: Partial<Record<ColorScheme, React.ReactNode>>; // default: Sun / SunMoon / Moon (lucide)
+}
+```
+
+- Renders three fixed segments (light/system/dark) wired to the `aesthetic` axis. Segments are fixed, not derived from `available` (FR-010).
+- When the aesthetic value is `brand` or `vaporwave`, no segment is selected and the control stays enabled; selecting a segment overwrites the aesthetic value.
+- Default `aria-label`: `"Color scheme"`.
+
+## `<DensityToggle>` (density axis)
+
+```ts
+interface DensityToggleProps extends SharedToggleProps {
+  labels?: Record<string, string>;            // keyed by density value; defaults English per value
+  icons?: Record<string, React.ReactNode>;    // keyed by density value; lucide defaults
+}
+```
+
+- Renders one segment per value in `available.density` (FR-012), so a newly authored value (such as `expanded`) appears with no component change, labeled by the raw value when no override is given.
+- No `system` segment, since density has no OS signal.
+- Default `aria-label`: `"Density"`.
+
+## Behavior shared by both
+
+- A toggle bound to a `forced` axis renders disabled (FR-014).
+- Until mounted, the control renders unresolved (no segment selected), then reflects the stored preference, so there is no hydration mismatch and no layout shift (FR-008).
+- Selecting a segment calls `set({ [axis]: value })`. For other UX (a switch, a dropdown, a two-state light/dark control), compose on `useTheme()` directly; see [quickstart.md](../quickstart.md).

--- a/specs/011-theme-toggle/contracts/tokens-registry.md
+++ b/specs/011-theme-toggle/contracts/tokens-registry.md
@@ -1,0 +1,26 @@
+# Contract: `themesForAxis()` (tokens registry)
+
+A new runtime export from `@unbranded-ds/tokens` that names the values available on an axis. It is the source of truth for `useTheme().available` and the data-driven toggles. Pure data, no React, so it respects the tokens package's React-free graph (Section II).
+
+## Import
+
+```ts
+import { themesForAxis } from '@unbranded-ds/tokens';
+```
+
+## Signature
+
+```ts
+function themesForAxis(axis: Axis): string[];
+```
+
+## Behavior
+
+- Returns the axis's built-in values, **including its file-less default** (clarify Q4). For `density` that is `['comfortable', 'compact']` even though only `compact.json` exists; `comfortable` is the base token set.
+- Includes anything registered at runtime through `registerTheme` on that axis (clarify Q3), so a consumer's custom theme shows up in toggles without extra wiring.
+- Order is stable, default first.
+
+## Implementation notes (for `/speckit.tasks`)
+
+- The built-in names per axis are known to the build. Surface them through a generated or maintained constant rather than reading the filesystem at runtime.
+- `registerTheme` currently injects a `<style>` block only. To make runtime registrations visible here, it must also record the `(axis, name)` in a module-level registry that `themesForAxis` reads, seeded with the built-ins. This is the one behavior change to existing tokens code; it is additive and does not alter `registerTheme`'s signature or its injection behavior.

--- a/specs/011-theme-toggle/contracts/useTheme.md
+++ b/specs/011-theme-toggle/contracts/useTheme.md
@@ -1,0 +1,53 @@
+# Contract: `useTheme()`
+
+The load-bearing primitive. Reads the nearest `<ThemeProvider>` and returns the multi-axis theme state plus one setter.
+
+## Import
+
+```ts
+import { useTheme } from '@unbranded-ds/react';
+```
+
+## Signature
+
+```ts
+function useTheme(): UseThemeReturn;
+```
+
+No arguments. Configuration (`defaults`, `forced`, `root`) lives on the provider, so every `useTheme()` call in the tree reflects one shared state.
+
+## Return
+
+```ts
+interface UseThemeReturn {
+  preference: Record<Axis, string>;        // stated choice; aesthetic may be 'system'
+  resolved: Record<Axis, string>;          // applied value; 'system' resolved to light/dark
+  system: Partial<Record<Axis, string>>;   // current OS value where a signal exists (aesthetic only)
+  forced: Partial<Record<Axis, string>>;   // provider-pinned, non-overridable
+  available: Record<Axis, string[]>;       // allowed values per axis, incl. the file-less default
+  set: (partial: Partial<Record<Axis, string>>) => void; // one object, any subset of axes
+}
+```
+
+`Axis` is the union exported by `@unbranded-ds/tokens` (`'aesthetic' | 'density'` today).
+
+## If you know `next-themes`, here is the translation (FR-019)
+
+| `useTheme()` (ours) | `next-themes` | Difference |
+|---------------------|---------------|------------|
+| `preference` | `theme` | Ours is a per-axis map and renamed, because a field called `theme` that is secretly an object is a false friend. The aesthetic axis may be `'system'`, like next-themes' `theme`. |
+| `resolved` | `resolvedTheme` | Per-axis map; same idea (`system` resolved to a concrete value). |
+| `system` | `systemTheme` | Per-axis; only axes with an OS signal appear (aesthetic). |
+| `forced` | `forcedTheme` | Per-axis; the pinned value set on the provider. |
+| `available` | `themes` | Per-axis lists rather than one flat list. |
+| `set(partial)` | `setTheme(value)` | One object setting any subset of axes in a single call, rather than one value. |
+
+The provider-plus-hook shape itself mirrors next-themes. The multi-axis object shape is ours; the concepts and names track upstream wherever they map one-to-one.
+
+## Behavior
+
+- `preference[axis]` is the stated value; `resolved[axis]` is what the DOM attribute carries. They differ only when the preference is `system`.
+- `set({ aesthetic: 'vaporwave', density: 'compact' })` updates both axes in one call; omitted axes are untouched.
+- `set` validates against `available[axis]` (or accepts `system` on a signal axis) and refuses forced axes; see [failures.md](failures.md).
+- Calling `useTheme()` with no `<ThemeProvider>` ancestor throws `THEME_NO_PROVIDER`.
+- SSR-safe: returns the provider defaults during the server render and the first client render, then reconciles to stored values on mount.

--- a/specs/011-theme-toggle/data-model.md
+++ b/specs/011-theme-toggle/data-model.md
@@ -1,0 +1,62 @@
+# Phase 1 Data Model: Theme controls
+
+There is no persisted database. The data here is the in-memory theme state, its localStorage projection, and the per-axis value sets. The TypeScript below is illustrative; the authoritative definitions ship in `packages/react/src/hooks/useTheme/types.ts`.
+
+## Axis
+
+An independent theming dimension. The canonical list is the `Axis` union from `@unbranded-ds/tokens`.
+
+- Today: `'aesthetic'` (attribute `data-theme`, storage key `unbranded-ds-theme`) and `'density'` (attribute `data-density`, storage key `unbranded-ds-density`).
+- A future `color-scheme` axis is additive: a new union member, attribute, and storage key, with no change to the hook's shape (FR-009).
+
+## Value vocabulary per axis
+
+- `aesthetic`: `light`, `dark`, `brand`, `vaporwave` (built-ins); `light` is the default.
+- `density`: `comfortable` (the file-less default) and `compact`.
+- `available[axis]` comes from `themesForAxis(axis)` in the tokens registry: built-ins including the file-less default, plus any runtime `registerTheme` additions.
+
+## Preference, Resolved, Forced, System
+
+- **Preference** (`Record<Axis, string>`): the user's stated choice. On the aesthetic axis it may be `system` (follow the OS). On density it is always concrete.
+- **Resolved** (`Record<Axis, string>`): the value applied to the DOM attribute. Equals the preference except when the preference is `system`, which resolves to `light` or `dark` from `prefers-color-scheme`.
+- **Forced** (`Partial<Record<Axis, string>>`): a provider-pinned value that overrides preference and storage for that axis and cannot change through `set()`.
+- **System** (`Partial<Record<Axis, string>>`): the current OS value for axes that have a signal (`aesthetic` only today, `light` or `dark`).
+
+## Hook return shape
+
+```ts
+interface UseThemeReturn {
+  preference: Record<Axis, string>;        // stated; aesthetic may be 'system'
+  resolved: Record<Axis, string>;          // applied; system resolved to light/dark
+  system: Partial<Record<Axis, string>>;   // OS value where a signal exists
+  forced: Partial<Record<Axis, string>>;   // provider-pinned, non-overridable
+  available: Record<Axis, string[]>;       // allowed values per axis (incl. file-less default)
+  set: (partial: Partial<Record<Axis, string>>) => void; // one object, any subset of axes
+}
+```
+
+## Storage model
+
+| Key | Holds | Read by |
+|-----|-------|---------|
+| `unbranded-ds-theme` | the concrete applied aesthetic value (never `system`) | spec-002 bootstrap, hook |
+| `unbranded-ds-theme-preference` | the stated aesthetic intent, including `system` (new companion key) | hook |
+| `unbranded-ds-density` | the density value | spec-002 bootstrap, hook |
+
+The bootstrap reads only the concrete keys, so it never applies a non-existent `data-theme="system"`. The hook treats the companion key as authoritative for intent, falling back to the concrete key and then the default.
+
+## State transitions
+
+- **Mount**: read storage (concrete keys plus the companion), resolve `system` against the OS, apply attributes if they differ, and subscribe to `prefers-color-scheme` if any axis is `system`.
+- **`set(partial)`**: for each axis in the object, validate the value against `available[axis]` (or accept `system` on a signal axis), reject forced axes, persist (the concrete key always receives a concrete value; the companion key receives the intent), update the store, then re-resolve and re-apply attributes.
+- **OS change while `system`**: re-resolve and re-apply the affected axis; do not write to storage.
+- **Unmount**: remove the media-query listener.
+
+## Validation rules
+
+| Condition | Outcome |
+|-----------|---------|
+| value not in `available[axis]` and not `system` | `THEME_INVALID_VALUE` (warn, no-op) |
+| `system` on an axis with no OS signal | `THEME_NO_SYSTEM_SOURCE` (warn, no-op) |
+| `set()` targets a forced axis | `THEME_AXIS_FORCED` (warn, no-op) |
+| `useTheme()` with no provider ancestor | `THEME_NO_PROVIDER` (throw) |

--- a/specs/011-theme-toggle/plan.md
+++ b/specs/011-theme-toggle/plan.md
@@ -1,0 +1,136 @@
+# Implementation Plan: Theme controls (provider, hook, and per-axis toggles)
+
+**Branch**: `011-theme-toggle` | **Date**: 2026-06-13 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/011-theme-toggle/spec.md`
+
+## Summary
+
+Ship the for-coleman theme-control pattern, reframed for the two-axis theming the system gained in spec 009. The load-bearing piece is an axis-agnostic `useTheme()` hook behind a `ThemeProvider`: the provider is the single source of truth and the home for per-axis `defaults` and `forced` (pinning), and the hook exposes per-axis `preference`/`resolved`/`system`/`forced`/`available` plus one object-valued `set(partial)`. On top sit two thin, named sibling controls. `<ThemeToggle>` is a fixed light/system/dark color-scheme control over the aesthetic axis; `<DensityToggle>` is data-driven from `available.density`. Vocabulary tracks `next-themes` where concepts map one-to-one and renames only where the multi-axis shape forces it, documented as a first-class deliverable. We build our own provider (no `next-themes` runtime dependency, since it is single-axis). The spec-002 bootstrap stays frozen and flash-free because a `system` preference persists its resolved `light`/`dark` to the bootstrap key while the `system` intent rides a companion key.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, strict mode, no `any`
+**Primary Dependencies**: React (peer; uses `useSyncExternalStore`), `@base-ui-components/react` (peer, reached via SegmentedControl), `lucide-react` ^1.8.0 (Sun/SunMoon/Moon icons, existing dep), `class-variance-authority` + `cn()` (existing), the `SegmentedControl` primitive (spec 004), `@unbranded-ds/tokens` runtime (storage-key constants, the `Axis` union, and a NEW "themes per axis" registry export). No `next-themes` runtime dependency (vocabulary alignment only).
+**Storage**: `localStorage`. Existing keys `unbranded-ds-theme` (now always holds a concrete theme) and `unbranded-ds-density`, plus one NEW companion key for the color-scheme `system` intent (working name `unbranded-ds-theme-preference`). Sidecars are markdown files on disk.
+**Testing**: Vitest with `renderHook` (hook + provider), a `matchMedia` mock (the media-query path), and the existing `__ssr__` harness (no-`window` render); Storybook `play` functions (interaction); `@storybook/addon-a11y` + test-runner (axe). The story-level live-OS-change interaction is driven through the test-runner's media emulation.
+**Target Platform**: Browsers, plus SSR hosts (Next.js, Remix) with no `window`/`localStorage` access at render.
+**Project Type**: Component library (`packages/react`) plus a small runtime export in `packages/tokens`.
+**Performance Goals**: OS color-scheme change reflected within one frame while at `system` (SC-002); no first-paint flash (SC-001); no layout shift on the toggles at hydration (FR-008).
+**Constraints**: SSR-safe; flash-free against the unchanged spec-002 bootstrap; axe zero serious/critical; ESM only; styling resolves through tokens (the toggles inherit SegmentedControl's token styling and add no hardcoded values); no `next-themes` runtime dependency.
+**Scale/Scope**: One provider, one hook, two components, one shared private `AxisToggle`, one tokens-package registry export, plus stories, unit tests, sidecars, and an `AGENTS.md` index entry.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against constitution 1.3.0. All applicable gates pass.
+
+- [x] **Section I (Repository shape)** — No new package. Work lands in `packages/react` (provider, hook, two components) plus one runtime export added to `packages/tokens`. Within the three-package shape.
+- [x] **Section II (Tokens independent of components)** — The new "themes per axis" export is pure data over the existing token map and `Axis` union, with no React, Storybook, or Base UI in its graph. A tokens-only consumer is unaffected.
+- [x] **Section III (Theming contract)** — Consumes the two-axis system (`data-theme`, `data-density`) unchanged. First-paint no-flash is preserved: the bootstrap key always holds a concrete theme, so the unchanged spec-002 bootstrap never encounters `system`. `validateTheme` and the cascade-layer composition are untouched.
+- [x] **Section IV (Components thin; set additions need a spec)** — `<ThemeToggle>` and `<DensityToggle>` are new components, and this spec is their written justification. Both are thin shells over `SegmentedControl` + `useTheme`, introduce no hardcoded color/spacing/radius, and style through the inherited token utilities.
+- [x] **Section V (Stories are the source of truth)** — Each toggle ships `Default` plus the SegmentedControl bar of variant stories (sizes, orientations, forced/disabled, custom labels/icons) and its behavioral stories, and a `Theming` story group surfaces `useTheme` + `<ThemeProvider>` with a compositional multi-axis story so the hook and provider reach Storybook and the MCP. Every story wraps in a `<ThemeProvider>` decorator. The full matrix is in the Storybook coverage section.
+- [x] **Section VI (Testing: three layers)** — Unit (hook storage / matchMedia / SSR / `set(partial)` / forced; provider defaults / forced / two-consumer sync), interaction (`play`), and a11y (axe). Tests target our wrapper logic, not SegmentedControl's keyboard baseline, which spec 004 already covers.
+- [x] **Section VII (Deployment / MCP)** — New stories flow to the Storybook MCP automatically; no MCP contract breaks. Surfacing the new tokens export in the token-query MCP is optional and out of scope here.
+- [x] **Section VIII (Tooling baseline)** — No new tooling. TypeScript strict / no-`any`, `tsup` ESM, Tailwind tokens, `cva`, `cn`, `lucide-react` (existing). State uses React's built-in `useSyncExternalStore`. No amendment needed.
+- [x] **Section IX (Definition of done)** — Each component ships `index.ts` / `*.tsx` / `*.stories.tsx` / `*.test.tsx`, tokens-only styling, the full story set, a `play`, axe-clean stories, an SSR-safe render, autodocs, and a root export. The hook and provider ship with unit tests, TSDoc, a sidecar, and root exports.
+- [x] **Section X (Governance)** — A `.changeset/*.md` declares the `@unbranded-ds/react` (minor: new exports) and `@unbranded-ds/tokens` (minor: new export) bumps. This Constitution Check travels in the PR.
+- [x] **Section XI (Agent and human legibility)** — required gate:
+  - **XI.1 Prose** — Spec prose already passed the humanizer; sidecars, TSDoc, and story descriptions will too, with no three-item-list tic.
+  - **XI.2 API shape** — Compat-first. The toggles inherit SegmentedControl's `size`/`orientation`. The hook and provider introduce the multi-axis surface, so their names track `next-themes` (the upstream analog) where a concept maps one-to-one (`forced`, `system`, `set`) and rename only where multi-axis forces it (`preference`, `resolved`). The full mapping is documented (FR-020). A deliberate, documented divergence, not a bespoke vocabulary.
+  - **XI.3 Docs surfaces** — `*.usage.md` sidecars for both toggles (validated by the spec-005 validator) and a `useTheme.usage.md`; the alignment note (why multi-axis and provider, with links to specs 002, 009, 014) lives in the hook sidecar and TSDoc; `AGENTS.md` gains the new entries.
+  - **XI.4 Failure modes** — Structured output: `THEME_INVALID_VALUE`, `THEME_AXIS_FORCED`, and `THEME_NO_SYSTEM_SOURCE` warn through the existing `warn()` helper and no-op; `THEME_NO_PROVIDER` throws a structured error. Each carries a stable code an agent can match.
+  - **XI.5 Story coverage** — Every behavior above is exercised in a story, so it is visible to humans in Storybook and to agents through the MCP.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-theme-toggle/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   ├── useTheme.md          # hook return shape + next-themes mapping
+│   ├── ThemeProvider.md     # provider props (defaults, forced)
+│   ├── toggles.md           # ThemeToggle + DensityToggle props
+│   ├── failures.md          # THEME_* codes and throw-vs-warn
+│   └── tokens-registry.md   # the "themes per axis" export
+├── checklists/
+│   └── requirements.md  # from /speckit.specify
+└── tasks.md             # Phase 2 output (/speckit.tasks, NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+packages/react/src/
+├── hooks/
+│   └── useTheme/
+│       ├── index.ts                 # exports ThemeProvider, useTheme, types
+│       ├── ThemeProvider.tsx        # provider: defaults + forced config, single source of truth
+│       ├── useTheme.ts              # the hook (reads provider context)
+│       ├── themeStore.ts            # useSyncExternalStore store: localStorage + matchMedia subscription
+│       ├── resolve.ts               # preference -> resolved (system -> light/dark), per axis
+│       ├── types.ts                 # Axis-keyed preference/resolved/forced/available + set()
+│       ├── useTheme.test.tsx        # unit: storage, matchMedia sub/cleanup, SSR, set(partial), forced, codes
+│       ├── Theming.stories.tsx      # 'Theming' group: Playground, Composition (multi-axis), ProviderConfig
+│       └── useTheme.usage.md        # sidecar: next-themes translation + the why-multi-axis alignment note
+├── components/
+│   ├── _internal/
+│   │   └── AxisToggle.tsx           # private shared shell over SegmentedControl + useTheme (not exported)
+│   ├── ThemeToggle/
+│   │   ├── index.ts
+│   │   ├── ThemeToggle.tsx          # fixed light/system/dark over the aesthetic axis
+│   │   ├── ThemeToggle.stories.tsx
+│   │   ├── ThemeToggle.test.tsx
+│   │   └── ThemeToggle.usage.md
+│   └── DensityToggle/
+│       ├── index.ts
+│       ├── DensityToggle.tsx        # data-driven from available.density
+│       ├── DensityToggle.stories.tsx
+│       ├── DensityToggle.test.tsx
+│       └── DensityToggle.usage.md
+└── index.ts                         # + export * from hooks/useTheme, ThemeToggle, DensityToggle
+
+packages/tokens/src/
+├── axes.ts                          # existing Axis union + AXIS_ATTRIBUTE (unchanged)
+├── runtime.ts                       # existing storage-key constants + bootstrap (unchanged)
+└── registry.ts                      # NEW: themesForAxis(axis) -> built-in values incl. file-less default, + runtime-registered
+
+AGENTS.md                            # + index entries for useTheme, ThemeToggle, DensityToggle
+.changeset/                          # + a changeset: @unbranded-ds/react minor, @unbranded-ds/tokens minor
+```
+
+**Structure Decision**: The provider and hook live together under `packages/react/src/hooks/useTheme/` because they are one unit (the hook is meaningless without its provider), with the `useSyncExternalStore` store and the resolve logic split into siblings for unit-testability. The two toggles are ordinary components under `packages/react/src/components/`, each with the full spec-IX file set; their shared wiring lives in a private `components/_internal/AxisToggle.tsx` that is never exported, so the public surface is exactly the two named toggles. The only `packages/tokens` change is a new `registry.ts` export, keeping that package React-free per Section II.
+
+## Storybook coverage
+
+Matching the bar SegmentedControl sets (Default, Sizes, Orientations, Disabled, plus behavioral and keyboard stories). Every story renders inside a `<ThemeProvider>` decorator, since the toggles throw `THEME_NO_PROVIDER` without one. Every story is axe-clean (zero serious or critical), per Section VI.
+
+`Components/ThemeToggle` (`ThemeToggle.stories.tsx`):
+
+- `Default` — three segments, system selected, with a `play` that selects dark and asserts the applied scheme.
+- `SystemFollowing` — a `play` drives a `prefers-color-scheme` change through the test-runner's media emulation and asserts `resolved` flips live without a storage write.
+- `Sizes` — sm / md / lg stacked.
+- `Orientations` — horizontal and vertical.
+- `Forced` — under a `forced={{ aesthetic: 'dark' }}` provider, the control renders disabled.
+- `AestheticIsBrand` — aesthetic set to `brand`, so no segment is selected and the control stays enabled.
+- `CustomLabelsAndIcons` — overridden `labels` and `icons`.
+
+`Components/DensityToggle` (`DensityToggle.stories.tsx`):
+
+- `Default`, `Sizes`, `Orientations`, `Forced`, `CustomLabelsAndIcons` — the same shape on the density axis.
+- `DataDrivenValues` — registers a theme on the density axis so a new segment appears, proving the `available`-driven rendering (FR-012).
+
+`Theming` (`hooks/useTheme/Theming.stories.tsx`):
+
+- `Playground` — a demo component reading `resolved` / `preference` and calling `set(partial)`, so `useTheme` is introspectable in the MCP; autodocs carry the next-themes mapping table.
+- `Composition` — `<ThemeToggle>` and `<DensityToggle>` side by side over one provider, with the live `resolved` pair shown, so a combination such as vaporwave plus compact visibly emerges from two independent controls (US3). This is the multi-axis story.
+- `ProviderConfig` — `defaults` and `forced` demonstrated.
+
+## Complexity Tracking
+
+No constitution violations. No entries.

--- a/specs/011-theme-toggle/quickstart.md
+++ b/specs/011-theme-toggle/quickstart.md
@@ -1,0 +1,83 @@
+# Quickstart: Theme controls
+
+How a consumer wires up flash-free, multi-axis theming with the toggles.
+
+## 1. Inline the bootstrap (no flash on reload)
+
+This is the spec-002 script, unchanged. It sets `data-theme` and `data-density` before first paint.
+
+```tsx
+import { themeBootstrapScript } from '@unbranded-ds/tokens/runtime';
+
+// In your document <head>, before the app renders:
+<script dangerouslySetInnerHTML={{ __html: themeBootstrapScript }} />
+```
+
+## 2. Wrap the app in the provider
+
+```tsx
+import { ThemeProvider } from '@unbranded-ds/react';
+
+export function App({ children }) {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+```
+
+## 3. Drop in the toggles
+
+A color-scheme control next to a density control. Setting one of each is how `vaporwave compact` happens: two independent axes, no composite variant.
+
+```tsx
+import { ThemeToggle, DensityToggle } from '@unbranded-ds/react';
+
+<ThemeToggle />     {/* light / system / dark */}
+<DensityToggle />   {/* comfortable / compact */}
+```
+
+## 4. Pin an axis you do not want users to change
+
+Lock density to `compact` and expose only the color scheme. The `<DensityToggle>` (if rendered) shows disabled, and `set({ density })` becomes a no-op.
+
+```tsx
+<ThemeProvider forced={{ density: 'compact' }}>
+  <ThemeToggle />
+</ThemeProvider>
+```
+
+## 5. Read or set any axis directly
+
+```tsx
+import { useTheme } from '@unbranded-ds/react';
+
+function Example() {
+  const { resolved, set } = useTheme();
+  return (
+    <button onClick={() => set({ aesthetic: 'vaporwave', density: 'compact' })}>
+      Current: {resolved.aesthetic} / {resolved.density}
+    </button>
+  );
+}
+```
+
+## 6. Two-state light/dark control (no `system`)
+
+`<ThemeToggle>` always includes `system`. For an explicit light/dark control, compose on the hook (about five lines).
+
+```tsx
+import { useTheme } from '@unbranded-ds/react';
+import { SegmentedControl } from '@unbranded-ds/react';
+
+function LightDarkToggle() {
+  const { resolved, set } = useTheme();
+  return (
+    <SegmentedControl.Root
+      aria-label="Color scheme"
+      value={resolved.aesthetic}
+      onValueChange={(value) => set({ aesthetic: value })}
+    >
+      <SegmentedControl.Item value="light">Light</SegmentedControl.Item>
+      <SegmentedControl.Item value="dark">Dark</SegmentedControl.Item>
+    </SegmentedControl.Root>
+  );
+}
+```

--- a/specs/011-theme-toggle/research.md
+++ b/specs/011-theme-toggle/research.md
@@ -1,0 +1,75 @@
+# Phase 0 Research: Theme controls
+
+Every `NEEDS CLARIFICATION` was resolved in the `/speckit.clarify` session; this file records those decisions plus the supporting best-practices for the new runtime code. Format: Decision / Rationale / Alternatives considered.
+
+## 1. State container: `useSyncExternalStore` plus provider context
+
+**Decision**: Hold theme state in a module-level store read through React's `useSyncExternalStore`, exposed via a `ThemeProvider` context. The provider seeds config (`defaults`, `forced`); the store owns the live values, the localStorage writes, and the `matchMedia` subscription.
+
+**Rationale**: `useSyncExternalStore` is the SSR-safe primitive for external mutable state. `getServerSnapshot` returns the configured defaults with no `window` access, the client snapshot reads localStorage after mount, and React handles tearing across multiple `useTheme()` consumers so two sibling toggles never disagree (FR-001).
+
+**Alternatives**: Plain `useState` in the provider renders fine but needs hand-wired `storage`/`matchMedia` effects and risks an SSR hydration mismatch; an external state library is unjustified weight for a single store.
+
+## 2. `system` persistence keeps the spec-002 bootstrap frozen (clarify Q1)
+
+**Decision**: The bootstrap key `unbranded-ds-theme` always holds a concrete value. A companion key, `unbranded-ds-theme-preference`, records the stated color-scheme intent including `system`. On mount the hook reads the companion key to re-enter `system` mode.
+
+**Rationale**: The spec-002 bootstrap runs `setAttribute('data-theme', getItem(key) || default)` and knows nothing about `system`. Writing `system` to that key would set `data-theme="system"`, which no CSS matches, breaking SC-001 for system users. A concrete bootstrap key preserves no-flash with the bootstrap untouched.
+
+**Alternatives**: Make the bootstrap `prefers-color-scheme`-aware, as next-themes' script is. Rejected: it reopens the frozen, CSP-hashed spec-002 bootstrap. Accept a flash for system users. Rejected: it weakens the headline criterion.
+
+## 3. `matchMedia` subscription for live OS following
+
+**Decision**: While a color-scheme preference is `system`, subscribe to `window.matchMedia('(prefers-color-scheme: dark)')` with `addEventListener('change', …)`, update `resolved` without writing to storage, and remove the listener on unmount or when the preference leaves `system`.
+
+**Rationale**: This is the FR-007 behavior. `addEventListener` is the current API; the deprecated `addListener` is avoided. The subscription is feature-detected and attached only client-side, after mount.
+
+**Alternatives**: Polling is wasteful and laggy. Subscribing on every axis is pointless, since only color-scheme has an OS signal today.
+
+## 4. SSR render: unresolved until mounted (clarify Q7)
+
+**Decision**: Toggles render immediately but in an unresolved state (no segment marked selected) until mounted, then reflect the stored preference.
+
+**Rationale**: The page theme never flashes, because the bootstrap already set the attributes, so only the toggle's highlight is uncertain before mount. Rendering an unresolved control on both the server and the first client render avoids a hydration mismatch with no `suppressHydrationWarning`, and keeping the control in the layout avoids a shift.
+
+**Alternatives**: Render the defaults with `suppressHydrationWarning` (mismatch risk plus a possible segment jump for non-default users); render `null` until mounted (layout shift as the control pops in).
+
+## 5. No `next-themes` runtime dependency (clarify Q5)
+
+**Decision**: Build the provider and hook in-repo; borrow next-themes' vocabulary and provider pattern only.
+
+**Rationale**: next-themes is single-axis. It cannot represent multi-axis state, per-axis `forced`, or the density axis without contortion. The implementation is small (a provider, a store, one media subscription), and skipping the dependency keeps us off its Next.js-oriented assumptions while still handing consumers a familiar, predictable API.
+
+**Alternatives**: Wrap next-themes for color-scheme and layer the rest on top (bridges a single-axis library into a multi-axis model); depend on it fully (conflates orthogonal axes into one value space).
+
+## 6. `available` from the tokens registry, defaults included (clarify Q3 and Q4)
+
+**Decision**: Add `themesForAxis(axis)` to `@unbranded-ds/tokens`, returning each axis's built-in values including its file-less default (such as `comfortable`), plus anything added at runtime via `registerTheme`. `useTheme().available` and the data-driven toggles read from it.
+
+**Rationale**: The tokens package owns which themes exist per axis, so it is the only source that makes "a newly authored value appears with no component change" true. The default value is part of the axis even without an override file, so the registry surfaces it as a first-class member.
+
+**Alternatives**: Consumer-configured `available` (bookkeeping, and the promise weakens to "for free once you update your config"); hardcoded per component (a new value means editing the component).
+
+## 7. `<ThemeToggle>` is fixed light/system/dark over the aesthetic axis (clarify Q2)
+
+**Decision**: `<ThemeToggle>` renders three fixed segments and targets the `aesthetic` axis. When the aesthetic value is `brand` or `vaporwave`, no segment is selected and the control stays enabled. The data-driven rule applies to `<DensityToggle>` and future axes only.
+
+**Rationale**: Color-scheme is not yet its own axis (the split is deferred), so light and dark live on the aesthetic axis alongside brand and vaporwave. A fixed curated subset is honest about the shared slot and avoids inventing the mappings the split will later introduce.
+
+**Alternatives**: Data-drive all aesthetic values (contradicts the three-segment intent and surfaces brand/vaporwave in a color-scheme control); disable on brand/vaporwave (less usable); map brand/vaporwave to an implicit light/dark (pulls the deferred split forward).
+
+## 8. Failure modes: warn three, throw one (clarify Q6)
+
+**Decision**: Route `THEME_INVALID_VALUE`, `THEME_AXIS_FORCED`, and `THEME_NO_SYSTEM_SOURCE` through the `warn()` helper (warn then no-op). Throw a structured error for `THEME_NO_PROVIDER`. Each failure carries a stable `code` field.
+
+**Rationale**: The first three are recoverable dev mistakes that should not crash a page, matching the existing non-throwing `warn()` convention from spec 004. A missing provider has no usable state to return, so throwing surfaces the wiring bug at once. A uniform `code` field lets an agent match the warned and thrown cases the same way.
+
+**Alternatives**: Warn on all four (a missing provider returns fabricated defaults and hides a real bug); throw on all four (a stray value crashes the page).
+
+## 9. Icons
+
+**Decision**: Color-scheme defaults to lucide `Sun` / `SunMoon` / `Moon`. Density defaults to a lucide pair that reads as roomy versus tight (working choice `Rows3` for comfortable, `Rows2` for compact), finalized during implementation. All overridable via `icons`.
+
+**Rationale**: lucide-react is already a dependency, and those glyphs are the conventional color-scheme set. Density has no canonical icon, so the default is a best effort a consumer can override.
+
+**Alternatives**: Text-only segments (less scannable at a glance); adding a new icon dependency (unjustified).

--- a/specs/011-theme-toggle/spec.md
+++ b/specs/011-theme-toggle/spec.md
@@ -1,0 +1,196 @@
+# Feature Specification: Theme controls (provider, hook, and per-axis toggles)
+
+**Feature Branch**: `011-theme-toggle`  
+**Created**: 2026-06-13  
+**Status**: Draft  
+**Input**: User description: "Ship the for-coleman ThemeToggle pattern, reconsidered for the multi-axis theming the system gained in spec 009. Rather than variant components for theme combinations (vaporwave compact, dark brand expanded), compose independent per-axis controls over a single axis-aware hook, behind a provider that follows next-themes conventions."
+
+**Depends on**: 002 (`themeBootstrapScript` and the storage keys), 004 (`SegmentedControl`, the underlying primitive), 005 (sidecar template and validator, Section XI), 009 (the two-axis token system this builds on), 013 (XI.2 compat-first vocabulary), 014 (resolution unification)
+**Blocks**: 012 (the example app consumes these controls)
+
+## Clarifications
+
+### Session 2026-06-13
+
+- Q: Do we need variant components for multi-axis theme combinations (e.g. `vaporwave compact`, `dark brand expanded high-contrast`)? → A: No. Named-composite variants are combinatorial and bake brand decisions into an unbranded DS. Combinations emerge instead from composing independent per-axis controls over one axis-aware hook.
+- Q: Split color-scheme (light/dark) out of the aesthetic axis now, so `dark brand` and a clean `system` become expressible? → A: Defer. Ship over the two axes that exist today (aesthetic, density). The hook is axis-agnostic, so splitting color-scheme into its own axis later is purely additive, not a rewrite.
+- Q: What shape is the multi-axis hook? → A: One `useTheme()` call returning per-axis maps, with a single `set(partial)` setter that takes one object and updates any subset of axes. No per-axis hook calls.
+- Q: Provider, or the brief's provider-less hook? → A: A `ThemeProvider`, matching next-themes. It is the home for `defaults` and `forced` config and the single source of truth that keeps sibling controls in sync.
+- Q: How do the names relate to next-themes? → A: Track upstream where a concept maps one-to-one (`forced`, `system`, `set`); rename only where the multi-axis shape forces it (`preference` for next-themes' `theme`, `resolved` for `resolvedTheme`). Document the mapping prominently.
+- Q: Should `<ThemeToggle>` let a consumer drop the `system` segment? → A: No. Three segments always (light/system/dark). A two-state light/dark control is a documented `useTheme()` recipe in the sidecar.
+- Q: How is a `system` color-scheme preference persisted so the unchanged spec-002 bootstrap stays flash-free? → A: The bootstrap key (`unbranded-ds-theme`) always holds a concrete `light`/`dark`; the `system` intent rides a separate companion key the hook reads on mount.
+- Q: With color-scheme still on the aesthetic axis, what does `<ThemeToggle>` show when the value is `brand`/`vaporwave`? → A: Fixed light/system/dark segments (not data-driven). No segment is selected but the control stays enabled; choosing a segment overwrites the aesthetic value. The data-driven rule (FR-012) applies to density and future axes only.
+- Q: Where does `available[axis]` come from, given the for-free promise and runtime `registerTheme`? → A: Derive it from the tokens package's theme registry (built-ins plus runtime-registered); add a per-axis "list themes" runtime export to `@unbranded-ds/tokens` if absent (in scope).
+- Q: How does an axis's file-less default (e.g. `comfortable` density) appear in `available`? → A: The registry includes each axis's default value as a first-class member even with no override file, so `available.density` is [comfortable, compact].
+- Q: Do we depend on `next-themes`, or only borrow its conventions? → A: Build our own provider and hook; borrow the vocabulary and provider pattern only, with no runtime dependency (`next-themes` is single-axis and cannot represent multi-axis state or per-axis `forced`).
+- Q: Do the `THEME_*` failures throw or warn-and-continue? → A: `THEME_INVALID_VALUE`, `THEME_AXIS_FORCED`, and `THEME_NO_SYSTEM_SOURCE` warn via `warn()` and no-op; `THEME_NO_PROVIDER` throws, since there is no usable state to return.
+- Q: What do toggles render before mount (SSR/hydration)? → A: An unresolved state (no segment selected) until mounted, then the stored preference. Server and first client render agree, so no mismatch and no layout shift.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Composable multi-axis theme state (Priority: P1)
+
+A consumer wraps their app in a provider and reads or updates the theme through one hook. They set any combination of axes (aesthetic, density) in a single call, the choices persist per axis, and the first paint after a reload shows no flash.
+
+**Why this priority**: The provider and hook are the load-bearing primitive. Every toggle and every downstream consumer builds on them, and they are the piece the for-coleman team said each app reimplements. Shipped alone, they already deliver the reusable core.
+
+**Independent Test**: Wrap a tree in `<ThemeProvider>`, call `useTheme()`, read `resolved` and `preference`, call `set()` with a subset of axes, and verify persistence, live system-following, and flash-free first paint when the spec-002 bootstrap is inlined.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `<ThemeProvider>` with the spec-002 bootstrap inlined in `<head>`, **When** the page reloads with a stored preference, **Then** no theme flash occurs and `resolved` matches what was stored.
+2. **Given** `preference.aesthetic` is `system`, **When** the OS color scheme changes mid-session, **Then** `resolved.aesthetic` updates live without a reload and without writing to storage.
+3. **Given** a mounted `useTheme()`, **When** `set({ density: 'compact' })` is called, **Then** density persists to its own key and the aesthetic axis is untouched.
+4. **Given** server-side rendering, **When** the provider renders on the server, **Then** it returns defaults without touching `window` or `localStorage` and hydrates on the client without a mismatch.
+
+### User Story 2 - Drop-in color-scheme toggle (Priority: P2)
+
+A consumer drops `<ThemeToggle>` into their UI and gets the light/system/dark control they would otherwise rebuild: persisted, system-aware, keyboard-navigable, accessible.
+
+**Why this priority**: This is the exact for-coleman pattern and the most visible win, and it completes the for-coleman scorecard at 6 of 6. It depends on US1 but delivers the recognizable artifact.
+
+**Independent Test**: Render `<ThemeToggle>`, confirm three segments (light/system/dark), confirm that selecting a segment updates the aesthetic axis and persists, and confirm the live OS-change path.
+
+**Acceptance Scenarios**:
+
+1. **Given** a rendered `<ThemeToggle>`, **When** the user selects dark, **Then** the applied color scheme becomes dark and the choice persists across a reload.
+2. **Given** the toggle set to `system`, **When** the OS scheme flips, **Then** the applied theme follows live.
+3. **Given** `labels` and `icons` props, **When** provided, **Then** they override the English and lucide defaults; when absent, the defaults render.
+4. **Given** the rendered control, **When** audited, **Then** it exposes an accessible group name and produces zero serious or critical accessibility violations.
+
+### User Story 3 - A second axis, and combinations for free (Priority: P3)
+
+A consumer drops a `<DensityToggle>` next to the `<ThemeToggle>`. Setting aesthetic to vaporwave and density to compact just works: the combination is the product of two independent controls, not a `vaporwave compact` variant anyone had to build.
+
+**Why this priority**: It proves the compose-don't-enumerate model and spares consumers from rebuilding a density control, the same motivation as US2 applied to the second axis. It ranks below US2 only because color-scheme is the more universal need.
+
+**Independent Test**: Render both toggles, set aesthetic to vaporwave and density to compact through them, and verify both `data-*` attributes apply independently.
+
+**Acceptance Scenarios**:
+
+1. **Given** both toggles rendered, **When** aesthetic is set to vaporwave and density to compact, **Then** both attributes apply and neither axis clobbers the other.
+2. **Given** a newly authored density value (for example `expanded`), **When** it appears in `available.density`, **Then** `<DensityToggle>` renders a segment for it with no component change, labeled by the raw value when no override is supplied.
+3. **Given** `<DensityToggle>`, **When** rendered, **Then** it has no `system` segment, because density has no OS signal.
+
+### User Story 4 - Pin an axis (Priority: P4)
+
+A consumer exposes one axis to end users and locks another to a fixed value: for example, an app that is always compact but lets users choose their color scheme.
+
+**Why this priority**: It is a distinct capability (configuration, not interaction) that several consumers need, and it was an explicit requirement. It rides on the provider from US1.
+
+**Independent Test**: Render `<ThemeProvider forced={{ density: 'compact' }}>`, verify density is applied while storage is ignored for it, verify a `<DensityToggle>` renders disabled, and verify `set({ density })` is a structured no-op.
+
+**Acceptance Scenarios**:
+
+1. **Given** `forced.density` is compact, **When** storage holds a different density, **Then** compact is applied (the forced value wins).
+2. **Given** a forced density axis, **When** a `<DensityToggle>` is rendered, **Then** it is disabled.
+3. **Given** a forced density axis, **When** `set({ density: 'comfortable' })` is called, **Then** the value does not change and a `THEME_AXIS_FORCED` structured failure is emitted.
+
+### User Story 5 - Predictable, and documented as such (Priority: P5)
+
+An agent or developer who knows next-themes can predict this API and find the alignment spelled out where they look: in TSDoc, in the sidecar, and in a short rationale note.
+
+**Why this priority**: Agent legibility is the constitution-level differentiator, and clear documentation of how it matches next-themes and our own conventions was a hard requirement. It comes last only because it depends on the surface the other stories define.
+
+**Independent Test (mechanical)**: Run the spec-005 sidecar validator and confirm each component's `*.usage.md` compiles; confirm the next-themes mapping appears in the hook's TSDoc and the sidecar. Whether the prose reads clearly is a humanizer-and-review gate, not an automated check.
+
+**Acceptance Scenarios**:
+
+1. **Given** the sidecar validator in CI, **When** a `*.usage.md` is missing or its `tsx` fails to compile, **Then** the build fails.
+2. **Given** a reader who knows next-themes, **When** they open the hook's TSDoc, **Then** the mapping (`theme` → `preference`, `resolvedTheme` → `resolved`, `forcedTheme` → `forced`, `systemTheme` → `system`, `setTheme` → `set`) is documented inline.
+3. **Given** the alignment note, **When** read, **Then** it states why the design is multi-axis and provider-based and links specs 002, 009, and 014.
+
+### Edge Cases
+
+- **Storage blocked** (private mode, blocked cookies): the provider falls back to `defaults` and does not throw, the same as the bootstrap's own try/catch.
+- **Unknown stored value** for an axis (storage holds a value not in `available`): the axis resolves to its default and a `THEME_INVALID_VALUE` failure is emitted, rather than applying a value the build cannot render.
+- **`system` on an axis with no OS signal** (e.g. `set({ density: 'system' })`): rejected with `THEME_NO_SYSTEM_SOURCE`.
+- **`useTheme()` outside a provider**: a `THEME_NO_PROVIDER` failure that names the fix rather than falling back silently.
+- **Two consumers of `useTheme()`** in one tree: both reflect a single state, because the provider is the source of truth.
+- **OS signals other than color scheme** (reduced-motion, contrast): out of scope; the aesthetic axis, via its light/dark values, is the only one with an OS source today.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Provider**
+
+- **FR-001**: A `ThemeProvider` MUST own theme state for every registered axis and be the single source of truth, so multiple controls render one consistent state.
+- **FR-002**: The provider MUST accept per-axis `defaults`, falling back to the system constants from spec 002's runtime (`light` for aesthetic, `comfortable` for density).
+- **FR-003**: The provider MUST accept per-axis `forced` values that are applied, take precedence over stored preferences, and cannot be changed through the hook.
+
+**Hook**
+
+- **FR-004**: `useTheme()` MUST return, per axis, the stated `preference` (which may be `system`) and the applied `resolved` value, plus `system` (the OS value where a signal exists), `forced`, and `available` (the allowed values per axis: each axis's built-in values from the tokens registry, including its file-less default such as `comfortable`, plus any registered at runtime via `registerTheme`).
+- **FR-005**: `useTheme()` MUST return `set(partial)`, accepting one object keyed by axis that updates any subset of axes in a single call and persists each changed axis to its own storage key.
+- **FR-006**: The hook MUST read and persist using the spec-002 keys (`unbranded-ds-theme`, `unbranded-ds-density`), so consumers who inline the bootstrap get no first-paint flash. The bootstrap-read key MUST always hold a concrete theme value: when a color-scheme preference is `system`, the resolved `light`/`dark` value is written to `unbranded-ds-theme` and the `system` intent is recorded in a separate companion key, so the unchanged spec-002 bootstrap never applies a non-existent `data-theme="system"`.
+- **FR-007**: For any axis whose preference is `system` and which has an OS signal, the hook MUST subscribe to that signal, update `resolved` live without writing to storage, and remove the listener on unmount. On mount the hook MUST read the companion key to re-enter `system` mode rather than treating the concrete stored value as an explicit choice.
+- **FR-008**: The provider and hook MUST render safely under SSR (defaults, no `window` or `localStorage` access) and reconcile to stored values on mount without a hydration mismatch. Until mounted, toggles MUST render in an unresolved state (no segment marked selected) so the server and first client render agree; the selected segment appears after mount, with no layout shift and no reliance on `suppressHydrationWarning`.
+- **FR-009**: The hook MUST be axis-agnostic, typed over the shared `Axis` union, so a future axis (notably a split-out color-scheme axis) is additive: a new key across `preference`, `resolved`, `forced`, `available`, and `set`, with `<ThemeToggle>` re-pointing to it and nothing else changing. This is the planned seam for the color-scheme-split follow-up.
+
+**Toggles**
+
+- **FR-010**: A `ThemeToggle` MUST render a fixed three-segment color-scheme control (light / system / dark) targeting the `aesthetic` axis (color-scheme is not yet its own axis). Its segments are fixed, not derived from `available`. When the aesthetic value is `brand` or `vaporwave` and no segment matches, the control MUST show no selected segment yet stay enabled; selecting a segment overwrites the aesthetic value with `light`, `dark`, or `system`.
+- **FR-011**: A `DensityToggle` MUST render a control over the density axis wired to the hook, with no `system` segment.
+- **FR-012**: Axis toggles other than `<ThemeToggle>` (the `<DensityToggle>` and any future per-axis toggle) MUST derive their segments from `available[axis]`, so a newly authored axis value appears without a component change. `<ThemeToggle>` is the curated exception (FR-010): color-scheme exposes a fixed light/system/dark subset of the aesthetic axis rather than all its values.
+- **FR-013**: Toggles MUST forward `size` and `orientation` to `SegmentedControl` (which exposes those, not `variant`), accept per-value `labels` and `icons` overrides (English and lucide defaults), pass through standard root props (`className`, `id`, ref, rest), and MUST expose an accessible group name (default "Color scheme" / "Density").
+- **FR-014**: A toggle bound to a forced axis MUST render disabled.
+- **FR-015**: Toggles MUST source their state from the provider and take no `value` or `onChange` props; a consumer wanting different UX composes on `useTheme()` directly.
+- **FR-016**: The color-scheme sidecar MUST document a two-state (light/dark, no system) recipe built on `useTheme()`, since `<ThemeToggle>` itself always includes the `system` segment.
+
+**Failures (Section XI.4)**
+
+- **FR-017**: The system MUST emit structured failures, each with a stable `code` and the offending value. `THEME_INVALID_VALUE` (a value not in `available[axis]` and not `system`), `THEME_AXIS_FORCED` (a set on a forced axis), and `THEME_NO_SYSTEM_SOURCE` (`system` on an axis with no OS signal) MUST warn through the existing `warn()` helper and no-op, leaving the app running. `THEME_NO_PROVIDER` (`useTheme()` outside a provider) MUST throw a structured error carrying that code, since there is no usable state to return.
+
+**Exports, vocabulary, and documentation**
+
+- **FR-018**: `ThemeProvider`, `useTheme`, `ThemeToggle`, and `DensityToggle` MUST be exported from the package root.
+- **FR-019**: Names MUST track next-themes where a concept maps one-to-one (`forced`, `system`, `set`) and diverge only where the multi-axis shape requires it (`preference` for next-themes' `theme`, `resolved` for `resolvedTheme`), per the compat-first reading of Section XI.2 (spec 013). This is vocabulary alignment only: the provider and hook are our own implementation with no runtime dependency on `next-themes`, which is single-axis and cannot represent multi-axis state or per-axis `forced`.
+- **FR-020**: This feature MUST ship a convention-alignment writeup that (a) places the full next-themes mapping in `useTheme` TSDoc and the sidecars, with `ThemeProvider` and each toggle's TSDoc carrying a one-line pointer to it (the mapping describes the hook's fields, so duplicating the full table on every symbol is redundant); (b) opens each `*.usage.md` sidecar with an "if you know next-themes, here is the translation" framing; and (c) explains why the design is multi-axis and provider-based, cross-linking specs 002, 009, and 014.
+- **FR-021**: Each component MUST ship a `*.usage.md` sidecar that passes the spec-005 validator.
+- **FR-022**: All autodoc and sidecar prose MUST pass the humanizer audit, with no three-item-list tic.
+
+**Stories and Storybook surface**
+
+- **FR-023**: Each toggle MUST ship a `Default` story plus a story per meaningful variant and state, matching the bar `SegmentedControl` sets: sizes (sm/md/lg), orientations (horizontal/vertical), the forced/disabled state, and a custom `labels`/`icons` override. `<ThemeToggle>` additionally ships a system-following story whose `play` drives a `prefers-color-scheme` change, and the brand/vaporwave indeterminate state; `<DensityToggle>` ships a story that registers a theme so a data-driven value appears. Every story renders inside a `<ThemeProvider>` decorator.
+- **FR-024**: A `Theming` story group MUST surface `useTheme` and `<ThemeProvider>` in Storybook, and therefore in the published MCP (Section XI.5), so the hook and provider are not visible only in the offline sidecar. It MUST include a compositional story that renders `<ThemeToggle>` and `<DensityToggle>` together and shows a multi-axis combination, such as vaporwave plus compact, emerging from the two independent controls. Its autodocs carry the next-themes mapping.
+
+### Key Entities
+
+- **Axis**: an independent theming dimension (aesthetic and density today), bound to a `data-*` attribute and its own storage key. The shared `Axis` union is the canonical list of axes.
+- **Preference**: a user's stated choice for an axis. May be `system` for an axis that has an OS signal.
+- **Resolved value**: the value actually applied for an axis after a `system` preference is resolved against the OS.
+- **Forced value**: a provider-pinned value for an axis that overrides stored preferences and cannot be changed through the hook.
+- **ThemeProvider**: the single source of truth holding per-axis state plus the `defaults` and `forced` configuration.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With the bootstrap inlined, a page reload carrying a stored preference shows no theme flash; the rendered theme never changes after first paint.
+- **SC-002**: Changing the OS color scheme while color-scheme is `system` updates the page within one frame, with no reload.
+- **SC-003**: A consumer can set any combination of axes (for example vaporwave plus compact) in a single call, and each axis persists independently across reloads.
+- **SC-004**: A consumer can expose one axis and pin another so that the pinned axis cannot be changed by an end user.
+- **SC-005**: Both toggles are fully operable by keyboard and produce zero serious or critical accessibility violations.
+- **SC-006**: A reader who knows next-themes can correctly predict the hook's fields and the toggle behavior from the documented mapping, without reading the source.
+- **SC-007**: A missing or non-compiling sidecar fails the build.
+- **SC-008**: An agent querying the published MCP can discover `useTheme` and `<ThemeProvider>` and find a worked example of two axes combining, not only the offline sidecar.
+
+## Assumptions
+
+- Color-scheme stays a value set on the aesthetic axis for now. Splitting it into its own axis is a deliberate near-term follow-up; the axis-agnostic hook makes that split additive rather than a rewrite (decided 2026-06-13).
+- The provider model is a conscious divergence from the brief's provider-less `useTheme` sketch, justified by pinning, shared state, and next-themes compatibility (Section XI.2, spec 013).
+- Density carries `comfortable` (default) and `compact` today. `expanded`, and any contrast or high-contrast axis, are not yet authored and are out of scope; the data-driven toggles absorb new values when they land.
+- The hook uses `system` (next-themes' term) rather than the brief's `auto`, following the compat-first vocabulary.
+- Color-scheme icons default to Sun / SunMoon / Moon; density uses a sensible lucide pair, with exact glyphs chosen at implementation.
+- `useTheme()` requires a `ThemeProvider` ancestor, as next-themes does; calling it without one is the `THEME_NO_PROVIDER` failure, not a silent fallback.
+- Multi-tab synchronization via the `storage` event is optional and may be deferred; it is not required for acceptance.
+- Deriving `available` from the tokens registry assumes (or adds) a per-axis "list registered themes" runtime export from `@unbranded-ds/tokens`; providing it if absent is in scope for this feature.
+
+## Out of Scope
+
+- A switch-style two-state toggle as its own component (covered by the documented `useTheme()` recipe).
+- Theme preview thumbnails in a toggle.
+- A multi-tenant theme registration UI.
+- Splitting color-scheme into its own axis (the planned follow-up this spec leaves a seam for).
+- Authoring new density values or a contrast axis.

--- a/specs/011-theme-toggle/tasks.md
+++ b/specs/011-theme-toggle/tasks.md
@@ -1,0 +1,217 @@
+# Tasks: Theme controls (provider, hook, and per-axis toggles)
+
+**Input**: Design documents from `/specs/011-theme-toggle/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: REQUIRED, not optional. Constitution Section VI mandates unit, interaction, and a11y layers, and every component ships with tests. Unit tests are written test-first and must fail before their implementation task.
+
+**Organization**: By user story (US1 to US5) in priority order. `[P]` marks a task that can run in parallel with its siblings (different files, no dependency on an incomplete task).
+
+## Format: `[ID] [P?] [Story?] Description`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Directory scaffolding and release bookkeeping. The monorepo already exists, so this phase is light.
+
+- [x] T001 Create the directory skeleton: `packages/react/src/hooks/useTheme/`, `packages/react/src/components/ThemeToggle/`, `packages/react/src/components/DensityToggle/`, `packages/react/src/components/_internal/`
+- [x] T002 [P] Add a changeset in `.changeset/` declaring `@unbranded-ds/react` (minor) and `@unbranded-ds/tokens` (minor)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared types and the tokens registry that every story builds on.
+
+**⚠️ CRITICAL**: No user story can begin until this phase is complete.
+
+- [x] T003 [P] Write a failing unit test for the theme registry in `packages/tokens/src/registry.test.ts` (built-ins include the file-less `comfortable` default; `registerTheme` additions appear; stable order, default first)
+- [x] T004 [P] Add the companion-key constant `THEME_PREFERENCE_STORAGE_KEY = 'unbranded-ds-theme-preference'` to `packages/tokens/src/runtime.ts`
+- [x] T005 [P] Define the shared types in `packages/react/src/hooks/useTheme/types.ts` (`Axis`-keyed `preference`/`resolved`/`system`/`forced`/`available`, `UseThemeReturn`, `ThemeProviderProps`)
+- [x] T006 Implement `themesForAxis(axis)` plus the runtime registry in `packages/tokens/src/registry.ts`, export it from `packages/tokens/src/index.ts`, and have `registerTheme` additively record `(axis, name)`; makes T003 pass
+
+**Checkpoint**: Types and the value-source registry exist. User stories can begin.
+
+---
+
+## Phase 3: User Story 1 - Composable multi-axis theme state (Priority: P1) 🎯 MVP
+
+**Goal**: `<ThemeProvider>` plus `useTheme()` deliver per-axis read and one-object `set(partial)`, with persistence, live system-following, and SSR safety.
+
+**Independent Test**: Wrap a tree in `<ThemeProvider>`, call `useTheme()`, `set({ density: 'compact' })`, reload, and confirm persistence; flip the OS scheme while at `system` and confirm live update; render on a server with no `window`.
+
+### Tests for User Story 1 (write first, must fail)
+
+- [x] T007 [P] [US1] Failing unit test for resolve logic in `packages/react/src/hooks/useTheme/resolve.test.ts` (`system` resolves to light/dark; concrete values pass through)
+- [x] T008 [P] [US1] Failing unit test for the store in `packages/react/src/hooks/useTheme/themeStore.test.ts` (per-axis localStorage read/write; `matchMedia` subscribe/update/cleanup; `getServerSnapshot` returns defaults with no `window`; companion-key `system` re-entry on mount)
+- [x] T009 [P] [US1] Failing render test for the hook + provider in `packages/react/src/hooks/useTheme/useTheme.test.tsx` (`set(partial)` touches only named axes; return shape; `defaults` and `forced` applied; `THEME_NO_PROVIDER` throws; `THEME_INVALID_VALUE`/`THEME_AXIS_FORCED`/`THEME_NO_SYSTEM_SOURCE` warn via `warn()`)
+- [x] T010 [P] [US1] Failing SSR test (in the `__ssr__` harness) asserting the provider renders without touching `window`/`localStorage` and hydrates with no mismatch
+
+### Implementation for User Story 1
+
+- [x] T011 [P] [US1] Implement the failure codes and `ThemeProviderError` (code `THEME_NO_PROVIDER`) in `packages/react/src/hooks/useTheme/errors.ts` per contracts/failures.md
+- [x] T012 [P] [US1] Implement `resolve.ts` (preference → resolved per axis, `system` via `prefers-color-scheme`); makes T007 pass
+- [x] T013 [US1] Implement `themeStore.ts` (`useSyncExternalStore` store: read/write the concrete + companion + density keys, apply `data-*` to `root`, `matchMedia` subscription with cleanup, `getServerSnapshot` = defaults, `forced` overrides storage); depends on T005, T012, T004; makes T008 pass
+- [x] T014 [US1] Implement `ThemeProvider.tsx` (context, `defaults`, `forced`, `root`, single source of truth); depends on T013
+- [x] T015 [US1] Implement `useTheme.ts` (assemble the return from the store + `themesForAxis` for `available`; `set(partial)` validates and warns; throws `THEME_NO_PROVIDER` outside a provider); depends on T014, T011, T006; makes T009 and T010 pass
+- [x] T016 [P] [US1] Create `hooks/useTheme/index.ts` and add `export * from './hooks/useTheme'` to `packages/react/src/index.ts`
+- [x] T017 [P] [US1] Write a basic `hooks/useTheme/useTheme.usage.md` sidecar (import path, return-shape table, examples), and extend the spec-005 sidecar validator glob to cover `packages/react/src/hooks/**` so the hook sidecar is validated in CI (FR-021/SC-007); the next-themes mapping and alignment note land in US5
+
+**Checkpoint**: US1 is functional and independently testable. This is the MVP.
+
+---
+
+## Phase 4: User Story 2 - Drop-in color-scheme toggle (Priority: P2)
+
+**Goal**: `<ThemeToggle>` gives a persisted, system-aware, accessible light/system/dark control.
+
+**Independent Test**: Render `<ThemeToggle>` inside a provider, confirm three segments, select dark and confirm the applied scheme persists, and confirm the live OS-change path.
+
+### Tests for User Story 2 (write first, must fail)
+
+- [x] T018 [P] [US2] Failing test in `packages/react/src/components/ThemeToggle/ThemeToggle.test.tsx` (three fixed segments; selecting calls `set({ aesthetic })`; `brand`/`vaporwave` shows no selection and stays enabled; forced → disabled; unresolved until mounted)
+
+### Implementation for User Story 2
+
+- [x] T019 [US2] Implement the private `AxisToggle.tsx` in `packages/react/src/components/_internal/` (renders `SegmentedControl` from a values list; wires `value`=resolved and `onValueChange`=`set`; `aria-label`, `labels`, `icons`; disables when the axis is forced; renders unresolved until mounted); depends on US1
+- [x] T020 [US2] Implement `ThemeToggle.tsx` (fixed light/system/dark over the aesthetic axis; Sun/SunMoon/Moon defaults; indeterminate on `brand`/`vaporwave`) on top of `AxisToggle`; depends on T019; makes T018 pass
+- [x] T021 [P] [US2] Write `ThemeToggle.stories.tsx` (Default with a `play`, SystemFollowing with a media-emulation `play`, Sizes, Orientations, Forced, AestheticIsBrand, CustomLabelsAndIcons; all under a `<ThemeProvider>` decorator)
+- [x] T022 [P] [US2] Write `ThemeToggle.usage.md` sidecar, including the two-state light/dark `useTheme()` recipe (FR-016)
+- [x] T023 [P] [US2] Create `ThemeToggle/index.ts` and add `export * from './components/ThemeToggle'` to the package index
+
+**Checkpoint**: US1 and US2 both work independently.
+
+---
+
+## Phase 5: User Story 3 - A second axis, and combinations for free (Priority: P3)
+
+**Goal**: `<DensityToggle>` plus a compositional story prove that combinations emerge from independent controls.
+
+**Independent Test**: Render `<ThemeToggle>` and `<DensityToggle>` together, set aesthetic to vaporwave and density to compact, and confirm both `data-*` attributes apply independently.
+
+### Tests for User Story 3 (write first, must fail)
+
+- [x] T024 [P] [US3] Failing test in `packages/react/src/components/DensityToggle/DensityToggle.test.tsx` (segments come from `available.density` including `comfortable`; no `system` segment; a `registerTheme` addition shows a new segment; forced → disabled)
+
+### Implementation for User Story 3
+
+- [x] T025 [US3] Implement `DensityToggle.tsx` (data-driven from `available.density`, no system segment) on `AxisToggle`; depends on T019 (AxisToggle) and US1; makes T024 pass
+- [x] T026 [P] [US3] Write `DensityToggle.stories.tsx` (Default, Sizes, Orientations, Forced, CustomLabelsAndIcons, DataDrivenValues that registers a theme; provider decorator)
+- [x] T027 [P] [US3] Write `DensityToggle.usage.md` sidecar
+- [x] T028 [P] [US3] Create `DensityToggle/index.ts` and add `export * from './components/DensityToggle'` to the package index
+- [x] T029 [US3] Write `hooks/useTheme/Theming.stories.tsx` (the `Theming` group: `Playground` exercising `useTheme`/`set`, `Composition` rendering both toggles over one provider with the live `resolved` pair, `ProviderConfig` demonstrating `defaults` and `forced`); depends on T020 and T025
+
+**Checkpoint**: All three controls work; the multi-axis composition is demonstrable in Storybook and the MCP.
+
+---
+
+## Phase 6: User Story 4 - Pin an axis (Priority: P4)
+
+**Goal**: A consumer can lock an axis so end users cannot change it. (The `forced` plumbing ships in US1's provider/store/hook and US2's `AxisToggle`; this phase proves the journey end to end and closes any gap.)
+
+**Independent Test**: Render `<ThemeProvider forced={{ density: 'compact' }}>` with a `<DensityToggle>`; confirm the toggle is disabled, `set({ density })` is a no-op emitting `THEME_AXIS_FORCED`, and the forced value wins over a different stored value.
+
+### Tests for User Story 4 (write first, must fail)
+
+- [x] T030 [P] [US4] Failing integration test in `packages/react/src/hooks/useTheme/forced.test.tsx` (forced axis applied over stored value; `<DensityToggle>` disabled under `forced`; `set()` on the forced axis is a no-op and emits `THEME_AXIS_FORCED`)
+
+### Implementation for User Story 4
+
+- [x] T031 [US4] Close any gap the test surfaces in the `forced` path across `themeStore.ts`, `useTheme.ts`, and `_internal/AxisToggle.tsx`; makes T030 pass
+
+**Checkpoint**: Pinning works end to end and is independently testable.
+
+---
+
+## Phase 7: User Story 5 - Predictable, and documented as such (Priority: P5)
+
+**Goal**: An agent or developer who knows next-themes can predict the API and find the alignment documented in TSDoc, the sidecars, and the MCP.
+
+**Independent Test**: The sidecar validator passes; the next-themes mapping table appears in `useTheme` TSDoc and its sidecar; the `Theming` group is introspectable via the MCP.
+
+### Implementation for User Story 5
+
+- [x] T032 [P] [US5] Add the next-themes mapping table to `useTheme` TSDoc and `useTheme.usage.md`, a one-line pointer to it from `ThemeProvider` and each toggle's TSDoc, plus the why-multi-axis alignment note with links to specs 002, 009, and 014
+- [x] T033 [P] [US5] Add the "if you know next-themes" framing to `ThemeToggle.usage.md` and `DensityToggle.usage.md`
+- [x] T034 [P] [US5] Add `AGENTS.md` index entries for `useTheme`, `ThemeProvider`, `ThemeToggle`, and `DensityToggle`
+- [x] T035 [US5] Run the `humanizer` skill over every prose surface this feature adds (sidecars, TSDoc, story descriptions) and revise in place per its audit loop
+- [x] T036 [US5] Verify SC-006/SC-008 (the `Theming` group surfaces the hook and provider in MCP introspection) and SC-007 (the sidecar validator fails on a missing or broken sidecar)
+
+**Checkpoint**: Both audiences can predict and discover the API.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+- [ ] T037 [P] Run the quickstart.md walkthrough end to end (bootstrap + provider + both toggles + a pinned axis); confirm no first-paint flash and a live OS-change update
+- [ ] T038 [P] Confirm axe reports zero serious or critical violations across all new stories
+- [ ] T039 Run the full local CI chain (lint, typecheck, unit, build, storybook build, test-runner) and confirm green per Section IX
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Setup (Phase 1)**: no dependencies.
+- **Foundational (Phase 2)**: after Setup. Blocks all stories.
+- **US1 (Phase 3)**: after Foundational. The base every other story builds on.
+- **US2 (Phase 4)**: after US1 (needs the hook).
+- **US3 (Phase 5)**: after US2 (reuses the private `AxisToggle` built in T019) and US1.
+- **US4 (Phase 6)**: after US2 (forced spans provider, hook, and `AxisToggle`).
+- **US5 (Phase 7)**: after US1 to US3 (documents what exists).
+- **Polish (Phase 8)**: after all desired stories.
+
+### Within a story
+
+- Tests are written first and must fail before the implementation task that satisfies them.
+- Store before provider before hook (T013 → T014 → T015).
+- `AxisToggle` (T019) before either concrete toggle (T020, T025).
+
+## Parallel Opportunities
+
+The user asked to parallelize aggressively. The widest windows:
+
+- **Foundational**: T003, T004, T005 run together (registry test, tokens constant, react types, three different files). T006 follows T003.
+- **US1 tests**: T007, T008, T009, T010 run together (four different test files). In implementation, T011 and T012 run together before the T013 → T014 → T015 chain; T016 and T017 run together after.
+- **US2 / US3 trailing tasks**: stories, sidecars, and index wiring (T021/T022/T023; T026/T027/T028) are each `[P]` within their story.
+- **US5**: T032, T033, T034 run together (different doc files), then T035 (humanizer) over the combined result.
+- **Cross-story**: US2 and US3 cannot fully overlap because US3's `DensityToggle` needs `AxisToggle` from T019. Once T019 lands, US3's stories/sidecar/index can proceed alongside US2's trailing tasks.
+
+### Parallel example: US1 tests
+
+```bash
+# Launch the four US1 test files together (all must fail first):
+Task: "resolve.test.ts"        # T007
+Task: "themeStore.test.ts"     # T008
+Task: "useTheme.test.tsx"      # T009
+Task: "__ssr__ provider test"  # T010
+```
+
+### Parallel example: Foundational
+
+```bash
+Task: "registry.test.ts"                    # T003
+Task: "THEME_PREFERENCE_STORAGE_KEY const"  # T004
+Task: "useTheme/types.ts"                   # T005
+```
+
+## Implementation Strategy
+
+### MVP first
+
+1. Setup + Foundational.
+2. US1 (provider + hook). **Stop and validate**: the hook persists, follows the OS, and renders SSR-safe. This alone is the reusable core the for-coleman team kept rebuilding.
+
+### Incremental delivery
+
+US1 (MVP) → US2 (the visible color-scheme toggle, completes the for-coleman scorecard) → US3 (density sibling + the compositional story) → US4 (pinning) → US5 (the alignment docs). Each adds value without breaking the prior stories.
+
+## Notes
+
+- `[P]` = different files, no incomplete-task dependency.
+- `AxisToggle` is a private internal and is never exported from the package index.
+- `forced` is implemented in US1 (provider/store/hook) and US2 (`AxisToggle`), so the Forced stories in US2/US3 are self-consistent; US4 is the end-to-end pinning slice.
+- Test our wrapper logic, not SegmentedControl's keyboard baseline (covered in spec 004): assert that selection routes to `set()` with the right axis, not the arrow-key mechanics.
+- Commit after each task or logical group.


### PR DESCRIPTION
## Summary

Adds the design system's theme controls: an axis-agnostic `useTheme` hook behind a `<ThemeProvider>`, plus two composable per-axis controls. `<ThemeToggle>` drives the color scheme (light/system/dark); `<DensityToggle>` drives density. Consumers stop hand-rolling theme state and import a surface that mirrors `next-themes` where the concepts line up.

## Why a Provider and a Multi-Axis Hook

Theming here already spans two axes: aesthetic (`data-theme`) and density (`data-density`). A single-value `theme` can't represent that, so `useTheme` is keyed over the axes and takes one object-valued `set(partial)`; the planned color-scheme split stays additive. The `<ThemeProvider>` is the single source of truth and the home for `defaults` and `forced`. This is a deliberate divergence from the brief's provider-less sketch, chosen so `forced` and shared multi-toggle state have somewhere to live, and so the shape matches the upstream pattern consumers already know.

## The next-themes Vocabulary

The hook tracks `next-themes` one-to-one where a concept maps cleanly, and renames only where the multi-axis shape forces it: `theme → preference`, `resolvedTheme → resolved`, `systemTheme → system`, `forcedTheme → forced`, `themes → available`, `setTheme → set`. The full table lives in the hook's sidecar.

## Browser-Safe Tokens Entry

`useTheme` reads the tokens' axis constants, storage keys, and per-axis theme list at runtime. Reaching them through the package barrel pulled `node:fs` into the consumer type graph, through the theme-map and validator code. This PR extracts the pure constants into `axis-constants.ts` and adds a browser-safe `@unbranded-ds/tokens/client` entry, so the react public surface is provably free of `node:fs`. The sidecar validator enforces that.

## What's Inside

- `@unbranded-ds/tokens`: axis constants, a theme registry (`themesForAxis`), the `./client` entry, and a companion storage key for the `system` intent.
- `@unbranded-ds/react`: `useTheme` and `ThemeProvider`, `<ThemeToggle>` (fixed light/system/dark), `<DensityToggle>` (segments data-driven from the registry), and the shared private `AxisToggle`.
- Docs: the `next-themes` mapping in the hook sidecar, AGENTS.md index entries, and the Theming story group (Playground, Composition, ProviderConfig).

## Verification

263 unit tests pass across both packages, both typecheck and build, and the sidecar validator is clean (the react surface stays `node:fs`-free). The Storybook interaction and a11y test-runner is browser-based and runs in CI; I didn't run it locally.

## Notes

- The color-scheme axis split is deferred. `<ThemeToggle>` shows no selection but stays enabled when the value is `brand` or `vaporwave`, and the seam for splitting it out is additive.
- No `next-themes` runtime dependency; the provider is implemented in-repo.

Implements spec 011.
