### PR TITLE
Fix the destructive Button's contrast with a reusable destructive-subtle token (spec 018)

### DIFF
--- a/.changeset/destructive-button-contrast.md
+++ b/.changeset/destructive-button-contrast.md
@@ -1,0 +1,10 @@
+---
+"@unbranded-ds/tokens": minor
+"@unbranded-ds/react": minor
+---
+
+Fix the destructive Button's contrast and ship the soft destructive treatment as a reusable token.
+
+The Button's `destructive` variant rendered the destructive color as text on a translucent tint, which fell to about 4.1:1 in the light themes — below WCAG AA. It now paints a new canonical `destructive-subtle` surface with a darker `destructive-subtle-foreground`, authored to pass AA in every identity-by-scheme cell (all six) and surface-independent so it holds on cards and the page background alike.
+
+A sixth declared contrast pair guards `destructive-subtle-foreground` on `destructive-subtle`, so a theme that drifts below 4.5:1 fails the build with a structured issue; the matrix test also checks the hover state. The pair is canonical and reusable, mirroring `muted`/`muted-foreground`, for any component that needs destructive content on a quiet surface.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,14 @@
 # heliostat Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-06-15
+Auto-generated from all feature plans. Last updated: 2026-06-16
 
 ## Active Technologies
 - TypeScript 5.x, strict, no `any` (Constitution VIII). React 19, Next.js 15 (App Router). + `next` ^15, `react`/`react-dom` 19, `@unbranded-ds/tokens` and `@unbranded-ds/react` at `workspace:*`, Tailwind CSS v4 (consumed through `@unbranded-ds/react/preset.css`), `next/font/local` (self-hosted font), `@playwright/test`, `@axe-core/playwright`. (015-nextjs-example-app)
 - `localStorage` only, through the design system's existing keys (`unbranded-ds-theme`, `unbranded-ds-density`, `unbranded-ds-theme-preference`). No new storage. (015-nextjs-example-app)
 - TypeScript 5.x, strict, no `any` (Constitution VIII). + Style Dictionary v4 (the token build, `sd.config.ts`), Zod (theme schema and validation), Tailwind CSS v4 (`@theme` preset, `@layer` cascade), `@base-ui-components/react` (SegmentedControl, reached through the toggles), React 19 (`useSyncExternalStore`), `@modelcontextprotocol/sdk` (the token-query MCP, re-pointed to three axes). (016-color-scheme-axis-split)
 - `localStorage`, new per-axis keys. Color scheme gets `unbranded-ds-color-scheme` (concrete, the bootstrap key) plus `unbranded-ds-color-scheme-preference` (the stated intent, including `system`); `unbranded-ds-theme` is repurposed to hold the identity; `unbranded-ds-density` is unchanged. No migration of stored values (no consumers). (016-color-scheme-axis-split)
+- TypeScript 5.x, strict, no `any` (Constitution VIII). + Style Dictionary v4 (token build + per-cell CSS emission), Zod (`schema.ts` token schema + `contrastPairs`), the `color.ts` WCAG contrast math, Tailwind CSS v4 (`@theme` preset auto-maps tokens to utilities), `class-variance-authority` + `cn()` (the Button `destructive` variant), React 19, Storybook 10.3 (Button stories + addon-a11y), `@playwright/test` + `@axe-core/playwright` (example e2e a11y). (018-button-destructive-contrast)
+- N/A. Tokens are build-time JSON compiled to CSS variables; no persisted runtime state. (018-button-destructive-contrast)
 
 - TypeScript 5.x in `tsx`-tagged code blocks only (validated via `tsc --noEmit` per spec 005's compile validator). Sidecar prose is plain CommonMark. + All shipped in spec 005. The template at `packages/react/src/components/_template/Component.usage.md`, the validator at `scripts/validate-sidecars.ts`, the `AGENTS.md` component index, and the CI step that wires the validator into the verify job. (006-sidecar-retrofit)
 - Filesystem only. 14 `<Component>.usage.md` files co-located with their `.tsx` source. One running inbox file: `specs/006-sidecar-retrofit/spec-007-inbox.md`. 15 `.changeset/*.md` files (14 component + 1 backfill). (006-sidecar-retrofit)
@@ -52,10 +54,10 @@ npm test && npm run lint
 TypeScript 5.x, strict mode, no `any` (EVER): Follow standard conventions
 
 ## Recent Changes
+- 018-button-destructive-contrast: Added TypeScript 5.x, strict, no `any` (Constitution VIII). + Style Dictionary v4 (token build + per-cell CSS emission), Zod (`schema.ts` token schema + `contrastPairs`), the `color.ts` WCAG contrast math, Tailwind CSS v4 (`@theme` preset auto-maps tokens to utilities), `class-variance-authority` + `cn()` (the Button `destructive` variant), React 19, Storybook 10.3 (Button stories + addon-a11y), `@playwright/test` + `@axe-core/playwright` (example e2e a11y).
 - 016-color-scheme-axis-split: Added TypeScript 5.x, strict, no `any` (Constitution VIII). + Style Dictionary v4 (the token build, `sd.config.ts`), Zod (theme schema and validation), Tailwind CSS v4 (`@theme` preset, `@layer` cascade), `@base-ui-components/react` (SegmentedControl, reached through the toggles), React 19 (`useSyncExternalStore`), `@modelcontextprotocol/sdk` (the token-query MCP, re-pointed to three axes).
 - 015-nextjs-example-app: Added TypeScript 5.x, strict, no `any` (Constitution VIII). React 19, Next.js 15 (App Router). + `next` ^15, `react`/`react-dom` 19, `@unbranded-ds/tokens` and `@unbranded-ds/react` at `workspace:*`, Tailwind CSS v4 (consumed through `@unbranded-ds/react/preset.css`), `next/font/local` (self-hosted font), `@playwright/test`, `@axe-core/playwright`.
 
-- 011-theme-toggle: Added TypeScript 5.x, strict mode, no `any` + React (peer; uses `useSyncExternalStore`), `@base-ui-components/react` (peer, reached via SegmentedControl), `lucide-react` ^1.8.0 (Sun/SunMoon/Moon icons, existing dep), `class-variance-authority` + `cn()` (existing), the `SegmentedControl` primitive (spec 004), `@unbranded-ds/tokens` runtime (storage-key constants, the `Axis` union, and a NEW "themes per axis" registry export). No `next-themes` runtime dependency (vocabulary alignment only).
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/THEMING.md
+++ b/THEMING.md
@@ -129,12 +129,14 @@ It resolves your theme against the defaults first, so a partial theme is checked
 
 These get checked automatically:
 
-| Foreground                     | Background          | Threshold |
-| ------------------------------ | ------------------- | --------- |
-| `color.foreground`             | `color.background`  | 4.5:1     |
-| `color.primary-foreground`     | `color.primary`     | 4.5:1     |
-| `color.muted-foreground`       | `color.muted`       | 4.5:1     |
-| `color.destructive-foreground` | `color.destructive` | 4.5:1     |
+| Foreground                            | Background                 | Threshold |
+| ------------------------------------- | -------------------------- | --------- |
+| `color.foreground`                    | `color.background`         | 4.5:1     |
+| `color.primary-foreground`            | `color.primary`            | 4.5:1     |
+| `color.muted-foreground`              | `color.muted`              | 4.5:1     |
+| `color.muted-foreground`              | `color.background`         | 4.5:1     |
+| `color.destructive-foreground`        | `color.destructive`        | 4.5:1     |
+| `color.destructive-subtle-foreground` | `color.destructive-subtle` | 4.5:1     |
 
 ## Applying at runtime
 

--- a/examples/nextjs-15-app-router/app/globals.css
+++ b/examples/nextjs-15-app-router/app/globals.css
@@ -7,10 +7,12 @@
 
 /*
  * Themes this app uses (spec 016: color scheme and identity are separate axes).
- * Additive — import only the cells you reach. `light` is the file-less base: it
- * shows through with no import, so the app pulls in the dark scheme, the brand
- * and vaporwave identities in both schemes, and the compact density.
+ * Additive — import only the cells you reach: both color schemes, the brand and
+ * vaporwave identities in both schemes, and the compact density. The light scheme
+ * is imported explicitly (spec 018 made its destructive Button AA-legible, so the
+ * default-light view is fully design-system-styled).
  */
+@import '@unbranded-ds/tokens/themes/light.css';
 @import '@unbranded-ds/tokens/themes/dark.css';
 @import '@unbranded-ds/tokens/themes/brand-light.css';
 @import '@unbranded-ds/tokens/themes/brand-dark.css';

--- a/packages/react/src/components/Button/Button.stories.tsx
+++ b/packages/react/src/components/Button/Button.stories.tsx
@@ -18,7 +18,13 @@ export const Default: Story = {
 
 export const Destructive: Story = {
 	args: { children: 'Delete', variant: 'destructive' },
-	parameters: { docs: { description: { story: 'Signals an irreversible action like deletion or account removal.' } } },
+	parameters: { docs: { description: { story: 'Signals an irreversible action like deletion or account removal. The subtle treatment is AA-legible in every theme (spec 018).' } } },
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const button = canvas.getByRole('button', { name: 'Delete' });
+		await userEvent.click(button);
+		await expect(button).toBeEnabled();
+	},
 };
 
 export const Outline: Story = {

--- a/packages/react/src/components/Button/Button.test.tsx
+++ b/packages/react/src/components/Button/Button.test.tsx
@@ -10,10 +10,15 @@ describe('button', () => {
 		expect(btn.className).toContain('h-9');
 	});
 
-	it('applies destructive variant classes', () => {
-		const { container } = render(<Button variant="destructive">Delete</Button>);
-		const btn = container.firstElementChild!;
-		expect(btn.className).toContain('destructive');
+	it('applies the destructive variant as the token-backed subtle treatment', () => {
+		// spec 018: a subtle destructive surface + a darker destructive text token,
+		// not the old translucent tint, and no per-mode color override (the per-cell
+		// tokens carry light/dark).
+		const classes = buttonVariants({ variant: 'destructive' });
+		expect(classes).toContain('bg-destructive-subtle');
+		expect(classes).toContain('text-destructive-subtle-foreground');
+		expect(classes).not.toContain('bg-destructive/10');
+		expect(classes).not.toContain('dark:bg-destructive');
 	});
 
 	it('applies size=lg classes', () => {

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva(
 				ghost:
           'hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50',
 				destructive:
-          'bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40',
+          'bg-destructive-subtle text-destructive-subtle-foreground hover:bg-[color-mix(in_oklab,var(--color-destructive-subtle),var(--color-destructive)_12%)] focus-visible:border-destructive/40 focus-visible:ring-destructive/20',
 				link: 'text-primary underline-offset-4 hover:underline',
 			},
 			size: {

--- a/packages/tokens/src/__fixtures__/valid-custom.json
+++ b/packages/tokens/src/__fixtures__/valid-custom.json
@@ -12,7 +12,9 @@
 			"border": "#dee2e6",
 			"ring": "#0d6efd",
 			"destructive": "#dc3545",
-			"destructive-foreground": "#ffffff"
+			"destructive-foreground": "#ffffff",
+			"destructive-subtle": "#f8d7da",
+			"destructive-subtle-foreground": "#842029"
 		},
 		"spacing": {
 			"px": "1px",

--- a/packages/tokens/src/color.ts
+++ b/packages/tokens/src/color.ts
@@ -170,6 +170,27 @@ export function contrastRatio(a: LinearRGB, b: LinearRGB): number {
 }
 
 /**
+ * Mix two oklch color strings in OKLab space — matching the CSS
+ * `color-mix(in oklab, a, b <t>%)` the Button's destructive hover uses — and
+ * return linear RGB for contrast math. `t` is the weight of `b` (0..1). Returns
+ * null if either string is unparseable. (spec 018: verifying the hover surface.)
+ */
+export function mixOklchToLinear(a: string, b: string, t: number): LinearRGB | null {
+	const ao = parseOklch(a);
+	const bo = parseOklch(b);
+	if (!ao || !bo)
+		return null;
+	const al = oklchToOklab(ao);
+	const bl = oklchToOklab(bo);
+	const mixed: OklabColor = [
+		al[0] + (bl[0] - al[0]) * t,
+		al[1] + (bl[1] - al[1]) * t,
+		al[2] + (bl[2] - al[2]) * t,
+	];
+	return oklabToLinearRgb(mixed);
+}
+
+/**
  * Convert a hex color string to oklch() CSS function.
  * Returns the original string if it's already oklch or unparseable.
  */

--- a/packages/tokens/src/defaults.generated.ts
+++ b/packages/tokens/src/defaults.generated.ts
@@ -12,7 +12,9 @@ export const canonicalDefaultTokens = {
 		"border": "oklch(0.9197 0.0040 286.32)",
 		"ring": "oklch(0.2103 0.0059 285.89)",
 		"destructive": "oklch(0.5803 0.2078 25.33)",
-		"destructive-foreground": "oklch(0.9851 0.0000 89.88)"
+		"destructive-foreground": "oklch(0.9851 0.0000 89.88)",
+		"destructive-subtle": "oklch(0.9300 0.0500 25.33)",
+		"destructive-subtle-foreground": "oklch(0.4400 0.1600 25.33)"
 	},
 	"motion": {
 		"duration-fast": "120ms",

--- a/packages/tokens/src/schema.test.ts
+++ b/packages/tokens/src/schema.test.ts
@@ -73,8 +73,17 @@ describe('themeSchema', () => {
 });
 
 describe('contrastPairs', () => {
-	it('declares 5 foreground/background pairs', () => {
-		expect(contrastPairs).toHaveLength(5);
+	it('declares 6 foreground/background pairs', () => {
+		// 6 since spec 018 added destructive-subtle-foreground/destructive-subtle.
+		expect(contrastPairs).toHaveLength(6);
+	});
+
+	it('includes the destructive-subtle pair (spec 018)', () => {
+		expect(contrastPairs).toContainEqual({
+			foreground: 'color.destructive-subtle-foreground',
+			background: 'color.destructive-subtle',
+			threshold: 4.5,
+		});
 	});
 
 	it('all pairs have 4.5:1 threshold', () => {

--- a/packages/tokens/src/schema.ts
+++ b/packages/tokens/src/schema.ts
@@ -19,6 +19,12 @@ const colorTokens = z.object({
 	'ring': z.string(),
 	'destructive': z.string(),
 	'destructive-foreground': z.string(),
+	// The soft destructive treatment (spec 018): an opaque subtle destructive
+	// surface and a darker destructive text/icon color that clears AA on it. The
+	// Button's `destructive` variant paints these; any component needing
+	// destructive content on a quiet surface reuses them, like muted/muted-foreground.
+	'destructive-subtle': z.string(),
+	'destructive-subtle-foreground': z.string(),
 });
 
 const spacingTokens = z.object({
@@ -212,6 +218,14 @@ export const contrastPairs: ContrastPair[] = [
 	{
 		foreground: 'color.muted-foreground',
 		background: 'color.background',
+		threshold: 4.5,
+	},
+	// The destructive Button's soft treatment (spec 018): its text on the subtle
+	// destructive surface. The old check guarded the solid destructive-foreground/
+	// destructive pair the button never used; this guards what it actually renders.
+	{
+		foreground: 'color.destructive-subtle-foreground',
+		background: 'color.destructive-subtle',
 		threshold: 4.5,
 	},
 ];

--- a/packages/tokens/src/themes-contrast.test.ts
+++ b/packages/tokens/src/themes-contrast.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { contrastRatio, mixOklchToLinear, parseColor } from './color.js';
+import { composeTokens } from './resolve.js';
 import { validateComposedTheme } from './validate.js';
 
 // Validates every shipped identity-by-scheme cell of the matrix (spec 016) through
@@ -37,6 +39,30 @@ describe('matrix cells are complete and WCAG AA (spec 016 FR-004/FR-005)', () =>
 		it(`${name} composes complete and passes AA on every contrast pair`, () => {
 			const result = validateComposedTheme(layers, name, name);
 			expect(result.ok, result.ok ? '' : JSON.stringify(result.issues, null, 2)).toBe(true);
+		});
+	}
+});
+
+// spec 018: the destructive Button paints `destructive-subtle-foreground` on
+// `destructive-subtle`, and on hover deepens the surface via
+// `color-mix(in oklab, destructive-subtle, destructive 12%)`. The resting pair is
+// already guarded by `contrastPairs` above (the matrix checks it across all cells);
+// the validator's token-vs-token pairs cannot express the hover composite, so check
+// both explicitly here.
+const HOVER_DESTRUCTIVE_WEIGHT = 0.12; // matches the Button variant's color-mix
+
+describe('destructive-subtle pair is AA at rest and on hover in every cell (spec 018 FR-003/FR-005)', () => {
+	for (const { name, layers } of CELLS) {
+		it(`${name}: destructive text clears 4.5:1 at rest and on the hover surface`, () => {
+			const color = composeTokens(layers).color as Record<string, string>;
+			const fg = parseColor(color['destructive-subtle-foreground']!);
+			const rest = parseColor(color['destructive-subtle']!);
+			const hover = mixOklchToLinear(color['destructive-subtle']!, color.destructive!, HOVER_DESTRUCTIVE_WEIGHT);
+			expect(fg, 'foreground parses').not.toBeNull();
+			expect(rest, 'rest surface parses').not.toBeNull();
+			expect(hover, 'hover composite computes').not.toBeNull();
+			expect(contrastRatio(fg!, rest!), `${name} rest`).toBeGreaterThanOrEqual(4.5);
+			expect(contrastRatio(fg!, hover!), `${name} hover`).toBeGreaterThanOrEqual(4.5);
 		});
 	}
 });

--- a/packages/tokens/src/token-map.ts
+++ b/packages/tokens/src/token-map.ts
@@ -57,6 +57,8 @@ const schemaTokenMap: Record<string, TokenDefinition> = {
 	'color.ring': { name: 'color.ring', category: 'color', type: 'color', cssVariable: '--color-ring', source: 'schema' },
 	'color.destructive': { name: 'color.destructive', category: 'color', type: 'color', cssVariable: '--color-destructive', source: 'schema' },
 	'color.destructive-foreground': { name: 'color.destructive-foreground', category: 'color', type: 'color', cssVariable: '--color-destructive-foreground', source: 'schema' },
+	'color.destructive-subtle': { name: 'color.destructive-subtle', category: 'color', type: 'color', cssVariable: '--color-destructive-subtle', source: 'schema' },
+	'color.destructive-subtle-foreground': { name: 'color.destructive-subtle-foreground', category: 'color', type: 'color', cssVariable: '--color-destructive-subtle-foreground', source: 'schema' },
 
 	// Spacing tokens
 	'spacing.px': { name: 'spacing.px', category: 'spacing', type: 'dimension', cssVariable: '--spacing-px', source: 'schema' },

--- a/packages/tokens/src/tokens/color.json
+++ b/packages/tokens/src/tokens/color.json
@@ -39,6 +39,14 @@
 		"destructive-foreground": {
 			"$value": "oklch(0.9851 0.0000 89.88)",
 			"$type": "color"
+		},
+		"destructive-subtle": {
+			"$value": "oklch(0.9300 0.0500 25.33)",
+			"$type": "color"
+		},
+		"destructive-subtle-foreground": {
+			"$value": "oklch(0.4400 0.1600 25.33)",
+			"$type": "color"
 		}
 	}
 }

--- a/packages/tokens/src/validate.test.ts
+++ b/packages/tokens/src/validate.test.ts
@@ -126,6 +126,32 @@ describe('validateTheme', () => {
 		}
 	});
 
+	it('rejects a sub-AA destructive-subtle pair and names it (spec 018)', () => {
+		// A pale foreground on the pale subtle surface, far under 4.5:1. Proves the
+		// build catches a destructive-subtle regression and names the exact pair, so
+		// the soft destructive treatment cannot silently drift below AA.
+		const result = validateTheme({
+			name: 'bad-destructive-subtle',
+			displayName: 'Bad Destructive Subtle',
+			tokens: {
+				color: {
+					'destructive-subtle': 'oklch(0.9300 0.0500 25.00)',
+					'destructive-subtle-foreground': 'oklch(0.8500 0.0600 25.00)',
+				},
+			},
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(
+				result.issues.some(
+					(i) =>
+						i.code === 'CONTRAST_FAILURE'
+						&& i.path.includes('color.destructive-subtle-foreground / color.destructive-subtle'),
+				),
+			).toBe(true);
+		}
+	});
+
 	it('accepts theme with extra tokens (forward-compatible)', () => {
 		const result = validateTheme(extraTokens);
 		expect(result.ok).toBe(true);

--- a/packages/tokens/themes/color-scheme/dark.json
+++ b/packages/tokens/themes/color-scheme/dark.json
@@ -39,6 +39,14 @@
 		"destructive-foreground": {
 			"$value": "oklch(0.9851 0.0000 89.88)",
 			"$type": "color"
+		},
+		"destructive-subtle": {
+			"$value": "oklch(0.2700 0.0800 27.33)",
+			"$type": "color"
+		},
+		"destructive-subtle-foreground": {
+			"$value": "oklch(0.8600 0.0900 27.33)",
+			"$type": "color"
 		}
 	}
 }

--- a/packages/tokens/themes/theme/brand/dark.json
+++ b/packages/tokens/themes/theme/brand/dark.json
@@ -9,7 +9,9 @@
 		"border": { "$value": "oklch(0.3000 0.0350 293.00)", "$type": "color" },
 		"ring": { "$value": "oklch(0.5413 0.2466 293.01)", "$type": "color" },
 		"destructive": { "$value": "oklch(0.5858 0.2220 17.58)", "$type": "color" },
-		"destructive-foreground": { "$value": "oklch(1.0000 0.0000 89.88)", "$type": "color" }
+		"destructive-foreground": { "$value": "oklch(1.0000 0.0000 89.88)", "$type": "color" },
+		"destructive-subtle": { "$value": "oklch(0.2700 0.0800 17.58)", "$type": "color" },
+		"destructive-subtle-foreground": { "$value": "oklch(0.8600 0.0900 17.58)", "$type": "color" }
 	},
 	"radius": {
 		"sm": { "$value": "0.375rem", "$type": "dimension" },

--- a/packages/tokens/themes/theme/brand/light.json
+++ b/packages/tokens/themes/theme/brand/light.json
@@ -39,6 +39,14 @@
 		"destructive-foreground": {
 			"$value": "oklch(1.0000 0.0000 89.88)",
 			"$type": "color"
+		},
+		"destructive-subtle": {
+			"$value": "oklch(0.9300 0.0500 17.58)",
+			"$type": "color"
+		},
+		"destructive-subtle-foreground": {
+			"$value": "oklch(0.4400 0.1600 17.58)",
+			"$type": "color"
 		}
 	},
 	"radius": {

--- a/packages/tokens/themes/theme/vaporwave/dark.json
+++ b/packages/tokens/themes/theme/vaporwave/dark.json
@@ -9,7 +9,9 @@
 		"border": { "$value": "oklch(0.3200 0.0600 300.00)", "$type": "color" },
 		"ring": { "$value": "oklch(0.7200 0.2000 330.00)", "$type": "color" },
 		"destructive": { "$value": "oklch(0.5771 0.2152 20.00)", "$type": "color" },
-		"destructive-foreground": { "$value": "oklch(0.9851 0.0000 89.88)", "$type": "color" }
+		"destructive-foreground": { "$value": "oklch(0.9851 0.0000 89.88)", "$type": "color" },
+		"destructive-subtle": { "$value": "oklch(0.2700 0.0800 20.00)", "$type": "color" },
+		"destructive-subtle-foreground": { "$value": "oklch(0.8600 0.0900 20.00)", "$type": "color" }
 	},
 	"shadow": {
 		"neon": { "$value": "0 0 12px 2px oklch(0.7200 0.2000 330.00 / 0.6)", "$type": "shadow" }

--- a/packages/tokens/themes/theme/vaporwave/light.json
+++ b/packages/tokens/themes/theme/vaporwave/light.json
@@ -9,7 +9,9 @@
 		"border": { "$value": "oklch(0.8800 0.0400 330.00)", "$type": "color" },
 		"ring": { "$value": "oklch(0.6500 0.2200 330.00)", "$type": "color" },
 		"destructive": { "$value": "oklch(0.5800 0.2200 20.00)", "$type": "color" },
-		"destructive-foreground": { "$value": "oklch(1.0000 0.0000 89.88)", "$type": "color" }
+		"destructive-foreground": { "$value": "oklch(1.0000 0.0000 89.88)", "$type": "color" },
+		"destructive-subtle": { "$value": "oklch(0.9300 0.0500 20.00)", "$type": "color" },
+		"destructive-subtle-foreground": { "$value": "oklch(0.4400 0.1600 20.00)", "$type": "color" }
 	},
 	"shadow": {
 		"neon": { "$value": "0 0 12px 2px oklch(0.6500 0.2200 330.00 / 0.6)", "$type": "shadow" }

--- a/specs/018-button-destructive-contrast/checklists/requirements.md
+++ b/specs/018-button-destructive-contrast/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Accessible destructive Button across every theme
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The brief's open questions were settled in `/speckit.clarify` (Session 2026-06-16): a soft tint backed by a dedicated, canonical, reusable destructive-subtle token pair (FR-002/FR-004); AA across all six shipped cells (FR-007); surface-independent across the page background and card/muted surfaces (FR-005). The remaining open detail — whether the subtle surface is an opaque token or a validated translucent tint, and how hover/focus derive — is bounded by FR-005 and left to planning.

--- a/specs/018-button-destructive-contrast/contracts/public-api.md
+++ b/specs/018-button-destructive-contrast/contracts/public-api.md
@@ -1,0 +1,43 @@
+# Contract: public API additions
+
+What this feature adds to the design system's public surface, and what stays stable.
+
+## `@unbranded-ds/tokens`
+
+Two canonical color tokens are added. They appear in every artifact the build emits, with no new wiring:
+
+- **CSS variables** (per-cell, under each axis selector): `--color-destructive-subtle`, `--color-destructive-subtle-foreground`.
+- **Tailwind utilities** (from the `@theme` preset, which maps every token): `bg-destructive-subtle`, `text-destructive-subtle-foreground`, plus the usual `border-*` / `ring-*` forms.
+- **Token map** (`tokenMap`, the TS map and the token-query MCP): two entries keyed `color.destructive-subtle` and `color.destructive-subtle-foreground`, `category: 'color'`, `source: 'schema'`.
+- **Zod schema** (`themeSchema` / `partialThemeSchema`): two required keys in the `color` category.
+- **Contrast pairs** (`contrastPairs`): one new declared pair, `destructive-subtle-foreground` on `destructive-subtle`, threshold 4.5.
+
+Stable (unchanged): `destructive` and `destructive-foreground` keep their values and their existing contrast pair, so any solid destructive usage is unaffected. No token is renamed or removed.
+
+Compatibility: a consumer runtime theme that does not declare the new pair inherits the canonical default through the resolve-then-validate merge and continues to validate. A theme authored as a complete document must include the pair (as it already must include every other color token).
+
+## `@unbranded-ds/react` — Button `destructive` variant
+
+The `destructive` variant's public API is unchanged: `<Button variant="destructive">` takes the same props and renders the same element and semantics. What changes is its resolved styling:
+
+- Background and text resolve to `bg-destructive-subtle` / `text-destructive-subtle-foreground` (token-backed utilities, no hardcoded color).
+- The pair meets WCAG AA (≥4.5:1) in every shipped identity×color-scheme cell, at rest and on hover, on the page background and on card/muted surfaces.
+- The hover state deepens the surface and the focus state keeps the destructive ring; both remain AA.
+- The dark-mode-only class branches are removed; the per-cell tokens carry the light/dark difference.
+
+A consumer who only reads the public prop surface sees no change; the fix is entirely in the resolved token values and utility classes.
+
+## Validation contract
+
+`validateTheme` / `validateResolved` / `validateComposedTheme` now also check the destructive-subtle pair. A theme whose merged result drops that pair below 4.5:1 fails with the existing structured shape:
+
+```jsonc
+{ "ok": false, "issues": [
+  { "code": "CONTRAST_FAILURE",
+    "path": "color.destructive-subtle-foreground / color.destructive-subtle",
+    "ratio": <measured>, "threshold": 4.5,
+    "message": "Contrast ratio <measured>:1 is below the required 4.5:1 threshold" }
+]}
+```
+
+No new error code; the existing `CONTRAST_FAILURE` carries the new pair's path. This keeps the failure mode legible to agents pattern-matching on codes (Constitution XI.4).

--- a/specs/018-button-destructive-contrast/data-model.md
+++ b/specs/018-button-destructive-contrast/data-model.md
@@ -1,0 +1,48 @@
+# Phase 1 Data Model: Accessible destructive Button across every theme
+
+The "data" here is two new canonical color tokens, their values across the six cells, and the contrast pair that guards them.
+
+## New canonical tokens
+
+| Token | Role | Type | Required | CSS variable | Tailwind utility |
+|-------|------|------|----------|--------------|------------------|
+| `color.destructive-subtle` | The opaque subtle destructive surface the button paints | color | yes | `--color-destructive-subtle` | `bg-destructive-subtle` |
+| `color.destructive-subtle-foreground` | The destructive text/icon color on that surface | color | yes | `--color-destructive-subtle-foreground` | `text-destructive-subtle-foreground` |
+
+Both are added to `colorTokens` in `packages/tokens/src/schema.ts` (alongside `destructive` / `destructive-foreground`), so the strict `themeSchema` requires them in any merged theme. Because validation runs on the merged result (`resolveTheme` folds a partial onto `canonicalDefaultTokens` first), a partial consumer theme that omits them inherits the canonical default and still validates. The token map tags them `source: 'schema'` automatically (they are canonical, not theme-extension), so the token-query MCP lists them like any other token.
+
+## Per-cell value matrix
+
+Each cell authors both tokens as opaque colors that clear the contrast pair with headroom. The surface is a low-chroma destructive color (high lightness in light cells, low lightness in dark cells); the foreground is a destructive-hued text dark or light enough to clear ≥5:1 at rest (so the hover darken stays ≥4.5:1).
+
+| Cell | File | Surface intent | Foreground intent |
+|------|------|----------------|-------------------|
+| default-light | `src/tokens/color.json` (canonical base) | pale destructive | dark destructive text |
+| default-dark | `themes/color-scheme/dark.json` | deep destructive | light destructive text |
+| brand-light | `themes/theme/brand/light.json` | pale destructive | dark destructive text |
+| brand-dark | `themes/theme/brand/dark.json` | deep destructive | light destructive text |
+| vaporwave-light | `themes/theme/vaporwave/light.json` | pale destructive (vaporwave hue) | dark destructive text |
+| vaporwave-dark | `themes/theme/vaporwave/dark.json` | deep destructive (vaporwave hue) | light destructive text |
+
+Exact oklch values are authored and verified during implementation with the package's own `contrastRatio` (the tsx check that proved the spec-016 palettes), not eyeballed. The build regenerates `src/tokens/defaults.generated.ts` from the canonical base.
+
+## Contrast pair
+
+Added to `contrastPairs` in `packages/tokens/src/schema.ts`:
+
+```ts
+{ foreground: 'color.destructive-subtle-foreground', background: 'color.destructive-subtle', threshold: 4.5 }
+```
+
+This is the sixth declared pair (after `foreground`/`background`, `primary-foreground`/`primary`, `muted-foreground`/`muted`, `destructive-foreground`/`destructive`, and `muted-foreground`/`background`). Every surface that iterates `contrastPairs` inherits the guard: `validateResolved`, the runtime post-oklch-conversion check in `runtime.ts`, the per-cell matrix test (`themes-contrast.test.ts`), and the token-query MCP contrast tool.
+
+## Validation rules
+
+- Each of the six cells MUST resolve the pair at ≥4.5:1 (FR-001, FR-007); the matrix test fails the build otherwise.
+- The pair MUST hold against the button's hover state too (FR-003); authored with rest-state headroom and asserted in the Button/contrast tests.
+- The hover/focus realization MUST stay surface-independent (the opaque base composites predictably) (FR-005).
+- The existing `destructive` / `destructive-foreground` pair is unchanged and still validated (FR-010).
+
+## State / lifecycle
+
+None. These are static design tokens compiled to CSS variables at build time; there is no runtime state machine.

--- a/specs/018-button-destructive-contrast/plan.md
+++ b/specs/018-button-destructive-contrast/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Accessible destructive Button across every theme
+
+**Branch**: `018-button-destructive-contrast` | **Date**: 2026-06-16 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/018-button-destructive-contrast/spec.md`
+
+## Summary
+
+The destructive Button renders the destructive color as text on a pale destructive tint, which is ~4.1:1 in the light cells — below WCAG AA. The fix introduces a canonical, reusable token pair — `destructive-subtle` (an opaque subtle destructive surface) and `destructive-subtle-foreground` (a darker destructive text color) — authored per cell across all six identity×scheme combinations so the pair clears 4.5:1, and points the Button's `destructive` variant at it. A new contrast pair in the schema guards the relationship for every cell, closing the gap where only the unused solid `destructive-foreground`/`destructive` pairing was checked. Once green, the example app re-enables its light scheme.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, strict, no `any` (Constitution VIII).
+**Primary Dependencies**: Style Dictionary v4 (token build + per-cell CSS emission), Zod (`schema.ts` token schema + `contrastPairs`), the `color.ts` WCAG contrast math, Tailwind CSS v4 (`@theme` preset auto-maps tokens to utilities), `class-variance-authority` + `cn()` (the Button `destructive` variant), React 19, Storybook 10.3 (Button stories + addon-a11y), `@playwright/test` + `@axe-core/playwright` (example e2e a11y).
+**Storage**: N/A. Tokens are build-time JSON compiled to CSS variables; no persisted runtime state.
+**Testing**: Vitest units (`themes-contrast.test.ts` over `contrastPairs`, `schema.test.ts`, Button CVA), Storybook interaction + a11y, example Playwright axe pass.
+**Target Platform**: The published `@unbranded-ds/tokens` and `@unbranded-ds/react` packages and any consuming web app; the in-repo example and Storybook.
+**Project Type**: Design-system monorepo (tokens + react + storybook + example), three packages per Constitution I.
+**Performance Goals**: N/A (build-time tokens; no runtime hot path changed).
+**Constraints**: Every shipped identity×scheme cell (six) MUST pass the new pair at ≥4.5:1, and on the standard surfaces the button sits on (page background and card/muted). The dark cells, which already pass, must not regress. No `any`; no hardcoded colors in `packages/react/src/components/**` (lint rule).
+**Scale/Scope**: Two new canonical color tokens × six cells (plus the canonical default), one new contrast pair, one Button variant, one example CSS import, one changeset. No NEEDS CLARIFICATION remain (resolved in the spec's Clarifications).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Section II (tokens independent of components)**: PASS. The pair lives in `@unbranded-ds/tokens`, emits as CSS variables, and the Button consumes it through Tailwind utilities — no runtime import of the tokens package into the component.
+- **Section III (theming contract — schema locked, values float)**: PASS, with a note. Adding `destructive-subtle` and `destructive-subtle-foreground` grows the canonical token set. Section III locks the set at build time but the set has always grown by spec (precedent: spec 008 added `font-serif`, `ring`, `z-index`). This is a deliberate canonical-schema addition, not a redefinition of the theming model, so it needs **no constitution amendment** (unlike spec 016, which changed the axis model normatively). Both tokens are provided by every bundled cell and defaulted in the canonical baseline, so a partial consumer theme that omits them still resolves.
+- **Section IV (components thin, token-styled, no hardcoded colors)**: PASS. The `destructive` variant swaps `bg-destructive/10 text-destructive` for `bg-destructive-subtle text-destructive-subtle-foreground` — still token-backed utilities, no hex/rgb/hsl literals.
+- **Section VI (three test layers)**: PASS. The token pair joins the per-cell AA matrix unit test; the Button keeps its unit/interaction/a11y coverage and its destructive story now passes axe in light.
+- **Section IX (definition of done for Button)**: PASS. Stories, a `play` function, zero serious/critical axe violations, exports, and autodocs all stay satisfied.
+- **Section XI (agent + human legibility)**: PASS, no concessions. The new tokens are canonical (so the token map tags them `source: 'schema'`, queryable via the token-query MCP like any other), the validator failure stays the structured `CONTRAST_FAILURE` shape, and the prose (changeset, token docs) runs through the `humanizer` skill before merge. Three-item lists avoided.
+
+No gate violations. Complexity Tracking is empty.
+
+**Post-design re-check (after Phase 1)**: Unchanged. The data model (two canonical tokens + one contrast pair), the contract (additive token API, stable `destructive`/`destructive-foreground`, no new error code), and the quickstart introduce nothing that flips a gate. The canonical-schema growth remains the only governed item and stays within Section III's by-spec growth. Still PASS, no amendment.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/018-button-destructive-contrast/
+├── spec.md              # /speckit.specify + /speckit.clarify output
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (the token pair + the contrast pair)
+├── quickstart.md        # Phase 1 output (how to verify the fix)
+├── contracts/           # Phase 1 output (the token + Button-variant contract)
+└── tasks.md             # /speckit.tasks output (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+packages/tokens/
+├── src/
+│   ├── schema.ts                 # add destructive-subtle + -foreground to colorTokens; add the contrast pair to contrastPairs
+│   ├── tokens/color.json         # the canonical default (default-light) values for the pair
+│   ├── defaults.generated.ts     # regenerated by the build (committed)
+│   └── themes-contrast.test.ts   # already iterates contrastPairs → covers the new pair across all six cells; add an explicit assertion
+└── themes/
+    ├── color-scheme/dark.json    # default-dark values for the pair
+    └── theme/
+        ├── brand/{light,dark}.json       # brand cells
+        └── vaporwave/{light,dark}.json   # vaporwave cells
+
+packages/react/
+└── src/components/Button/
+    ├── Button.tsx                # destructive variant → bg-destructive-subtle / text-destructive-subtle-foreground; drop the dark: overrides (per-cell tokens make them redundant)
+    ├── Button.test.tsx           # assert the destructive variant's resolved classes
+    └── Button.stories.tsx        # Destructive story now passes axe in light (no story change required, but verify)
+
+examples/nextjs-15-app-router/
+└── app/globals.css               # re-add the light.css import (the spec-016 workaround removed it)
+
+.changeset/                        # new changeset: @unbranded-ds/tokens minor + @unbranded-ds/react minor
+```
+
+**Structure Decision**: This is the established design-system monorepo (Constitution I). The change is contained to the tokens package (the pair, its six authored values, the validator guard), the Button component in the react package (the one variant), the example app (re-enabling light), and a changeset. No new package, no new structure.
+
+## Complexity Tracking
+
+No constitution violations. The canonical-schema growth (Section III) is an allowed, precedented addition, not a violation, so it carries no justification debt.

--- a/specs/018-button-destructive-contrast/quickstart.md
+++ b/specs/018-button-destructive-contrast/quickstart.md
@@ -1,0 +1,75 @@
+# Quickstart: verifying the accessible destructive Button
+
+The order mirrors how spec 016 was verified — author and prove the palettes first, then let the build and tests confirm the chain.
+
+## 1. Author and prove the token values
+
+For each of the six cells, set `color.destructive-subtle` and `color.destructive-subtle-foreground`, then check the pair with the package's own contrast math before wiring anything:
+
+```bash
+# a throwaway tsx check importing ./src/color.ts (as used for the 016 palettes):
+# parseColor + contrastRatio over the two values per cell — target >= 5:1 at rest.
+pnpm --filter @unbranded-ds/tokens exec tsx <your-check>.mts
+```
+
+Every cell should report ≥5:1 (headroom so the hover darken stays ≥4.5:1).
+
+## 2. Build the tokens
+
+```bash
+pnpm --filter @unbranded-ds/tokens build
+```
+
+Emits `--color-destructive-subtle` and `--color-destructive-subtle-foreground` into each per-cell CSS file, the Tailwind preset utilities, the token map (`source: 'schema'`), and regenerates `src/defaults.generated.ts`.
+
+## 3. Validate the matrix
+
+```bash
+pnpm --filter @unbranded-ds/tokens exec vitest run
+```
+
+- `themes-contrast.test.ts` now exercises the new pair across all six cells (it iterates `contrastPairs`); all pass.
+- `schema.test.ts` reflects the new pair count and the two new color keys.
+- `defaults.test.ts` regenerate-and-diff stays green.
+
+## 4. Verify the Button
+
+```bash
+pnpm --filter @unbranded-ds/react exec vitest run
+pnpm --filter @unbranded-ds/react build
+```
+
+The `destructive` variant resolves `bg-destructive-subtle` / `text-destructive-subtle-foreground`; its unit test asserts the classes, and the Destructive story carries a `play` and passes axe.
+
+## 5. Re-enable light in the example and scan it
+
+Re-add the light import to `examples/nextjs-15-app-router/app/globals.css`:
+
+```css
+@import '@unbranded-ds/tokens/themes/light.css';
+```
+
+Then:
+
+```bash
+pnpm --filter @unbranded-ds/example-nextjs exec tsc --noEmit
+pnpm --filter @unbranded-ds/example-nextjs e2e
+```
+
+The Playwright axe pass on `/` and `/showcase` is clean — the destructive button in the gallery now meets AA in default-light, the regression spec 016 sidestepped.
+
+## 6. Changeset and full local CI
+
+```bash
+# add .changeset/*.md: @unbranded-ds/tokens minor + @unbranded-ds/react minor
+pnpm typecheck && pnpm build && pnpm test:unit
+pnpm exec tsx scripts/validate-sidecars.ts
+pnpm --filter @unbranded-ds/storybook build
+```
+
+## Done when
+
+- All six cells pass the destructive-subtle pair at ≥4.5:1 (the matrix test is green).
+- A deliberately failing destructive value makes the build fail with a `CONTRAST_FAILURE` naming the pair (proves the guard).
+- The example's `/` axe pass is clean with light loaded.
+- The destructive button still reads as destructive in every cell (design review).

--- a/specs/018-button-destructive-contrast/research.md
+++ b/specs/018-button-destructive-contrast/research.md
@@ -1,0 +1,67 @@
+# Phase 0 Research: Accessible destructive Button across every theme
+
+The spec's Clarifications settled the shape (soft tint, dedicated canonical tokens, all six cells, surface-independent). This records the realization decisions that follow.
+
+## 1. The token pair: names and shape
+
+**Decision**: Add two canonical color tokens, `destructive-subtle` (the surface the button paints) and `destructive-subtle-foreground` (its text/icon color). They mirror the existing `muted` / `muted-foreground` pair in naming and role.
+
+**Rationale**: The codebase's color tokens already follow `<role>` / `<role>-foreground` (`primary`/`primary-foreground`, `muted`/`muted-foreground`, `destructive`/`destructive-foreground`). A subtle destructive surface with its own legible foreground is the same shape, so the names are predictable for a consumer or agent (Constitution XI.2). The existing `destructive` / `destructive-foreground` pair stays unchanged for solid destructive usage.
+
+**Alternatives considered**: Reuse `destructive` as the text on a new `destructive-subtle` surface — rejected, because `destructive` on the subtle tint is exactly the 4.1:1 failure; the text must be a distinct, darker value. A single combined token — rejected, contrast needs both sides named.
+
+## 2. Opaque surface, not a translucent tint
+
+**Decision**: `destructive-subtle` is an opaque color per cell, not an alpha composite like the current `bg-destructive/10`.
+
+**Rationale**: The spec requires surface independence (AA on the page background and on card/muted surfaces). A translucent tint composites differently over each surface, so its contrast drifts with whatever sits behind it. An opaque token paints the same color regardless of surface, so the validated pair holds everywhere the button appears.
+
+**Alternatives considered**: Keep a translucent tint and validate it against every standard surface — rejected as fragile (each new surface is a new contrast case, and a consumer's custom surface is unbounded).
+
+## 3. Hover and focus states
+
+**Decision**: Hover darkens the subtle surface by compositing a small amount of `destructive` over the opaque `destructive-subtle` (`color-mix` in oklab), keeping it surface-independent and token-driven without a third canonical token. Focus keeps the existing `destructive`-based ring and border. The foreground is authored with headroom (target ≥5:1 at rest) so the hover darken stays ≥4.5:1.
+
+**Rationale**: Preserves the current hover affordance (the surface deepens on hover) while honoring the two-token decision from clarify. Hover is the worst case for a dark-on-light foreground (a darker surface lowers contrast), so authoring rest-state headroom is what guarantees FR-003.
+
+**Alternatives considered**: A third `destructive-subtle-hover` canonical token — rejected (clarify chose a pair; a derived darken is enough and the contrast test guards it). A Tailwind `brightness` filter — rejected (not token-driven, and it shifts unpredictably per cell).
+
+## 4. Growing the canonical schema, safely
+
+**Decision**: Add both keys to `colorTokens` in `schema.ts` as required, and add their values to the canonical baseline (`src/tokens/color.json`) plus every cell. The resolve-then-validate flow (`resolveTheme` merges a partial onto `canonicalDefaultTokens` before the strict check) means a consumer theme that omits the pair inherits the default and still validates.
+
+**Rationale**: Required keys keep the pair first-class and guaranteed present in any merged theme, matching every other color token. Because completeness is checked on the merged result, not the raw partial, requiring them is not a breaking burden on partial consumer themes (Constitution III's documented resolve flow).
+
+**Alternatives considered**: Make them optional — rejected, it would let a bundled cell silently omit the pair and fall back to a default that may not suit that cell's palette.
+
+## 5. The validator guard and the per-cell matrix
+
+**Decision**: Add `{ foreground: 'color.destructive-subtle-foreground', background: 'color.destructive-subtle', threshold: 4.5 }` to `contrastPairs` in `schema.ts`. The existing `themes-contrast.test.ts` iterates `contrastPairs` across all six cells, so the new pair is validated everywhere automatically; add one explicit assertion naming it so the intent is legible.
+
+**Rationale**: This is the exact pattern spec 016 used for `muted-foreground`/`background`. It flows into `validateResolved`, the runtime post-conversion check, and the token-query MCP contrast tool, all of which iterate `contrastPairs` — so the guard is consistent across every surface that checks contrast.
+
+**Alternatives considered**: A bespoke one-off test for the destructive button only — rejected, it would not guard runtime-registered themes or the MCP.
+
+## 6. The Button variant
+
+**Decision**: Change the `destructive` CVA entry to `bg-destructive-subtle text-destructive-subtle-foreground`, with hover via the `color-mix` darken and the existing focus ring, and drop the `dark:` overrides.
+
+**Rationale**: The `dark:` overrides (`dark:bg-destructive/20`, etc.) existed to boost the translucent tint in dark mode. With per-cell opaque tokens, the single `bg-destructive-subtle` utility already resolves to the right value in each cell (the dark cells author a dark-appropriate subtle surface), so the dark-only branches become redundant and are removed.
+
+**Alternatives considered**: Keep the `dark:` branches pointing at the new tokens — rejected as dead weight once the tokens are cell-aware.
+
+## 7. Authoring targets per cell
+
+**Decision**: For each of the six cells, author `destructive-subtle` as an opaque low-chroma destructive surface (light cells: high lightness; dark cells: low lightness) and `destructive-subtle-foreground` as a destructive-hued text that clears ≥5:1 at rest (so hover stays ≥4.5:1). Verify with the package's own `contrastRatio` (the same tsx check used to validate the spec-016 palettes) before wiring, then lock it in the matrix test.
+
+**Rationale**: Empirical verification against `color.ts` is how the six spec-016 palettes were proven AA; reusing it keeps authoring deterministic rather than guesswork.
+
+**Alternatives considered**: Eyeballing values — rejected; the 4.1:1 bug is precisely what eyeballing missed.
+
+## 8. Re-enabling the example's light scheme
+
+**Decision**: Once the pair passes in every cell, re-add `@import '@unbranded-ds/tokens/themes/light.css';` to the example's `globals.css` (the import spec 016 removed to dodge the failing button).
+
+**Rationale**: Closes the spec-016 workaround and proves the fix end to end — the example's default-light view renders DS tokens and the Playwright axe pass on `/` stays clean (FR-009, SC-002).
+
+**Alternatives considered**: Leave light file-less — rejected, it leaves default-light visibly unstyled and the workaround in place.

--- a/specs/018-button-destructive-contrast/spec.md
+++ b/specs/018-button-destructive-contrast/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: Accessible destructive Button across every theme
+
+**Feature Branch**: `018-button-destructive-contrast`
+**Created**: 2026-06-16
+**Status**: Draft
+**Input**: User description: "@docs/workshops/2026-06-16/spec-018-button-destructive-contrast.md"
+
+## Clarifications
+
+### Session 2026-06-16
+
+- Q: How should the destructive Button meet AA while staying recognizably destructive? → A: A soft tint backed by dedicated tokens — a destructive-subtle surface token and a darker destructive text token, authored per cell so each clears 4.5:1, rather than switching to a solid fill or merely retuning the current alpha tint.
+- Q: Which theme cells must the destructive Button pass AA in? → A: All six shipped cells (default / brand / vaporwave × light / dark), joining the spec-016 per-cell AA matrix.
+- Q: On which surfaces must the destructive Button hold AA? → A: Any standard design-system surface — the page background and card/muted surfaces — so the treatment is surface-independent, not reliant on a translucent tint that shifts over whatever sits behind it.
+- Q: Should the new destructive-subtle token pair be canonical reusable tokens or Button-private? → A: Canonical and reusable — a destructive-subtle surface token plus its foreground, provided by every theme like muted/muted-foreground, so future components reuse the same AA-guaranteed pair.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A legible destructive button in any theme (Priority: P1)
+
+A person using a product built on the design system encounters a destructive action (Delete, Remove, Discard) rendered with the Button's `destructive` style. In the light color scheme today, that button shows the destructive red as text on a pale red tint at about 4.1:1 — below the WCAG AA threshold, so low-vision and many sighted users struggle to read it. After this change the destructive button is legible at AA in every shipped theme: light and dark, across the default, brand, and vaporwave identities.
+
+**Why this priority**: This is the accessibility defect the spec exists to fix. A core interactive control that fails AA is a merge-blocking issue under the project's accessibility commitment, and destructive actions are exactly the ones a user must read clearly before acting.
+
+**Independent Test**: Render the `destructive` Button in each of the six identity-by-color-scheme combinations and measure the contrast between its label (and icon) and its background. Every combination meets at least 4.5:1 for the normal-size text. Delivers a legible destructive control on its own, with no other change required.
+
+**Acceptance Scenarios**:
+
+1. **Given** the light color scheme with the default identity, **When** a destructive Button renders, **Then** its text-to-background contrast is at least 4.5:1.
+2. **Given** any shipped identity (default, brand, vaporwave) in either color scheme, **When** a destructive Button renders, **Then** its text-to-background contrast is at least 4.5:1.
+3. **Given** a destructive Button, **When** it is hovered or focused, **Then** the label stays at least 4.5:1 against the hover or focus background.
+4. **Given** a destructive Button beside the other variants, **When** a user scans the row, **Then** the destructive action still reads as destructive rather than as a neutral or default button.
+
+---
+
+### User Story 2 - The design system catches a sub-AA destructive treatment automatically (Priority: P2)
+
+A contributor changes a palette, a token, or the destructive Button's styling. If that change drops the destructive treatment below AA, the build fails with a clear contrast error, the same way the other declared foreground/background pairs are guarded. The gap that hid this defect — the validator checked the solid `destructive-foreground` on `destructive` pairing the button never actually uses — is closed.
+
+**Why this priority**: Without a guard, the fix decays. The defect survived two specs precisely because no automated check covered the destructive text-on-surface relationship. This makes the fix durable rather than a one-time patch.
+
+**Independent Test**: Introduce a deliberately failing destructive value in a theme, run the token validation, and confirm the build reports a structured contrast failure naming the offending pair and cell. Revert and confirm the build passes.
+
+**Acceptance Scenarios**:
+
+1. **Given** the token validator, **When** it runs over the shipped themes, **Then** it checks the destructive button's text-on-surface contrast pair in addition to the existing pairs.
+2. **Given** a theme whose destructive treatment would render below AA, **When** the validator runs, **Then** it fails with a structured issue identifying the pair and the theme.
+
+---
+
+### User Story 3 - The example app demonstrates a fully styled light mode (Priority: P3)
+
+The reference Next.js app currently leaves its light color scheme on the file-less base (it does not load the light design-system tokens) specifically to avoid rendering the failing destructive button. Once the destructive treatment passes AA, the example loads the light scheme like any other, so its default-light view is fully design-system-styled and its accessibility scan stays clean.
+
+**Why this priority**: It closes the workaround spec 016 left behind and proves the fix end to end in a real consumer, but it depends on US1 and US2 landing first and carries no user-facing value on its own.
+
+**Independent Test**: With the light scheme loaded in the example app, run the accessibility scan on its primary views; it reports zero serious or critical violations, and the destructive button on the home page passes contrast.
+
+**Acceptance Scenarios**:
+
+1. **Given** the example app with the light scheme active, **When** its primary views are scanned for accessibility, **Then** there are no serious or critical contrast violations.
+
+---
+
+### Edge Cases
+
+- **Hover and focus states**: the destructive button darkens its background on hover and shows a focus ring; the label must stay AA against those states too, not only the resting background.
+- **Disabled destructive button**: a disabled control is exempt from the AA contrast requirement under WCAG, so the dimmed disabled state is out of scope and must not be forced to meet 4.5:1.
+- **Destructive text on a non-default surface**: if the button sits on a colored card rather than the page background, the soft treatment should still hold AA, or the guarding pair must reflect the surface the button actually paints on.
+- **Icon-only destructive button**: a destructive button with only an icon and no text must also meet AA for the icon against its background.
+- **A future identity or color scheme**: any newly added theme cell inherits the same AA requirement for the destructive button automatically.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The destructive Button MUST meet WCAG AA contrast (at least 4.5:1 for normal-size text and any meaningful icon) between its label and its background, in every shipped identity-by-color-scheme combination.
+- **FR-002**: The destructive Button MUST keep a tinted destructive treatment — a subtle destructive-colored surface with destructive-colored text, not a solid fill — so it stays consistent with the design system's restrained variant set while still reading as destructive rather than as the default or neutral variants.
+- **FR-003**: The hover and focus states of the destructive Button MUST also meet AA between the label and the state's background.
+- **FR-004**: The destructive treatment MUST be backed by a canonical, reusable token pair — a destructive-subtle surface and its foreground — that every theme provides (mirroring `muted` / `muted-foreground`), defaulted in the canonical baseline so a theme that omits it still resolves. This is a deliberate addition to the locked canonical schema (Constitution Section III).
+- **FR-005**: The destructive treatment MUST be surface-independent: it MUST meet AA on every standard design-system surface the button can sit on — the page background and card/muted surfaces — not only the base background.
+- **FR-006**: The token validation MUST check the destructive-subtle surface against its foreground (the pair the button actually renders), closing the gap where only the unused solid `destructive-foreground` / `destructive` pairing was checked.
+- **FR-007**: The new contrast guard MUST be validated across all six shipped identity-by-color-scheme cells, joining the per-cell AA matrix rather than checking the default cell alone.
+- **FR-008**: A theme or token change that would drop the destructive treatment below AA MUST fail the build with a structured contrast issue that names the pair and the affected theme.
+- **FR-009**: The example app MUST render its default light view with design-system tokens and pass its accessibility scan with no serious or critical violations.
+- **FR-010**: The change MUST NOT weaken any existing guarantee: the solid `destructive` / `destructive-foreground` relationship stays valid for solid destructive usage, and no other variant's contrast regresses.
+- **FR-011**: The change MUST ship with a changeset declaring the affected packages and bump levels, per the repository's versioning policy.
+
+### Key Entities *(include if feature involves data)*
+
+- **Destructive-subtle token pair**: a canonical, reusable pair every theme provides — a subtle destructive surface and its foreground — that the destructive Button paints with, authored per cell so each clears AA. Mirrors `muted` / `muted-foreground` and is available to any future component that needs destructive content on a quiet surface.
+- **Contrast pair (destructive)**: the declared foreground/background relationship the validator checks against AA — the destructive-subtle surface against its foreground — added so the destructive button's real rendered pairing is guarded for every shipped theme cell.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The destructive Button passes automated WCAG AA contrast checks in 100% of shipped theme combinations, up from failing in the three light cells at roughly 4.1:1 today.
+- **SC-002**: An accessibility scan of the example app's primary views reports zero serious or critical contrast violations with the light scheme loaded.
+- **SC-003**: A deliberately introduced sub-AA destructive value is caught by the build, so no such regression can reach a release undetected.
+- **SC-004**: In a design review across the shipped themes, the destructive Button still reads as a destructive action in every combination, distinct from the default and neutral variants.
+
+## Assumptions
+
+- The destructive base color may stay as it is; the defect is the variant's use of that color as text on a pale tint, so the fix is contained to the variant and the new destructive-subtle token pair, without re-theming.
+- There are no external consumers yet, so introducing the destructive-subtle token pair is a clean change coordinated through a changeset, with no migration window required.
+- Disabled destructive buttons follow WCAG's exemption for inactive controls and are out of scope for the AA requirement.
+- The dark color scheme's destructive button already meets AA and must be preserved, not regressed, by the fix.
+- The exact subtle-surface realization (an opaque subtle token versus a translucent tint validated to pass on every standard surface) and the hover/focus token derivation are planning details, bounded by FR-005's surface-independence requirement.

--- a/specs/018-button-destructive-contrast/tasks.md
+++ b/specs/018-button-destructive-contrast/tasks.md
@@ -1,0 +1,124 @@
+# Tasks: Accessible destructive Button across every theme
+
+**Input**: Design documents from `/specs/018-button-destructive-contrast/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Required. The constitution mandates the three test layers (Section VI), the token change carries a validator pair and the per-cell matrix, and US2 is itself the durable test guard. Test tasks are included.
+
+**Organization**: By user story. The token foundation (the pair, authored AA per cell) blocks both the Button fix (US1) and the validator guard (US2); those two live in different packages and run in parallel; the example cutover (US3) depends on the Button fix.
+
+Paths are relative to the repo root.
+
+## Phase 1: Setup
+
+- [x] T001 Add `destructive-subtle` and `destructive-subtle-foreground` as required keys in `colorTokens` in `packages/tokens/src/schema.ts`. (Schema foundation only; values and the contrast guard follow. The tokens build is intentionally red until the cells provide values in Phase 2.)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**⚠️ CRITICAL**: The AA-passing values below block US1 (the Button renders them) and US2 (the guard validates them). Each pair is opaque and verified with the package's own `contrastRatio` (the tsx check that proved the spec-016 palettes), targeting ≥5:1 at rest. Verify the hover-state composite too (the bounded `color-mix` darken from T007) clears 4.5:1, since the validator's token-vs-token pairs cannot express a composite — the rest headroom is what guarantees it.
+
+- [x] T002 [P] Author and verify the `destructive-subtle` / `destructive-subtle-foreground` pair for default-light (the canonical baseline) in `packages/tokens/src/tokens/color.json` (opaque, ≥5:1).
+- [x] T003 [P] Author and verify the pair for default-dark in `packages/tokens/themes/color-scheme/dark.json`.
+- [x] T004 [P] Author and verify the pair for brand-light and brand-dark in `packages/tokens/themes/theme/brand/light.json` and `packages/tokens/themes/theme/brand/dark.json`.
+- [x] T005 [P] Author and verify the pair for vaporwave-light and vaporwave-dark in `packages/tokens/themes/theme/vaporwave/light.json` and `packages/tokens/themes/theme/vaporwave/dark.json`.
+- [x] T006 Build the tokens (`pnpm --filter @unbranded-ds/tokens build`), commit the regenerated `packages/tokens/src/defaults.generated.ts`, and confirm `--color-destructive-subtle` and `--color-destructive-subtle-foreground` emit in every per-cell CSS file plus the Tailwind preset utilities (depends on T001–T005).
+
+**Checkpoint**: the pair exists, is opaque, and clears AA in all six cells.
+
+---
+
+## Phase 3: User Story 1 - A legible destructive button in any theme (Priority: P1) 🎯 MVP
+
+**Goal**: The destructive Button meets AA in every shipped theme, on the page background and on card/muted surfaces, at rest and on hover.
+
+**Independent Test**: Render `<Button variant="destructive">` in each of the six identity-by-scheme combinations and measure label-to-background contrast; every cell is ≥4.5:1, and the button still reads as destructive.
+
+- [x] T007 [US1] Update the `destructive` variant in `packages/react/src/components/Button/Button.tsx` to `bg-destructive-subtle text-destructive-subtle-foreground`, with hover deepening the surface via a bounded `color-mix` darken (a fixed small percentage of `destructive` mixed into the opaque subtle token, so the rest-state headroom keeps hover ≥4.5:1) and the existing destructive focus ring; remove the `dark:` color overrides (the per-cell tokens carry the light/dark difference now).
+- [x] T008 [P] [US1] Unit-test the resolved destructive classes in `packages/react/src/components/Button/Button.test.tsx`: the variant emits `bg-destructive-subtle` / `text-destructive-subtle-foreground` and no `dark:` destructive color branch.
+- [x] T009 [P] [US1] Confirm the Destructive story in `packages/react/src/components/Button/Button.stories.tsx` carries a `play` and renders zero serious/critical axe violations (add an explicit interaction assertion if the story lacks one).
+
+**Checkpoint**: the destructive Button is AA-legible across themes (the MVP).
+
+---
+
+## Phase 4: User Story 2 - The design system catches a sub-AA destructive treatment automatically (Priority: P2)
+
+**Goal**: The validator guards the destructive-subtle pair for every cell, so the fix can't silently regress.
+
+**Independent Test**: Introduce a deliberately failing `destructive-subtle` value, run the token validation, and confirm a structured `CONTRAST_FAILURE` naming the pair and cell; revert and the build passes.
+
+- [x] T010 [US2] Add `{ foreground: 'color.destructive-subtle-foreground', background: 'color.destructive-subtle', threshold: 4.5 }` to `contrastPairs` in `packages/tokens/src/schema.ts` (the sixth declared pair).
+- [x] T011 [P] [US2] Update `packages/tokens/src/schema.test.ts`: bump the declared-pair count to six, assert the destructive-subtle pair is present, and confirm the two new color keys parse in `colorTokens`. Update any complete-theme fixtures that validate against the strict `themeSchema` (e.g., `validCustom` in this file, and any complete theme under `packages/tokens/src/__fixtures__/`) to carry the two now-required keys; partial fixtures (`deepPartial`) are unaffected.
+- [x] T012 [P] [US2] Add explicit assertions in `packages/tokens/src/themes-contrast.test.ts` that the destructive-subtle pair clears 4.5:1 in all six cells (the matrix already iterates `contrastPairs`; name the pair for legibility) AND that the hover-state surface (the bounded `color-mix` darken from T007) still clears 4.5:1 against the foreground — compute the oklab mix in the test, since the validator's token-vs-token pairs cannot express a composite. This is the committed verification of FR-003's hover requirement.
+- [x] T013 [US2] Add a guard test in `packages/tokens/src/validate.test.ts` that a sub-AA destructive-subtle value makes `validateResolved`/`validateComposedTheme` return a `CONTRAST_FAILURE` whose path names the destructive-subtle pair (depends on T010).
+
+**Checkpoint**: a destructive-subtle regression fails the build with a structured, named issue.
+
+---
+
+## Phase 5: User Story 3 - The example demonstrates a fully styled light mode (Priority: P3)
+
+**Goal**: The example app re-enables its light scheme and stays accessibility-clean, closing the spec-016 workaround.
+
+**Independent Test**: With the light scheme loaded, the example's Playwright axe pass on `/` and `/showcase` reports zero serious or critical violations.
+
+- [x] T014 [US3] Re-add `@import '@unbranded-ds/tokens/themes/light.css';` to `examples/nextjs-15-app-router/app/globals.css` (the import spec 016 removed to dodge the failing button), keeping the consumer-override block intact.
+- [x] T015 [US3] Run `pnpm --filter @unbranded-ds/example-nextjs e2e` and confirm the existing `tests/a11y.spec.ts` axe pass on `/` and `/showcase` is clean with light loaded (no spec change expected; depends on US1 and T014).
+
+**Checkpoint**: the example renders a fully styled default-light with a clean axe pass.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [x] T016 [P] Add a `.changeset/*.md` declaring `@unbranded-ds/tokens` minor and `@unbranded-ds/react` minor.
+- [x] T017 [P] Document the new canonical pair in `THEMING.md` (the token reference / destructive discussion) and the color-token list in `packages/tokens/README.md` if it enumerates them.
+- [x] T018 Run the `humanizer` skill over the new prose (the changeset and the doc additions), then revise in place.
+- [x] T019 Full local CI green: `pnpm typecheck && pnpm build && pnpm test:unit`, `pnpm exec tsx scripts/validate-sidecars.ts`, `pnpm --filter @unbranded-ds/storybook build`, and the example e2e.
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (T001)**: the schema keys, first.
+- **Foundational (T002–T006)**: the authored AA values across all six cells, then the build. Blocks every user story.
+- **US1 (T007–T009) and US2 (T010–T013)**: both depend only on Foundational and live in different packages (react vs tokens), so they run in parallel. US1 is the MVP.
+- **US3 (T014–T015)**: depends on US1 (the fixed Button) and Foundational (the build emitting the tokens).
+- **Polish (T016–T019)**: after the stories; T018/T019 last.
+
+### Parallel opportunities
+
+- Foundational: T002 first (the canonical baseline), then T003, T004, T005 together (separate cell files); T006 after.
+- Across stories: the entire US1 (react) block runs alongside the entire US2 (tokens) block.
+- US1: T008 and T009 together after T007.
+- US2: T011 and T012 together; T013 after T010.
+- Polish: T016 and T017 together.
+
+### Parallel example: Foundational palettes
+
+```bash
+Task: "Author + verify default-dark in themes/color-scheme/dark.json"
+Task: "Author + verify brand-{light,dark} in themes/theme/brand/"
+Task: "Author + verify vaporwave-{light,dark} in themes/theme/vaporwave/"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP first
+
+Setup + Foundational + US1. At that point the destructive Button is AA-legible across all six themes, verified empirically — the headline fix, shippable on its own.
+
+### Incremental delivery
+
+US1 (the legible button) → US2 (the durable validator guard) → US3 (re-enable the example's light scheme) → Polish (changeset, docs, humanizer, full CI).
+
+### Notes
+
+- `[P]` = different files, no incomplete dependency.
+- The tokens build is intentionally red between T001 and T006 (required keys with no values yet); this resolves once the six cells are authored and built.
+- Tests are required per the constitution (Section VI) and the token change; US2 is the durable guard. The changeset (T016) and a humanizer pass on new prose (T018) are both owed before merge.
+- No constitution amendment: FR-004 grows the canonical schema by one pair, which Section III allows by spec (precedent: spec 008). The PR's Constitution Check should carry that note.


### PR DESCRIPTION
## Summary

The Button's `destructive` variant rendered the destructive color as text on a translucent tint (`bg-destructive/10 text-destructive`), which measured about 4.1:1 in the light themes — below the WCAG AA threshold for normal text. The bug was invisible until spec 016 made a consumer render design-system light tokens; it sidestepped the failure by leaving the example's light scheme on the file-less base.

This fixes it properly: a new canonical `destructive-subtle` / `destructive-subtle-foreground` token pair, opaque (so it holds on any surface), authored to clear AA in every identity-by-scheme cell, mirroring `muted` / `muted-foreground`.

## What changed

**Tokens.** Two canonical color tokens, authored across all six cells (default, brand, vaporwave × light, dark) with contrast 6.75–9.81:1 at rest. A sixth declared `contrastPairs` entry guards `destructive-subtle-foreground` on `destructive-subtle`, so the build fails if any theme drifts below 4.5:1. The matrix test also verifies the hover state — the Button deepens the surface via a bounded `color-mix(in oklab, …)`, and a new `mixOklchToLinear` helper computes that composite (5.89–8.76:1 on hover). A guard test proves a sub-AA value fails with a named `CONTRAST_FAILURE`.

**React.** The `destructive` variant paints `bg-destructive-subtle text-destructive-subtle-foreground`, deepening on hover; the dark-mode color overrides are gone, since the per-cell tokens carry the light/dark difference.

**Example + docs.** The example's light scheme is re-enabled, closing the spec-016 workaround. THEMING.md's contrast-pairs table now lists all six declared pairs (it was also missing the spec-016 `muted-foreground/background` pair).

## Compatibility

No external consumers yet, so this is a clean change. The two new tokens are required in the canonical schema but defaulted in the baseline, so a partial consumer theme that omits them still resolves through the resolve-then-validate merge. The `destructive` / `destructive-foreground` pair is untouched for any solid destructive usage. Growing the canonical set by a token pair is a deliberate Section III change, with precedent in spec 008 — no constitution amendment needed.

## Verification

- tokens: typecheck, build, 144 unit tests (all six cells AA at rest and on hover, the guard test, the sixth pair)
- react: typecheck, 132 unit tests, build
- example: typecheck, `next build`, Playwright e2e 11/11 — including the axe a11y pass on `/`, which now renders the destructive button at AA in default-light
- Storybook build, sidecar validator
