### PR TITLE
Fix the accessible-name pattern in the form-control docs, with a dev guard

### DIFF
--- a/.changeset/accessible-name-form-controls.md
+++ b/.changeset/accessible-name-form-controls.md
@@ -1,0 +1,9 @@
+---
+"@unbranded-ds/react": patch
+---
+
+Fix the accessible-name guidance for the ARIA-role form controls, and warn in development when one renders unnamed.
+
+Checkbox, Switch, and Slider render a `role="checkbox"`/`"switch"`/`"slider"` element, which a native `<label>` does not name — only `aria-label` or `aria-labelledby` does. The docs taught the native-label pattern, so a developer who copied an example shipped an unnamed control. The `@example` blocks and usage sidecars now show the working pattern: `aria-label` for an unlabeled control, or a visible `<Label id>` paired with `aria-labelledby` for a labeled one. The wrapping `<label>` (Checkbox) and `htmlFor` association (Switch) stay for click-to-toggle.
+
+A development-only warning now fires when one of these controls mounts with neither `aria-label` nor `aria-labelledby`, naming the control and the fix. It reads props only, never the DOM, and production builds strip it. Neither the warning nor the doc fixes change any rendered DOM.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,10 @@
 # heliostat Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-06-16
+Auto-generated from all feature plans. Last updated: 2026-06-17
 
 ## Active Technologies
+- TypeScript 5.x, strict, no `any` (Constitution VIII). React 19. + `@base-ui-components/react` (peer), the existing `lib/warn.ts` helper, `lib/cn`. No new dependencies. (021-form-control-a11y-naming)
+- N/A — a dev-only console warning; no runtime or persisted state. (021-form-control-a11y-naming)
 
 - TypeScript 5.x, strict, no `any` (Constitution VIII). React 19, Next.js 15 (App Router). + `next` ^15, `react`/`react-dom` 19, `@unbranded-ds/tokens` and `@unbranded-ds/react` at `workspace:*`, Tailwind CSS v4 (consumed through `@unbranded-ds/react/preset.css`), `next/font/local` (self-hosted font), `@playwright/test`, `@axe-core/playwright`. (015-nextjs-example-app)
 - `localStorage` only, through the design system's existing keys (`unbranded-ds-theme`, `unbranded-ds-density`, `unbranded-ds-theme-preference`). No new storage. (015-nextjs-example-app)
@@ -61,10 +63,10 @@ npm test && npm run lint
 TypeScript 5.x, strict mode, no `any` (EVER): Follow standard conventions
 
 ## Recent Changes
+- 021-form-control-a11y-naming: Added TypeScript 5.x, strict, no `any` (Constitution VIII). React 19. + `@base-ui-components/react` (peer), the existing `lib/warn.ts` helper, `lib/cn`. No new dependencies.
 
 - 020-storybook-zindex-test-env: Added TypeScript 5.x, strict, no `any` (Constitution VIII) + Vitest 3 (browser mode), `@vitest/browser` + `playwright` (Chromium), `@storybook/addon-vitest` (`storybookTest()`), `@storybook/addon-a11y`, Storybook 10.3 `@storybook/react-vite`, Tailwind CSS v4 (`@tailwindcss/vite`; the preset's `@theme inline` block)
 - 019-storybook-test-runner-ci: Added TypeScript 5.x, strict, no `any` (Constitution VIII) + Vitest 3 (browser mode), `@vitest/browser` (^3, the optional peer that is currently absent), `playwright` (Chromium; `playwright@1.61.0` is already in the workspace store), `@storybook/addon-vitest` ^10.3 (`storybookTest()` plugin, already a devDep), `@storybook/addon-a11y` ^10.3 (axe, `test: 'error'` already set), Storybook 10.3 `@storybook/react-vite`, GitHub Actions
-- 017-react-use-client: Added TypeScript 5.x, strict, no `any` (Constitution VIII) + sup ^8 (the bundler gaining the banner), React 19 (peer), `@base-ui-components/react` (peer), Next.js 15 App Router (the RSC consumer and guard), Vitest ^3 (the directive unit test), `@playwright/test` (the example e2e that runs `next build`)
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/packages/react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.test.tsx
@@ -1,23 +1,75 @@
 import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Checkbox } from './Checkbox';
 
 describe('checkbox', () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		// The accessible-name guard warns on an unnamed control; capture it so the
+		// suite stays quiet and the naming assertions below can inspect the calls.
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it('renders with checkbox data-slot', () => {
-		const { container } = render(<Checkbox />);
+		const { container } = render(<Checkbox aria-label="Accept" />);
 		expect(container.querySelector('[data-slot=\'checkbox\']')).toBeInTheDocument();
 	});
 
 	it('applies styling classes via cn', () => {
-		const { container } = render(<Checkbox />);
+		const { container } = render(<Checkbox aria-label="Accept" />);
 		const checkbox = container.querySelector('[data-slot=\'checkbox\']')!;
 		expect(checkbox.className).toContain('rounded');
 		expect(checkbox.className).toContain('border');
 	});
 
 	it('merges consumer className', () => {
-		const { container } = render(<Checkbox className="my-check" />);
+		const { container } = render(<Checkbox className="my-check" aria-label="Accept" />);
 		const checkbox = container.querySelector('[data-slot=\'checkbox\']')!;
 		expect(checkbox.className).toContain('my-check');
+	});
+
+	// Renders without StrictMode (RTL's default), so the dev double-invoke can't
+	// turn "warns once" into a flaky assertion.
+	describe('accessible-name warning', () => {
+		it('warns once when rendered with no accessible name', async () => {
+			render(<Checkbox />);
+			await Promise.resolve();
+			const nameWarnings = warnSpy.mock.calls.filter(
+				([, payload]) => (payload as { issue?: string })?.issue === 'missing-accessible-name',
+			);
+			expect(nameWarnings).toHaveLength(1);
+			expect(warnSpy).toHaveBeenCalledWith(
+				'[unbranded-ds]',
+				expect.objectContaining({ component: 'Checkbox', issue: 'missing-accessible-name' }),
+			);
+		});
+
+		it('stays silent when given an aria-label', async () => {
+			render(<Checkbox aria-label="Accept terms" />);
+			await Promise.resolve();
+			expect(warnSpy).not.toHaveBeenCalledWith(
+				'[unbranded-ds]',
+				expect.objectContaining({ issue: 'missing-accessible-name' }),
+			);
+		});
+
+		it('stays silent when given an aria-labelledby', async () => {
+			render(
+				<>
+					<span id="cb-label">Accept terms</span>
+					<Checkbox aria-labelledby="cb-label" />
+				</>,
+			);
+			await Promise.resolve();
+			expect(warnSpy).not.toHaveBeenCalledWith(
+				'[unbranded-ds]',
+				expect.objectContaining({ issue: 'missing-accessible-name' }),
+			);
+		});
 	});
 });

--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -1,8 +1,11 @@
+'use client';
+
 import type * as React from 'react';
 import { Checkbox as CheckboxPrimitive } from '@base-ui-components/react/checkbox';
 
 import { CheckIcon } from 'lucide-react';
 import { cn } from '../../lib/cn';
+import { useAccessibleNameWarning } from '../../lib/use-accessible-name-warning';
 
 interface CheckboxOwnProps {
 	/**
@@ -143,8 +146,8 @@ type CheckboxProps = CheckboxPrimitive.Root.Props & CheckboxOwnProps;
  *   return (
  *     // eslint-disable-next-line jsx-a11y/label-has-associated-control
  *     <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
- *       <Checkbox name="terms" />
- *       <Label>Accept terms and conditions</Label>
+ *       <Checkbox name="terms" aria-labelledby="terms-label" />
+ *       <Label id="terms-label">Accept terms and conditions</Label>
  *     </label>
  *   );
  * }
@@ -165,8 +168,9 @@ type CheckboxProps = CheckboxPrimitive.Root.Props & CheckboxOwnProps;
  *         checked={subscribed}
  *         onCheckedChange={(checked) => setSubscribed(checked)}
  *         name="subscribe"
+ *         aria-labelledby="subscribe-label"
  *       />
- *       <Label>Subscribe to updates</Label>
+ *       <Label id="subscribe-label">Subscribe to updates</Label>
  *     </label>
  *   );
  * }
@@ -177,6 +181,8 @@ type CheckboxProps = CheckboxPrimitive.Root.Props & CheckboxOwnProps;
  * @see {@link Label}
  */
 function Checkbox({ className, ...props }: CheckboxProps) {
+	useAccessibleNameWarning('Checkbox', props);
+
 	return (
 		<CheckboxPrimitive.Root
 			data-slot="checkbox"

--- a/packages/react/src/components/Checkbox/Checkbox.usage.md
+++ b/packages/react/src/components/Checkbox/Checkbox.usage.md
@@ -32,7 +32,7 @@ import { Checkbox } from '@unbranded-ds/react';
 
 ### Standalone uncontrolled
 
-The simplest case: an uncontrolled checkbox with a visible label. Wrap both in a `<label>` so clicking the text toggles the checkbox without extra wiring.
+The simplest case: an uncontrolled checkbox with a visible label. The wrapping `<label>` makes clicking the text toggle the box, but a native `<label>` does not name a `role="checkbox"` element — so point `aria-labelledby` at the `<Label>` to give the checkbox its accessible name.
 
 ```tsx
 import { Checkbox, Label } from '@unbranded-ds/react';
@@ -40,8 +40,8 @@ import { Checkbox, Label } from '@unbranded-ds/react';
 export function AcceptTerms() {
 	return (
 		<label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-			<Checkbox defaultChecked={false} name="terms" />
-			<Label>Accept terms and conditions</Label>
+			<Checkbox defaultChecked={false} name="terms" aria-labelledby="terms-label" />
+			<Label id="terms-label">Accept terms and conditions</Label>
 		</label>
 	);
 }
@@ -64,8 +64,9 @@ export function SubscribeToggle() {
 				checked={subscribed}
 				onCheckedChange={(checked) => setSubscribed(checked)}
 				name="subscribe"
+				aria-labelledby="subscribe-label"
 			/>
-			<Label>Subscribe to updates</Label>
+			<Label id="subscribe-label">Subscribe to updates</Label>
 		</label>
 	);
 }
@@ -91,8 +92,9 @@ export function SelectAll() {
 					checked={allChecked}
 					indeterminate={someChecked && !allChecked}
 					onCheckedChange={(checked) => setItems(items.map(() => checked))}
+					aria-labelledby="select-all-label"
 				/>
-				<Label>Select all</Label>
+				<Label id="select-all-label">Select all</Label>
 			</label>
 		</div>
 	);
@@ -109,8 +111,8 @@ import { Checkbox, Label } from '@unbranded-ds/react';
 export function DisabledOption() {
 	return (
 		<label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-			<Checkbox disabled defaultChecked />
-			<Label>Notifications (unavailable on this plan)</Label>
+			<Checkbox disabled defaultChecked aria-labelledby="notifications-label" />
+			<Label id="notifications-label">Notifications (unavailable on this plan)</Label>
 		</label>
 	);
 }
@@ -124,7 +126,7 @@ The component is focusable with Tab. Space toggles the checked state. The focus 
 
 `aria-invalid` styling activates when the underlying input is marked invalid, turning the border and ring destructive red. This integrates with field-level validation patterns without additional ARIA attributes on the consumer side.
 
-Pair every standalone checkbox with a `<label>` (or `aria-label`/`aria-labelledby`) so screen readers can announce what the checkbox controls. The component itself does not inject a label.
+Give every checkbox an accessible name with `aria-label` or `aria-labelledby`. A native `<label>` wrap is worth keeping for the click-to-toggle target, but on its own it names nothing here: the checkbox is a `role="checkbox"` element, not a native `<input>`, so the label has no control to attach to. For a labeled checkbox, keep the wrapping `<label>` and point `aria-labelledby` at the visible `<Label>`. The component injects no label of its own.
 
 ## Variants and slots
 

--- a/packages/react/src/components/Slider/Slider.stories.tsx
+++ b/packages/react/src/components/Slider/Slider.stories.tsx
@@ -107,8 +107,8 @@ export const Range: Story = {
 					<Slider.Track>
 						<Slider.Indicator />
 					</Slider.Track>
-					<Slider.Thumb aria-label="Value" />
-					<Slider.Thumb aria-label="Value" />
+					<Slider.Thumb aria-label="Minimum" />
+					<Slider.Thumb aria-label="Maximum" />
 				</Slider.Control>
 			</Slider.Root>
 		</div>

--- a/packages/react/src/components/Slider/Slider.test.tsx
+++ b/packages/react/src/components/Slider/Slider.test.tsx
@@ -2,6 +2,9 @@ import { fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Slider } from './Slider';
 
+// Thumbs are named here so the unrelated validation tests below (which assert
+// on the warn spy) aren't polluted by the accessible-name warning. The naming
+// warning gets its own block, with deliberately unnamed thumbs.
 function renderSingle(props: Parameters<typeof Slider.Root>[0] = { children: null }) {
 	return render(
 		<Slider.Root {...props}>
@@ -9,7 +12,7 @@ function renderSingle(props: Parameters<typeof Slider.Root>[0] = { children: nul
 				<Slider.Track>
 					<Slider.Indicator />
 				</Slider.Track>
-				<Slider.Thumb />
+				<Slider.Thumb aria-label="Value" />
 			</Slider.Control>
 		</Slider.Root>,
 	);
@@ -24,8 +27,8 @@ function renderRange(
 				<Slider.Track>
 					<Slider.Indicator />
 				</Slider.Track>
-				<Slider.Thumb />
-				<Slider.Thumb />
+				<Slider.Thumb aria-label="Minimum" />
+				<Slider.Thumb aria-label="Maximum" />
 			</Slider.Control>
 		</Slider.Root>,
 	);
@@ -119,7 +122,7 @@ describe('slider', () => {
 						<Slider.Track>
 							<Slider.Indicator />
 						</Slider.Track>
-						<Slider.Thumb className="my-thumb" />
+						<Slider.Thumb className="my-thumb" aria-label="Value" />
 					</Slider.Control>
 				</Slider.Root>,
 			);
@@ -250,7 +253,7 @@ describe('slider', () => {
 						<Slider.Track>
 							<Slider.Indicator />
 						</Slider.Track>
-						<Slider.Thumb />
+						<Slider.Thumb aria-label="Value" />
 					</Slider.Control>
 				</Slider.Root>,
 			);
@@ -266,6 +269,76 @@ describe('slider', () => {
 			const firstCallArg = onValueChange.mock.calls[0]?.[0];
 			expect(Array.isArray(firstCallArg)).toBe(true);
 			expect(firstCallArg).toEqual([60]);
+		});
+	});
+
+	// The accessible-name check lives on each thumb (the role="slider" element),
+	// so a range slider warns once per unnamed thumb. Renders without StrictMode
+	// (RTL's default), so the per-mount count stays deterministic.
+	describe('validation: missing-accessible-name', () => {
+		function nameWarnings() {
+			return warnSpy.mock.calls.filter(
+				([, payload]) => (payload as { issue?: string })?.issue === 'missing-accessible-name',
+			);
+		}
+
+		it('warns once when a single thumb has no accessible name', async () => {
+			render(
+				<Slider.Root defaultValue={[50]}>
+					<Slider.Control>
+						<Slider.Track>
+							<Slider.Indicator />
+						</Slider.Track>
+						<Slider.Thumb />
+					</Slider.Control>
+				</Slider.Root>,
+			);
+			await Promise.resolve();
+			expect(nameWarnings()).toHaveLength(1);
+			expect(warnSpy).toHaveBeenCalledWith(
+				'[unbranded-ds]',
+				expect.objectContaining({ component: 'Slider', issue: 'missing-accessible-name' }),
+			);
+		});
+
+		it('stays silent when the thumb has an aria-label', async () => {
+			renderSingle({ defaultValue: [50], children: null });
+			await Promise.resolve();
+			expect(nameWarnings()).toHaveLength(0);
+		});
+
+		it('stays silent when the thumb has an aria-labelledby', async () => {
+			render(
+				<>
+					<span id="thumb-label">Volume</span>
+					<Slider.Root defaultValue={[50]}>
+						<Slider.Control>
+							<Slider.Track>
+								<Slider.Indicator />
+							</Slider.Track>
+							<Slider.Thumb aria-labelledby="thumb-label" />
+						</Slider.Control>
+					</Slider.Root>
+				</>,
+			);
+			await Promise.resolve();
+			expect(nameWarnings()).toHaveLength(0);
+		});
+
+		it('warns once per unnamed thumb in range mode', async () => {
+			render(
+				<Slider.Root defaultValue={[20, 80]}>
+					<Slider.Control>
+						<Slider.Track>
+							<Slider.Indicator />
+						</Slider.Track>
+						<Slider.Thumb />
+						<Slider.Thumb />
+					</Slider.Control>
+				</Slider.Root>,
+			);
+			await Promise.resolve();
+			expect(nameWarnings()).toHaveLength(2);
 		});
 	});
 });

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -8,6 +8,7 @@ import { cva } from 'class-variance-authority';
 
 import { useEffect, useMemo } from 'react';
 import { cn } from '../../lib/cn';
+import { useAccessibleNameWarning } from '../../lib/use-accessible-name-warning';
 import { warn } from '../../lib/warn';
 
 const sliderRootVariants = cva(
@@ -423,6 +424,10 @@ function SliderIndicator({ className, ...props }: SliderIndicatorProps) {
  * @see {@link Slider} for full keyboard interactions and usage guidance.
  */
 function SliderThumb({ className, ...props }: SliderThumbProps) {
+	// The thumb is the role="slider" element, so the accessible-name check lives
+	// here, not on the Root — this covers single and range thumbs uniformly.
+	useAccessibleNameWarning('Slider', props);
+
 	return (
 		<SliderPrimitive.Thumb
 			data-slot="slider-thumb"
@@ -501,7 +506,7 @@ function SliderThumb({ className, ...props }: SliderThumbProps) {
  *           <Slider.Track>
  *             <Slider.Indicator />
  *           </Slider.Track>
- *           <Slider.Thumb />
+ *           <Slider.Thumb aria-label="Value" />
  *         </Slider.Control>
  *       </Slider.Root>
  *     </div>
@@ -544,7 +549,7 @@ function SliderThumb({ className, ...props }: SliderThumbProps) {
  *           <Slider.Track>
  *             <Slider.Indicator />
  *           </Slider.Track>
- *           <Slider.Thumb />
+ *           <Slider.Thumb aria-label="Value" />
  *         </Slider.Control>
  *       </Slider.Root>
  *       <output>{`Value: ${value[0]}`}</output>

--- a/packages/react/src/components/Slider/Slider.usage.md
+++ b/packages/react/src/components/Slider/Slider.usage.md
@@ -78,7 +78,7 @@ export function BasicSlider() {
 					<Slider.Track>
 						<Slider.Indicator />
 					</Slider.Track>
-					<Slider.Thumb />
+					<Slider.Thumb aria-label="Value" />
 				</Slider.Control>
 			</Slider.Root>
 		</div>
@@ -103,7 +103,7 @@ export function ControlledSlider() {
 					<Slider.Track>
 						<Slider.Indicator />
 					</Slider.Track>
-					<Slider.Thumb />
+					<Slider.Thumb aria-label="Value" />
 				</Slider.Control>
 			</Slider.Root>
 			<output>{`Value: ${value[0]}`}</output>
@@ -114,7 +114,7 @@ export function ControlledSlider() {
 
 ### Range slider (two thumbs)
 
-Pass two values in `defaultValue` and render two `Slider.Thumb` elements. Base UI manages which thumb responds to a given interaction based on proximity.
+Pass two values in `defaultValue` and render two `Slider.Thumb` elements. Base UI routes each interaction to the nearest thumb. Give each thumb its own `aria-label` for the bound it controls, so a screen-reader user knows which handle they are moving.
 
 ```tsx
 import { Slider } from '@unbranded-ds/react';
@@ -127,8 +127,8 @@ export function RangeSlider() {
 					<Slider.Track>
 						<Slider.Indicator />
 					</Slider.Track>
-					<Slider.Thumb />
-					<Slider.Thumb />
+					<Slider.Thumb aria-label="Minimum" />
+					<Slider.Thumb aria-label="Maximum" />
 				</Slider.Control>
 			</Slider.Root>
 		</div>
@@ -151,7 +151,7 @@ export function VerticalSlider() {
 					<Slider.Track>
 						<Slider.Indicator />
 					</Slider.Track>
-					<Slider.Thumb />
+					<Slider.Thumb aria-label="Value" />
 				</Slider.Control>
 			</Slider.Root>
 		</div>
@@ -161,7 +161,7 @@ export function VerticalSlider() {
 
 ## Accessibility
 
-Each `Slider.Thumb` renders with `role="slider"` and exposes `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` to assistive technology. Screen readers announce the current value as the thumb moves.
+Each `Slider.Thumb` renders with `role="slider"` and exposes `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` to assistive technology. Screen readers announce the current value as the thumb moves. Because the thumb is the `role="slider"` element rather than a native input, give every thumb its own `aria-label` (or `aria-labelledby`) — a single-thumb slider needs one name just as a range slider needs one per thumb.
 
 Keyboard interaction on a focused thumb:
 

--- a/packages/react/src/components/Switch/Switch.test.tsx
+++ b/packages/react/src/components/Switch/Switch.test.tsx
@@ -1,23 +1,75 @@
 import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Switch } from './Switch';
 
 describe('switch', () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		// The accessible-name guard warns on an unnamed control; capture it so the
+		// suite stays quiet and the naming assertions below can inspect the calls.
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it('renders with switch and thumb data-slots', () => {
-		const { container } = render(<Switch />);
+		const { container } = render(<Switch aria-label="Airplane mode" />);
 		expect(container.querySelector('[data-slot=\'switch\']')).toBeInTheDocument();
 		expect(container.querySelector('[data-slot=\'switch-thumb\']')).toBeInTheDocument();
 	});
 
 	it('applies styling classes via cn', () => {
-		const { container } = render(<Switch />);
+		const { container } = render(<Switch aria-label="Airplane mode" />);
 		const sw = container.querySelector('[data-slot=\'switch\']')!;
 		expect(sw.className).toContain('inline-flex');
 	});
 
 	it('merges consumer className', () => {
-		const { container } = render(<Switch className="my-switch" />);
+		const { container } = render(<Switch className="my-switch" aria-label="Airplane mode" />);
 		const sw = container.querySelector('[data-slot=\'switch\']')!;
 		expect(sw.className).toContain('my-switch');
+	});
+
+	// Renders without StrictMode (RTL's default), so the dev double-invoke can't
+	// turn "warns once" into a flaky assertion.
+	describe('accessible-name warning', () => {
+		it('warns once when rendered with no accessible name', async () => {
+			render(<Switch />);
+			await Promise.resolve();
+			const nameWarnings = warnSpy.mock.calls.filter(
+				([, payload]) => (payload as { issue?: string })?.issue === 'missing-accessible-name',
+			);
+			expect(nameWarnings).toHaveLength(1);
+			expect(warnSpy).toHaveBeenCalledWith(
+				'[unbranded-ds]',
+				expect.objectContaining({ component: 'Switch', issue: 'missing-accessible-name' }),
+			);
+		});
+
+		it('stays silent when given an aria-label', async () => {
+			render(<Switch aria-label="Airplane mode" />);
+			await Promise.resolve();
+			expect(warnSpy).not.toHaveBeenCalledWith(
+				'[unbranded-ds]',
+				expect.objectContaining({ issue: 'missing-accessible-name' }),
+			);
+		});
+
+		it('stays silent when given an aria-labelledby', async () => {
+			render(
+				<>
+					<span id="sw-label">Airplane mode</span>
+					<Switch aria-labelledby="sw-label" />
+				</>,
+			);
+			await Promise.resolve();
+			expect(warnSpy).not.toHaveBeenCalledWith(
+				'[unbranded-ds]',
+				expect.objectContaining({ issue: 'missing-accessible-name' }),
+			);
+		});
 	});
 });

--- a/packages/react/src/components/Switch/Switch.tsx
+++ b/packages/react/src/components/Switch/Switch.tsx
@@ -4,6 +4,7 @@ import type * as React from 'react';
 import { Switch as SwitchPrimitive } from '@base-ui-components/react/switch';
 
 import { cn } from '../../lib/cn';
+import { useAccessibleNameWarning } from '../../lib/use-accessible-name-warning';
 
 interface SwitchOwnProps {
 	/**
@@ -144,8 +145,8 @@ type SwitchProps = SwitchPrimitive.Root.Props & SwitchOwnProps;
  * export function AirplaneMode() {
  *   return (
  *     <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
- *       <Switch id="airplane-mode" />
- *       <Label htmlFor="airplane-mode">Airplane mode</Label>
+ *       <Switch id="airplane-mode" aria-labelledby="airplane-mode-label" />
+ *       <Label id="airplane-mode-label" htmlFor="airplane-mode">Airplane mode</Label>
  *     </div>
  *   );
  * }
@@ -164,8 +165,9 @@ type SwitchProps = SwitchPrimitive.Root.Props & SwitchOwnProps;
  *         id="notifications"
  *         checked={enabled}
  *         onCheckedChange={(checked) => setEnabled(checked)}
+ *         aria-labelledby="notifications-label"
  *       />
- *       <Label htmlFor="notifications">Push notifications</Label>
+ *       <Label id="notifications-label" htmlFor="notifications">Push notifications</Label>
  *     </div>
  *   );
  * }
@@ -179,6 +181,8 @@ function Switch({
 	size = 'default',
 	...props
 }: SwitchProps) {
+	useAccessibleNameWarning('Switch', props);
+
 	return (
 		<SwitchPrimitive.Root
 			data-slot="switch"

--- a/packages/react/src/components/Switch/Switch.usage.md
+++ b/packages/react/src/components/Switch/Switch.usage.md
@@ -32,7 +32,7 @@ import { Switch } from '@unbranded-ds/react';
 
 ### Paired with a label
 
-The Switch does not render its own label text. Wire a `<Label>` via matching `id` and `htmlFor` so clicking the label text also toggles the switch.
+The Switch does not render its own label text. The `htmlFor`/`id` pairing makes clicking the label toggle the switch, but it does not name a `role="switch"` element — so also point `aria-labelledby` at the `<Label>` to give the switch its accessible name.
 
 ```tsx
 import { Label, Switch } from '@unbranded-ds/react';
@@ -40,8 +40,8 @@ import { Label, Switch } from '@unbranded-ds/react';
 export function AirplaneMode() {
 	return (
 		<div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-			<Switch id="airplane-mode" />
-			<Label htmlFor="airplane-mode">Airplane mode</Label>
+			<Switch id="airplane-mode" aria-labelledby="airplane-mode-label" />
+			<Label id="airplane-mode-label" htmlFor="airplane-mode">Airplane mode</Label>
 		</div>
 	);
 }
@@ -64,8 +64,9 @@ export function NotificationsToggle() {
 				id="notifications"
 				checked={enabled}
 				onCheckedChange={(checked) => setEnabled(checked)}
+				aria-labelledby="notifications-label"
 			/>
-			<Label htmlFor="notifications">Push notifications</Label>
+			<Label id="notifications-label" htmlFor="notifications">Push notifications</Label>
 		</div>
 	);
 }
@@ -81,8 +82,8 @@ import { Label, Switch } from '@unbranded-ds/react';
 export function CompactSetting() {
 	return (
 		<div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-			<Switch id="compact-wifi" size="sm" defaultChecked />
-			<Label htmlFor="compact-wifi">Wi-Fi</Label>
+			<Switch id="compact-wifi" size="sm" defaultChecked aria-labelledby="compact-wifi-label" />
+			<Label id="compact-wifi-label" htmlFor="compact-wifi">Wi-Fi</Label>
 		</div>
 	);
 }
@@ -98,8 +99,8 @@ import { Label, Switch } from '@unbranded-ds/react';
 export function UnavailableSetting() {
 	return (
 		<div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-			<Switch id="enterprise-feature" disabled defaultChecked />
-			<Label htmlFor="enterprise-feature">Advanced audit log (Enterprise only)</Label>
+			<Switch id="enterprise-feature" disabled defaultChecked aria-labelledby="enterprise-feature-label" />
+			<Label id="enterprise-feature-label" htmlFor="enterprise-feature">Advanced audit log (Enterprise only)</Label>
 		</div>
 	);
 }
@@ -111,7 +112,7 @@ Switch renders a `<span>` with `role="switch"` and a hidden `<input>` beside it.
 
 The component is reachable via Tab. Space toggles the current state. A visible focus ring appears on `:focus-visible` so keyboard users get a clear indicator without pointer clicks picking up the ring.
 
-`aria-invalid` styling activates automatically when the underlying input is marked invalid — the border and ring shift to destructive red. Pair every Switch with a `<Label>`, `aria-label`, or `aria-labelledby` so screen readers can announce what setting the switch controls; the component does not inject label text on its own.
+`aria-invalid` styling activates automatically when the underlying input is marked invalid — the border and ring shift to destructive red. Give every Switch an accessible name with `aria-label` or `aria-labelledby`. A `<Label htmlFor>` is worth keeping for the click-to-toggle target, but on its own it names nothing here: the switch is a `role="switch"` element, not a native `<input>`. For a labeled switch, keep the `htmlFor` association and point `aria-labelledby` at the visible `<Label>`. The component injects no label text of its own.
 
 ## Variants and slots
 

--- a/packages/react/src/lib/use-accessible-name-warning.test.tsx
+++ b/packages/react/src/lib/use-accessible-name-warning.test.tsx
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAccessibleNameWarning } from './use-accessible-name-warning';
+
+// The behavior matrix from contracts/accessible-name-warning.md. renderHook does
+// not wrap in StrictMode, so the dev double-invoke can't make "called once" flaky.
+describe('useAccessibleNameWarning', () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+	const originalEnv = process.env.NODE_ENV;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		process.env.NODE_ENV = originalEnv;
+	});
+
+	it('warns once when neither aria-label nor aria-labelledby is set', () => {
+		renderHook(() => useAccessibleNameWarning('Checkbox', {}));
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy).toHaveBeenCalledWith(
+			'[unbranded-ds]',
+			expect.objectContaining({
+				component: 'Checkbox',
+				issue: 'missing-accessible-name',
+				remedy: expect.stringContaining('aria-label'),
+			}),
+		);
+	});
+
+	it('stays silent when aria-label is a non-empty string', () => {
+		renderHook(() => useAccessibleNameWarning('Switch', { 'aria-label': 'Airplane mode' }));
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it('stays silent when aria-labelledby is a non-empty string', () => {
+		renderHook(() => useAccessibleNameWarning('Slider', { 'aria-labelledby': 'label-id' }));
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it('warns when aria-label is an empty string, since empty names nothing', () => {
+		renderHook(() => useAccessibleNameWarning('Checkbox', { 'aria-label': '' }));
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy).toHaveBeenCalledWith(
+			'[unbranded-ds]',
+			expect.objectContaining({ issue: 'missing-accessible-name' }),
+		);
+	});
+
+	it('warns when aria-label is whitespace only', () => {
+		renderHook(() => useAccessibleNameWarning('Checkbox', { 'aria-label': '   ' }));
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('reports the calling component in the payload', () => {
+		renderHook(() => useAccessibleNameWarning('Switch', {}));
+		expect(warnSpy).toHaveBeenCalledWith(
+			'[unbranded-ds]',
+			expect.objectContaining({ component: 'Switch' }),
+		);
+	});
+
+	it('stays silent in a production build, even with no name', () => {
+		process.env.NODE_ENV = 'production';
+		renderHook(() => useAccessibleNameWarning('Checkbox', {}));
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/react/src/lib/use-accessible-name-warning.ts
+++ b/packages/react/src/lib/use-accessible-name-warning.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect } from 'react';
+import { warn } from './warn';
+
+// Type `process.env.NODE_ENV` without taking a dependency on @types/node. The
+// consumer's bundler replaces this exact expression and strips the dev-only
+// branch below; the module-scoped ambient keeps it typed even where node
+// globals aren't in `types` (e.g. the sidecar example validator).
+declare const process: { env: { NODE_ENV?: string } };
+
+/**
+ * The prop subset that can name an ARIA-role control. A wrapping `<label>` or an
+ * `htmlFor` association toggles the hidden input but does not name a
+ * `role="checkbox"`/`"switch"`/`"slider"` element — only these two props do.
+ */
+interface AccessibleNameProps {
+	'aria-label'?: string;
+	'aria-labelledby'?: string;
+}
+
+const REMEDY = 'Add aria-label, or aria-labelledby referencing a visible label.';
+
+/**
+ * Dev-only guard that warns when a Checkbox, Switch, or Slider thumb renders
+ * with no accessible name.
+ *
+ * These controls expose an ARIA role rather than a native form element, so a
+ * native `<label>` names nothing on them — a real defect the docs used to teach.
+ * Detection is props-only: it reads the control's own `aria-label` /
+ * `aria-labelledby` and never computes a name from the DOM, which keeps it
+ * simple and predictable at the cost of a known false positive (a Slider named
+ * by a native `<label>`, whose remedy is to add `aria-labelledby`). The
+ * automated axe check in stories stays the full source of truth.
+ *
+ * The warning emits from `useEffect`, never at render, so SSR output stays clean
+ * (Constitution IX.6), and the body is gated to development so a consumer's
+ * production bundler dead-code-eliminates it.
+ *
+ * @param component - the calling control, recorded in the warn payload
+ * @param props - the control's own props; only the two ARIA naming props are read
+ */
+function useAccessibleNameWarning(
+	component: 'Checkbox' | 'Switch' | 'Slider',
+	props: AccessibleNameProps,
+): void {
+	const named
+		= isNonEmpty(props['aria-label']) || isNonEmpty(props['aria-labelledby']);
+
+	useEffect(() => {
+		if (process.env.NODE_ENV === 'production')
+			return;
+		if (named)
+			return;
+		warn({ component, issue: 'missing-accessible-name', remedy: REMEDY });
+	}, [component, named]);
+}
+
+// An empty or whitespace-only value names nothing, so it must not count as named.
+function isNonEmpty(value: string | undefined): boolean {
+	return typeof value === 'string' && value.trim().length > 0;
+}
+
+export { useAccessibleNameWarning };
+export type { AccessibleNameProps };

--- a/specs/021-form-control-a11y-naming/checklists/requirements.md
+++ b/specs/021-form-control-a11y-naming/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Fix the accessible-name pattern in form-control docs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Resolved in `/speckit.clarify` (Session 2026-06-17): the dev-time warning ships (FR-007 / User Story 3), uses props-only detection (`aria-label`/`aria-labelledby`, `title` excluded), ships no suppression mechanism, and is scoped to Checkbox/Switch/Slider. See the spec's Clarifications section for the four recorded decisions.
+- Component names (Checkbox, Switch, Slider, Select, Input) and the `aria-label`/`aria-labelledby` mechanism appear in the spec because they are the user-facing subject of the docs being corrected, not implementation choices. The "broken native-label pattern" is described by behavior, not by a specific file or framework call.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/021-form-control-a11y-naming/contracts/accessible-name-warning.md
+++ b/specs/021-form-control-a11y-naming/contracts/accessible-name-warning.md
@@ -1,0 +1,41 @@
+# Contract: the accessible-name dev warning
+
+The observable contract of FR-007. This is what the unit test asserts and what a consumer or agent can rely on.
+
+## Trigger
+
+When a Checkbox, Switch, or Slider thumb mounts in a development build (`process.env.NODE_ENV !== 'production'`) with neither a non-empty `aria-label` nor a non-empty `aria-labelledby` on the control, exactly one warning is emitted via `warn()`.
+
+## Payload
+
+```jsonc
+{
+  "component": "Checkbox",                 // or "Switch" | "Slider"
+  "issue": "missing-accessible-name",
+  "remedy": "Add aria-label, or aria-labelledby referencing a visible label."
+}
+```
+
+Emitted as `console.warn('[unbranded-ds]', payload)`. The `issue` code is stable and agent-matchable (Constitution XI.4).
+
+## Behavior matrix
+
+| Control state | Environment | Warns? |
+|---------------|-------------|--------|
+| no `aria-label`, no `aria-labelledby` | development | yes, once per mount |
+| `aria-label="Volume"` | development | no |
+| `aria-labelledby="some-id"` | development | no |
+| `aria-label=""` (empty) | development | yes (empty names nothing) |
+| no name | production | no |
+| named by native `<label>` only (Slider thumb) | development | yes — known false positive; remedy is `aria-labelledby` (clarify decision: no suppression ships) |
+
+## Non-goals (explicit)
+
+- Does not read the DOM or compute an accessible name.
+- Does not inspect `title`, ancestor `fieldset`/`legend`, or native `<label>` association.
+- Does not apply to Select or the File input.
+- Ships no suppression mechanism. A per-instance opt-out prop may be added in a later patch if real demand appears (additive, non-breaking).
+
+## Range sliders
+
+A two-thumb slider runs the check per thumb. Two unnamed thumbs produce two warnings (one per control), which is correct — each thumb is a distinct `role="slider"`.

--- a/specs/021-form-control-a11y-naming/data-model.md
+++ b/specs/021-form-control-a11y-naming/data-model.md
@@ -1,0 +1,47 @@
+# Phase 1 Data Model: Fix the accessible-name pattern in form-control docs
+
+This feature has no persistent data. The "entities" are the warning's decision inputs/outputs and the canonical naming pattern the docs teach.
+
+## The "named" predicate (props-only)
+
+The single input the warning reasons about, read from the control's own props:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `aria-label` | `string?` | A non-empty value names the control. |
+| `aria-labelledby` | `string?` | A non-empty value names the control (the id is not resolved against the DOM). |
+
+`named === isNonEmpty(props['aria-label']) || isNonEmpty(props['aria-labelledby'])`. An empty string names nothing and therefore does **not** count as named. No other source (native `<label>`, `title`, ancestor `fieldset`/`legend`) is inspected — by decision, the warning is props-only and the automated accessibility check in stories remains the full source of truth.
+
+## The warn payload (structured output)
+
+Emitted via `warn()` (`lib/warn.ts`), conforming to `WarnPayload` and the Constitution XI.4 structured-failure convention:
+
+| Field | Value |
+|-------|-------|
+| `component` | `'Checkbox'` \| `'Switch'` \| `'Slider'` |
+| `issue` | `'missing-accessible-name'` (new code, alongside `no-items` / `invalid-bounds` / `invalid-step` / `value-out-of-range`) |
+| `remedy` | `'Add aria-label, or aria-labelledby referencing a visible label.'` |
+
+## Scope: which controls warn
+
+| Control | Warns? | Detection site | Why |
+|---------|--------|----------------|-----|
+| Checkbox | Yes | the `Checkbox` component | `role="checkbox"`; native label names nothing |
+| Switch | Yes | the `Switch` component | `role="switch"`; native label names nothing |
+| Slider | Yes | each `SliderThumb` | `role="slider"` is the thumb; per-thumb naming covers single + range |
+| Select | No | — | trigger named by value/placeholder content; props-only would false-positive |
+| Input (incl. file) | No | — | native `<input>`; `htmlFor` names it correctly |
+
+## The canonical naming pattern (what the docs teach)
+
+| Case | Checkbox | Switch | Slider |
+|------|----------|--------|--------|
+| Unlabeled | `aria-label` on the control | `aria-label` on the control | `aria-label` on each `Slider.Thumb` |
+| Labeled | wrapping `<label>` (click-to-toggle) + `aria-labelledby` → `<Label id>` | `<Label htmlFor id>` (click-to-toggle) + `aria-labelledby` → that id | per-thumb `aria-label` ("Minimum"/"Maximum") |
+
+The labeled pattern keeps the native interaction affordance and adds `aria-labelledby` to name the ARIA element. Reference implementations: `Checkbox.stories.tsx:34-37`, `Switch.stories.tsx:52-53`, `Slider.tsx:524-525`.
+
+## State transitions
+
+None. The predicate is evaluated once per mount; the warning is a fire-and-forget dev-only console signal.

--- a/specs/021-form-control-a11y-naming/plan.md
+++ b/specs/021-form-control-a11y-naming/plan.md
@@ -1,0 +1,88 @@
+# Implementation Plan: Fix the accessible-name pattern in form-control docs
+
+**Branch**: `021-form-control-a11y-naming` | **Date**: 2026-06-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/021-form-control-a11y-naming/spec.md`
+
+## Summary
+
+Two threads, one patch release. First, correct the form-control docs that teach a native-`<label>` pattern which names nothing on Base UI's ARIA-role controls: Checkbox and Switch `@example` blocks and sidecars, plus the Slider basic example (currently unnamed). The corrected pattern mirrors the spec-019 story fixes exactly — `aria-label` for an unlabeled control; for a labeled one, keep the wrapping `<label>` (Checkbox) or `<Label htmlFor>` (Switch) for click-to-toggle AND add `aria-labelledby` pointing at a visible `<Label id>` to name the ARIA element. Second, add a dev-only `warn()` when a Checkbox/Switch/Slider renders with no accessible name, detected props-only (`aria-label` or `aria-labelledby`), emitted from a shared hook in `useEffect`, gated to development, scoped to those three controls.
+
+Select and Input need no fix (audit confirms): the Select trigger is named by its value/placeholder content, and Input is a native `<input>` where `htmlFor` is correct (its file-input story already uses `aria-label`). The Range slider story's two `"Value"` thumbs become `"Minimum"`/`"Maximum"`. One patch changeset on `@unbranded-ds/react`.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, strict, no `any` (Constitution VIII). React 19.  
+**Primary Dependencies**: `@base-ui-components/react` (peer), the existing `lib/warn.ts` helper, `lib/cn`. No new dependencies.  
+**Storage**: N/A — a dev-only console warning; no runtime or persisted state.  
+**Testing**: Vitest unit test for the new hook + per-component wiring (Constitution VI.1); the Storybook test-runner (interaction + a11y axe) already passes for these components after spec 019.  
+**Target Platform**: ESM package consumed by React 19 / Next.js 15 App Router (RSC-aware).  
+**Project Type**: component library (`packages/react`) and its co-located documentation surfaces.  
+**Performance Goals**: N/A — the warning is dev-only and off any runtime hot path; production builds strip it.  
+**Constraints**: SSR-safe (warn fires in `useEffect`, never at render — Constitution IX.6); dev-only (`process.env.NODE_ENV` gate, dead-code-eliminated in consumer prod builds); no change to the controls' rendered DOM (FR-006).  
+**Scale/Scope**: 3 components get the warning; 3 components' docs corrected; 2 components audited (no change); 1 story updated; 1 new hook + test; 1 changeset.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+- [x] **Section IV (components thin/unopinionated)**: no new component; the warning adds dev-only behavior with no DOM, style, or public-API change. The component set is unchanged.
+- [x] **Section VI (three test layers)**: a Vitest unit test covers the warning's behavior matrix (unnamed → one warn; `aria-label`/`aria-labelledby` → none; production → none). Interaction and a11y layers already pass.
+- [x] **Section VIII (tooling, strict TS, no `any`)**: the hook is fully typed (a props subset with optional `aria-label`/`aria-labelledby`). No new tooling.
+- [x] **Section IX (DoD, SSR)**: the warning defers to `useEffect`, so no browser globals are touched at render; SSR output stays clean. Adding the hook makes `Checkbox.tsx` a client component (`'use client'`) — consistent with spec 017's handling and with Switch/Slider, which already carry the banner.
+- [x] **Section X (changeset + compliance)**: one `.changeset/*.md` declaring a patch bump on `@unbranded-ds/react`. A patch is correct — no public-API or rendered-output change, a dev-only signal.
+- [x] **Section XI.1 (prose humanized)**: the changed sidecar prose and any new `@example`/comment prose are human-facing and must pass the `humanizer` skill before merge.
+- [x] **Section XI.2 (API shape)**: no new props (the clarify pass rejected a suppress prop). `aria-label`/`aria-labelledby` are standard ARIA, not introduced vocabulary.
+- [x] **Section XI.4 (structured failure output)**: the warn payload carries a machine-parseable code (`issue: 'missing-accessible-name'`) plus `component` and `remedy`, matching the existing `warn()` convention.
+- [x] **Section XI.5 (story coverage)**: minor, noted — the warning is a dev-tool console signal with no visual/interaction surface, so it is unit-tested rather than storied, consistent with the existing Slider `warn()` validations. The corrected naming patterns are already exercised by the spec-019 stories.
+
+No violations. Complexity Tracking is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/021-form-control-a11y-naming/
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions (warn pattern, detection site, audit outcomes)
+├── data-model.md        # Phase 1 — the named predicate, warn payload, scope, naming pattern
+├── quickstart.md        # Phase 1 — how to verify
+├── contracts/
+│   └── accessible-name-warning.md   # Phase 1 — the warning's structured-output contract + matrix
+└── tasks.md             # Phase 2 — created by /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+packages/react/src/
+├── lib/
+│   ├── use-accessible-name-warning.ts        # NEW — the shared dev-only hook
+│   └── use-accessible-name-warning.test.tsx  # NEW — the behavior-matrix unit test
+└── components/
+    ├── Checkbox/
+    │   ├── Checkbox.tsx        # add 'use client' + hook; fix the two @example blocks
+    │   ├── Checkbox.usage.md   # rewrite the native-label examples to aria-labelledby/aria-label
+    │   └── Checkbox.test.tsx   # assert the warning wiring (named → silent, unnamed → warns)
+    ├── Switch/
+    │   ├── Switch.tsx          # add hook; fix the two @example blocks
+    │   ├── Switch.usage.md     # rewrite the htmlFor-only examples to add aria-labelledby
+    │   └── Switch.test.tsx     # assert the warning wiring
+    └── Slider/
+        ├── Slider.tsx          # add hook to SliderThumb; name the basic @example thumb
+        ├── Slider.usage.md     # ensure the single-thumb example names the thumb
+        ├── Slider.stories.tsx  # Range story thumbs: "Value"/"Value" → "Minimum"/"Maximum"
+        └── Slider.test.tsx     # assert the warning wiring (per-thumb)
+
+# Audited, expected no change (confirm in a task):
+#   components/Select/Select.tsx + Select.usage.md   (trigger named by content; out of warning scope)
+#   components/Input/Input.tsx + Input.usage.md      (native input; htmlFor is correct)
+
+.changeset/<name>.md            # NEW — patch @unbranded-ds/react
+```
+
+**Structure Decision**: Existing monorepo layout (Constitution I). All work lands in `packages/react`; no new package, no new top-level directory. The hook lives in `packages/react/src/lib` beside `warn.ts`, the helper it wraps.
+
+## Complexity Tracking
+
+No Constitution violations. Section not applicable.

--- a/specs/021-form-control-a11y-naming/quickstart.md
+++ b/specs/021-form-control-a11y-naming/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart: verifying spec 021
+
+How to confirm the feature is correct, end to end.
+
+## 1. The docs no longer teach the broken pattern
+
+```bash
+# No bare native-label naming of Checkbox/Switch remains in the @example blocks or sidecars.
+# Each corrected example shows aria-label or aria-labelledby.
+rg -n 'aria-labelledby|aria-label' packages/react/src/components/{Checkbox,Switch,Slider}/*.usage.md
+rg -n 'aria-labelledby|aria-label' packages/react/src/components/{Checkbox,Switch}/*.tsx
+```
+
+Expected: the labeled examples pair a visible `<Label id>` with `aria-labelledby`, and keep the wrapping `<label>` (Checkbox) or `<Label htmlFor>` (Switch) for click-to-toggle. Unlabeled examples use `aria-label`. The Slider basic `@example` names its thumb.
+
+## 2. The Range story names both thumbs
+
+```bash
+rg -n 'aria-label' packages/react/src/components/Slider/Slider.stories.tsx
+```
+
+Expected: the Range story's two thumbs read `"Minimum"` and `"Maximum"`, not `"Value"`/`"Value"`.
+
+## 3. The dev warning fires (and stays quiet) correctly
+
+```bash
+pnpm --filter @unbranded-ds/react test
+```
+
+The hook's unit test asserts the full matrix: unnamed → one `warn()` with `issue: 'missing-accessible-name'`; `aria-label` → none; `aria-labelledby` → none; `NODE_ENV=production` → none. Per-component tests assert each control wires the hook.
+
+## 4. The a11y gate still passes
+
+```bash
+pnpm --filter @unbranded-ds/storybook test:storybook
+```
+
+Expected: green. The corrected examples and the renamed Range thumbs all expose accessible names; no axe `aria-toggle-field-name` / `label` violations across Checkbox, Switch, Slider.
+
+## 5. The sidecar examples still compile
+
+```bash
+pnpm tsx scripts/validate-sidecars.ts
+```
+
+Expected: the rewritten `*.usage.md` `tsx` blocks compile under `tsc --noEmit` (spec 005's validator).
+
+## 6. Production strips the warning
+
+Build the package and confirm the `NODE_ENV === 'production'` branch dead-code-eliminates — no `missing-accessible-name` string in the prod bundle.
+
+```bash
+pnpm --filter @unbranded-ds/react build
+rg -n 'missing-accessible-name' packages/react/dist || echo "absent in prod build — correct"
+```
+
+## 7. The changeset is present
+
+```bash
+ls .changeset/*.md   # one patch changeset for @unbranded-ds/react
+```

--- a/specs/021-form-control-a11y-naming/research.md
+++ b/specs/021-form-control-a11y-naming/research.md
@@ -1,0 +1,74 @@
+# Phase 0 Research: Fix the accessible-name pattern in form-control docs
+
+All decisions below are grounded in the current code (read 2026-06-17), not assumption.
+
+## D1 — The `warn()` house pattern: compute at render, emit in `useEffect`
+
+**Decision**: Mirror the existing Slider validation pattern. Compute the warning condition during render, emit it from a `useEffect` keyed on the condition.
+
+**Rationale**: `Slider.tsx:319-325` already does exactly this for its clamp warnings, with the comment "Warnings emit on the client only — `useEffect` doesn't run on the server, which keeps SSR output clean and avoids re-emitting on every render." That satisfies Constitution IX.6 (no browser-only work at render) and prevents per-render console spam. `warn()` itself (`lib/warn.ts`) is a thin `console.warn('[unbranded-ds]', payload)` with no dedup or gating, so timing and gating are the caller's job — same as Slider.
+
+**Alternatives considered**: Warn during render (rejected — runs on the server for an RSC, prints SSR-side noise, re-emits each render). A module-level dedup `Set` (rejected — no stable per-instance key; complexity not worth it for a dev-only message).
+
+## D2 — Detection lives in a shared dev-only hook
+
+**Decision**: Add `useAccessibleNameWarning(component, props)` in `packages/react/src/lib/use-accessible-name-warning.ts`. It reads `aria-label`/`aria-labelledby` off the passed props, and in a `useEffect` emits one `warn()` when both are absent, unless `process.env.NODE_ENV === 'production'`. Checkbox, Switch, and SliderThumb each call it.
+
+**Rationale**: One tested place for the SSR-safe timing, the prod gate, and the predicate, rather than three copies. The "named" predicate is non-empty `aria-label` OR non-empty `aria-labelledby` (an empty string names nothing, so it must not count). The payload uses the established shape: `{ component, issue: 'missing-accessible-name', remedy: 'Add aria-label, or aria-labelledby referencing a visible label.' }` — a new `issue` code alongside the existing `no-items` / `invalid-bounds` / `value-out-of-range` codes, agent-parseable per Constitution XI.4.
+
+**Alternatives considered**: Inline per component (rejected — three copies of the same SSR/gate logic to test). Computed accessible name from the DOM (rejected in the clarify pass — props-only by decision).
+
+## D3 — The Slider warning checks each `SliderThumb`, not the Root
+
+**Decision**: Call the hook from `SliderThumb` (each thumb checks its own `aria-label`/`aria-labelledby`), not from `SliderRoot`.
+
+**Rationale**: The `role="slider"` element is the Thumb (`Slider.tsx:414-433`). Checking per-thumb handles single and range modes uniformly: every thumb needs its own name, which is exactly the documented range pattern (`Slider.Thumb aria-label="Minimum price"`). A Root-level check would false-positive on the correct range pattern (per-thumb labels the Root can't see) and depends on whether Base UI forwards a Root `aria-label` to the thumb input — an ambiguity the per-thumb check sidesteps. Every existing Slider story already labels its thumb (`aria-label="Value"`), so no story regresses; the only thing that newly warns is the basic `@example` (`<Slider.Thumb />`), which D6 fixes anyway.
+
+**Alternatives considered**: Root-level prop check (rejected — false-positives the range pattern). Forwarding-aware logic (rejected — needs DOM/Base UI internals; props-only by decision).
+
+## D4 — "Exactly one" means once per mount; no module-level dedup
+
+**Decision**: The `useEffect` deps are `[component, named]`, so it fires once per mount and not on re-renders. We do not add cross-render/instance deduplication.
+
+**Rationale**: Matches the Slider clamp warnings, which also fire once per mount via `useEffect` with no dedup. React StrictMode's intentional dev double-invoke may emit twice in development; this is consistent with every other `warn()` in the codebase and not worth special-casing for a dev-only message. The unit test renders without StrictMode and asserts a single call.
+
+## D5 — Production gate (the one difference from existing warnings)
+
+**Decision**: The naming hook early-returns when `process.env.NODE_ENV === 'production'`. The existing Slider clamp warnings do not gate this way.
+
+**Rationale**: FR-007 requires dev-only. A clamp is a data bug worth surfacing in any environment; a missing accessible name is a dev-time authoring issue, so it is gated and dead-code-eliminated from consumer production bundles.
+
+## D6 — The corrected doc pattern mirrors the spec-019 stories exactly
+
+**Decision**: Copy the naming pattern the spec-019 story fixes already established into the `@example` blocks and sidecars. The native label is kept for interaction; `aria-labelledby` is added for the name.
+
+**Rationale**: The bug is that a native `<label>` toggles the hidden input but does not name the `role="checkbox"`/`"switch"` element. The fix is additive, and the stories are the reference:
+- **Checkbox** (`Checkbox.stories.tsx:34-37`): keep the wrapping `<label>` (click-to-toggle via the hidden input), add `aria-labelledby="id"` on the Checkbox, point it at `<Label id="id">`. Unlabeled: `aria-label` on the Checkbox.
+- **Switch** (`Switch.stories.tsx:52-53`): `<Switch id="x" aria-labelledby="y">` with `<Label id="y" htmlFor="x">` — `htmlFor` gives click-to-toggle, `aria-labelledby` gives the name. Unlabeled: `aria-label`.
+- **Slider** (`Slider.tsx:524-525`): the range `@example` already labels each thumb; only the basic `@example` (`<Slider.Thumb />`) needs a name.
+
+The current `@example`/sidecar pattern (Checkbox wraps a bare `<label>`; Switch uses `htmlFor` alone; sidecar prose at `Checkbox.usage.md:35` literally says "Wrap both in a `<label>`") is what teaches the defect.
+
+**Alternatives considered**: Drop the native label entirely and rely on `aria-labelledby` (rejected — loses click-to-toggle, a real UX regression the spec-019 pattern deliberately avoids).
+
+## D7 — Audit outcome: Select and Input need no change
+
+**Decision**: Confirm-only. Neither teaches the broken pattern for a non-native control.
+
+**Rationale**:
+- **Select** (`Select.usage.md`: no native-label hits; `Select.tsx:159,192`): the trigger renders the selected value (`SelectValue`) as its text content, so it is named by content; the `htmlFor` Label it documents is supplementary. Out of the warning's scope per the clarify decision.
+- **Input** (`Input.usage.md:30-38`, `Input.tsx:109`): a native `<input>`, which a `<label htmlFor>` names correctly. The file-input story already sets `aria-label: 'Upload file'` (`Input.stories.tsx:68`).
+
+The audit task records this confirmation; if either turns out to teach a non-native-control native-label pattern on a closer read, correct it then.
+
+## D8 — `Checkbox.tsx` becomes a client component
+
+**Decision**: Add `'use client'` to `Checkbox.tsx` when the hook lands.
+
+**Rationale**: `Checkbox.tsx` currently has no directive and no hooks (`Checkbox.tsx:1`); adding a `useEffect`-based hook requires the banner. Switch and Slider already carry it. Checkbox wraps a Base UI client primitive regardless, so this changes no rendered output — only the server/client boundary marker. Verify the spec-017 `'use client'` directive coverage (a unit test enumerating banners, if present) includes Checkbox after the change.
+
+## D9 — Versioning
+
+**Decision**: One patch changeset on `@unbranded-ds/react` covering the whole spec.
+
+**Rationale**: The warning is the only runtime change, and it adds no public API or rendered DOM (dev-only). The doc corrections live in the same package. Patch is the right level per the clarify decision and Constitution X.

--- a/specs/021-form-control-a11y-naming/spec.md
+++ b/specs/021-form-control-a11y-naming/spec.md
@@ -1,0 +1,117 @@
+# Feature Specification: Fix the accessible-name pattern in form-control docs
+
+**Feature Branch**: `021-form-control-a11y-naming`  
+**Created**: 2026-06-17  
+**Status**: Draft  
+**Input**: User description: "@docs/workshops/2026-06-16/spec-021-form-control-a11y-naming.md"
+
+## Clarifications
+
+### Session 2026-06-17
+
+- Q: Does spec 021 include the runtime `warn()` when a Checkbox/Switch/Slider renders with no accessible name, or stay documentation-only? → A: Ship the warning for Checkbox/Switch/Slider. User Story 3 / FR-007 is in scope; it carries a patch bump on `@unbranded-ds/react` and a unit test.
+- Q: What does the warning inspect to decide a control is unnamed? → A: Props-only. It warns when neither `aria-label` nor `aria-labelledby` is set on the control. No post-mount DOM read or accessible-name computation.
+- Q: What shape is the warning's opt-out (FR-008)? → A: None ships. The "named" rule is strictly `aria-label` or `aria-labelledby` (`title` does not count). The remedy for the rare control named another way (a Slider named by a native `<label>`) is to add `aria-labelledby`, which the warning message states. A per-instance suppress prop can be added later if real demand appears (additive, non-breaking).
+- Q: Does the dev warning also cover Select and the File input, or only Checkbox/Switch/Slider? → A: Checkbox/Switch/Slider only. Select is named by its value/placeholder content and the File input by a native label or button text, so props-only detection would false-positive on them. They remain in the docs audit (FR-003) but out of the runtime warning.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Component docs teach the working accessible-name pattern (Priority: P1)
+
+A developer building a form copies the documented example for Checkbox, Switch, or Slider straight out of the component's `@example` block or its usage sidecar. Today that example wraps the control in a native `<label>` (or wires one up with `htmlFor`). Because these controls render an ARIA-role element rather than a native form control, the native label names nothing, so the developer ships a control with no accessible name and an automated accessibility check flags it. After this change, the documented example shows the pattern that actually names the control: `aria-label` for an unlabeled control, or `aria-labelledby` pointing at a visible Label for a labeled one. The developer who copies it gets an accessible control on the first try.
+
+**Why this priority**: This is the defect. The docs are actively teaching a pattern that produces inaccessible controls, and the value of the design system rests on its guidance being trustworthy. Fixing the guidance is the whole point of the spec; everything else is secondary.
+
+**Independent Test**: Read the `@example` blocks for Checkbox, Switch, and Slider and their usage sidecars. Confirm none of them demonstrate the native-label pattern for the ARIA-role control and each demonstrates `aria-label` or `aria-labelledby`. Render any example that exists as a story and confirm the accessibility check reports an accessible name.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Checkbox, Switch, and Slider `@example` blocks, **When** a developer reads them, **Then** each shows `aria-label` (unlabeled) or `aria-labelledby` referencing a visible Label (labeled), and none shows a bare native `<label>` naming the control.
+2. **Given** the Checkbox, Switch, and Slider usage sidecars, **When** a developer reads them, **Then** they teach the same accessible-name pattern with no remaining instance of the broken native-label advice.
+3. **Given** the Select and Input (including the File input) docs, **When** they are audited against the same rule, **Then** any that teach the broken pattern for a non-native control are corrected and any already-correct ones are confirmed.
+4. **Given** a developer copies any corrected example verbatim, **When** the resulting control is checked for an accessible name, **Then** it has one with no further edits.
+
+---
+
+### User Story 2 - The Range slider example names both thumbs distinctly (Priority: P2)
+
+A developer looking at the Range slider example sees two thumbs that are each named for what they do, "Minimum" and "Maximum", rather than both carrying the placeholder "Value" that spec 019 used only to clear the gate. The example models the real-world expectation that a two-thumb slider gives each thumb a distinct, meaningful name.
+
+**Why this priority**: The placeholder is technically accessible but pedagogically wrong; it teaches developers to give both thumbs the same name. It is a smaller correctness fix than the core docs defect, and it is independently shippable, so it sits below P1.
+
+**Independent Test**: Render the Range slider story and confirm it exposes exactly two thumbs whose accessible names are "Minimum" and "Maximum", and that the accessibility check passes.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Range slider example, **When** it renders, **Then** its two thumbs report the accessible names "Minimum" and "Maximum" rather than a shared placeholder.
+2. **Given** the Range slider example, **When** the accessibility check runs, **Then** it reports no accessible-name violation for either thumb.
+
+---
+
+### User Story 3 - A dev-time warning catches an unnamed control at the source (Priority: P3)
+
+A developer renders a Checkbox, Switch, or Slider in development and forgets to give it an accessible name. Instead of finding out only when a story's accessibility check fails (or worse, never), they see a single development-time warning at render that names the offending control and points at the fix. A control that already carries `aria-label` or `aria-labelledby` produces no warning.
+
+**Why this priority**: This is the only part of the work that changes shipped runtime code and therefore carries a `@unbranded-ds/react` version bump, and it has a real false-positive to manage (a control named by a mechanism props-only detection cannot see). It is a genuine ergonomic improvement that ships in this spec (clarified 2026-06-17); it stays at P3 because the documentation fix is the core value and the warning is the ergonomic add-on layered on top.
+
+**Independent Test**: Render each of Checkbox, Switch, and Slider with no naming prop and confirm exactly one development warning fires per control identifying it; render each with `aria-label` and with `aria-labelledby` and confirm no warning fires.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Checkbox, Switch, or Slider rendered in development with neither `aria-label` nor `aria-labelledby`, **When** it mounts, **Then** a single development warning fires naming the control and the remedy.
+2. **Given** the same control rendered with a valid `aria-label` or `aria-labelledby`, **When** it mounts, **Then** no warning fires.
+3. **Given** a production build, **When** any such control mounts, **Then** no warning fires regardless of naming.
+
+---
+
+### Edge Cases
+
+- A `fieldset`/`legend` names the group, not the individual control. A Checkbox/Switch/Slider inside a fieldset with no name of its own is correctly flagged by axe and by the dev warning; this is not a false positive. (An earlier draft treated it as one; that was a misconception about how the accessible-name algorithm handles legends.)
+- The props-only check will warn on a control that is named by a mechanism its own props cannot see — a native `<label>` association (which can name the Slider's range input), or a `title`. These cases are rare, and the patterns are either fragile or weakly named; the documented remedy is to add `aria-labelledby`/`aria-label`, which the warning message states. No suppression mechanism ships (see Clarifications, 2026-06-17).
+- A Range slider has two thumbs; a single name on the slider root does not name both. Each thumb must be nameable independently, and the documented example must show how.
+- A consumer who keeps the old native-label markup after the docs change is not broken: the controls' rendered DOM is unchanged, so existing code behaves exactly as before. The native label simply remains insufficient on its own to name the control.
+- The Select trigger and the File input may or may not share the defect. The audit outcome for each is either a correction or an explicit confirmation that it is already correct; both are acceptable.
+- For the dev warning specifically, "named" is decided strictly from the control's own `aria-label`/`aria-labelledby` props (`title` does not count); it does not attempt to resolve native or ancestor labelling. The automated accessibility check in stories remains the full source of truth.
+- The dev warning is deliberately limited to Checkbox, Switch, and Slider (clarified 2026-06-17). Select is named by its selected value or placeholder content, and the File input by a native label or a button's text, so a props-only check would false-positive on both. They are covered by the documentation audit (FR-003) only, not the runtime warning.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Checkbox, Switch, and Slider `@example` blocks MUST demonstrate the accessible-name pattern, `aria-label` for an unlabeled control and `aria-labelledby` referencing a visible Label for a labeled one, instead of a native `<label>` wrap or `htmlFor` association naming the control.
+- **FR-002**: The Checkbox, Switch, and Slider usage sidecars MUST teach the same accessible-name pattern, with no remaining example of the broken native-label pattern.
+- **FR-003**: The Select and Input docs (including the File input) MUST be audited against the same rule; any that teach the broken pattern for a non-native control MUST be corrected, and any already correct MUST be confirmed as such.
+- **FR-004**: Every documented example that renders a Checkbox, Switch, Slider, or Select control MUST yield a control with an accessible name, verifiable by the automated accessibility check where the example exists as a story and by review or the sidecar compile-validator where it exists as documentation only.
+- **FR-005**: The Range slider example MUST give its two thumbs the distinct accessible names "Minimum" and "Maximum" rather than a shared placeholder name.
+- **FR-006**: The corrected guidance MUST NOT change the rendered DOM of the shipped controls. This is a documentation and example change, and the controls' current runtime behavior MUST be preserved (the dev warning of FR-007 is the sole permitted runtime addition, and it adds no DOM).
+- **FR-007**: In a development build, the system MUST decide whether a Checkbox, Switch, or Slider is named by inspecting the control's own props only: it is "named" when `aria-label` or `aria-labelledby` is set. When neither is set, the system MUST emit exactly one development warning that identifies the control and states the remedy (add `aria-label`, or `aria-labelledby` referencing a visible label). It MUST NOT compute an accessible name from the DOM, and MUST NOT warn in a production build. This warning applies only to Checkbox, Switch, and Slider; Select and the File input are out of scope for the runtime warning (see Edge Cases).
+- **FR-008**: No dedicated suppression mechanism for FR-007 ships in this spec. The documented remedy for a control named by a mechanism props-only detection cannot see (notably a Slider named by a native `<label>`) is to add `aria-labelledby`. A per-instance opt-out prop MAY be added in a later patch if real consumer demand appears; it would be additive and non-breaking.
+
+### Key Entities
+
+- **Form control with an ARIA role**: Checkbox, Switch, and Slider. Each renders a `role="checkbox"`/`"switch"`/`"slider"` element (Slider via a clipped `<input type="range">`) that a native `<label>` does not name. These are the controls the docs must teach to name with `aria-label`/`aria-labelledby`.
+- **Documented example surface**: the `@example` block inside each component source and the matching `*.usage.md` sidecar. These are the artifacts that currently teach the broken pattern and that this feature corrects.
+- **Range slider thumb**: one of the two draggable handles of a two-thumb slider, each of which needs its own accessible name ("Minimum", "Maximum").
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Zero occurrences of the broken native-label pattern remain in the Checkbox, Switch, and Slider `@example` blocks and usage sidecars, and in any Select or Input doc the audit found teaching it.
+- **SC-002**: A developer who copies any corrected form-control example verbatim produces a control that passes an automated accessible-name check on the first attempt, with no additional edits.
+- **SC-003**: 100% of the documented Checkbox, Switch, Slider, and Select examples that render as stories report an accessible name under the automated accessibility check (zero accessible-name violations across those component docs).
+- **SC-004**: The Range slider example presents exactly two thumbs, each identifiable by a distinct accessible name ("Minimum" and "Maximum").
+- **SC-005**: Every Checkbox, Switch, or Slider rendered in development with neither `aria-label` nor `aria-labelledby` surfaces exactly one warning; setting `aria-label` or `aria-labelledby` produces no warning, and no warning fires in a production build.
+
+## Assumptions
+
+- The dev-time warning (User Story 3 / FR-007) ships in this spec (clarified 2026-06-17, previously the open scope decision). It carries a patch bump on `@unbranded-ds/react`; User Stories 1 and 2 remain documentation-only with no bump.
+- The correct accessible-name pattern is the one spec 019 applied to the stories: `aria-label` for an unlabeled control, `aria-labelledby` referencing a visible Label for a labeled one. This is settled and not re-opened here.
+- No shipped consumer code is inaccessible today. The example Next.js app already uses the `aria-labelledby` pattern (`gallery.tsx`), so this is a documentation defect rather than a runtime one, and no consumer migration or breakage notice is required.
+- "Audit Select and Input" means check their docs for the same broken native-label advice and correct only where the control being named is non-native (the Base UI Select trigger, the File input). A native `<input>` that a `<label htmlFor>` legitimately names is fine and stays as is.
+- Verification reuses the existing automated accessibility pass for stories and the existing sidecar compile-validator for the markdown examples. No new test infrastructure is assumed.
+
+## Dependencies
+
+- Depends on spec 019 (the test-runner gate that surfaced this defect and supplies the reference fix pattern).
+- The dev warning depends on the existing `lib/warn.ts` helper.

--- a/specs/021-form-control-a11y-naming/tasks.md
+++ b/specs/021-form-control-a11y-naming/tasks.md
@@ -1,0 +1,200 @@
+---
+description: "Task list for spec 021: Fix the accessible-name pattern in form-control docs"
+---
+
+# Tasks: Fix the Accessible-Name Pattern in Form-Control Docs
+
+**Input**: Design documents from `/specs/021-form-control-a11y-naming/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/accessible-name-warning.md
+
+**Organization**: Tasks are grouped by user story (US1/US2/US3 from spec.md) to enable independent delivery. US1 and US2 are documentation-only with no version bump; US3 adds the runtime dev warning and carries a patch changeset.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no cross-task dependencies at that point)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- All paths are relative to the repo root
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Housekeeping that blocks nothing but should be done early — the changeset documents the intended release before the first line of implementation is written.
+
+- [ ] T001 Create `.changeset/<unique-name>.md` — patch bump for `@unbranded-ds/react`, summarizing the dev warning addition (the only runtime change); US1/US2 docs need no bump on their own
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisite for US3)
+
+**Purpose**: The shared hook lives in `lib/` and is imported by all three component wiring tasks in US3. US1 and US2 do NOT depend on it and can proceed in parallel with this phase.
+
+**⚠️ CRITICAL for US3**: T013–T015 (hook wiring) cannot start until T002 is complete.
+
+- [ ] T002 Create `packages/react/src/lib/use-accessible-name-warning.ts` — the shared dev-only hook; reads `aria-label`/`aria-labelledby` from props, emits one `warn({ component, issue: 'missing-accessible-name', remedy })` from a `useEffect` when both are absent, gates on `process.env.NODE_ENV !== 'production'`; import from `./warn` for the `warn()` call and `WarnPayload` type
+- [ ] T003 Create `packages/react/src/lib/use-accessible-name-warning.test.tsx` — unit test covering the full behavior matrix from `contracts/accessible-name-warning.md`: unnamed in dev → one `warn()`; `aria-label` set → no warn; `aria-labelledby` set → no warn; empty string → one warn; production → no warn
+
+**Checkpoint**: `packages/react/src/lib/use-accessible-name-warning.ts` exported and passing `pnpm --filter @unbranded-ds/react test` for its own test file.
+
+---
+
+## Phase 3: User Story 1 — Component docs teach the working accessible-name pattern (Priority: P1) 🎯 MVP
+
+**Goal**: Every `@example` block and usage sidecar for Checkbox, Switch, and Slider demonstrates `aria-label` (unlabeled) or `aria-labelledby` referencing a visible Label (labeled). Select and Input are audited and confirmed correct.
+
+**Independent Test**: Run `rg -n 'aria-labelledby|aria-label' packages/react/src/components/{Checkbox,Switch,Slider}/*.tsx packages/react/src/components/{Checkbox,Switch,Slider}/*.usage.md` — every named example must show the correct pattern. Run `pnpm tsx scripts/validate-sidecars.ts` to confirm the updated examples compile.
+
+All tasks in this phase touch different files and can run in parallel.
+
+### Implementation for User Story 1
+
+- [ ] T004 [P] [US1] Fix the two `@example` blocks in `packages/react/src/components/Checkbox/Checkbox.tsx`: labeled example adds `aria-labelledby` on `<Checkbox>` pointing at a `<Label id>` while keeping the wrapping `<label>` for click-to-toggle; unlabeled example uses `aria-label` on `<Checkbox>` directly (reference: `Checkbox.stories.tsx:34-37`)
+- [ ] T005 [P] [US1] Rewrite the broken native-label examples in `packages/react/src/components/Checkbox/Checkbox.usage.md` — anywhere it says "wrap both in a `<label>`" or teaches that a wrapping `<label>` names the control, replace with the `aria-labelledby` + wrapping-label pattern (labeled) or `aria-label` (unlabeled); prose around the examples also needs the humanizer pass (see Polish phase)
+- [ ] T006 [P] [US1] Fix the two `@example` blocks in `packages/react/src/components/Switch/Switch.tsx`: labeled example adds `aria-labelledby` on `<Switch>` referencing the `<Label id>` while keeping `<Label htmlFor>` for click-to-toggle; unlabeled example uses `aria-label` on `<Switch>` (reference: `Switch.stories.tsx:52-53`)
+- [ ] T007 [P] [US1] Rewrite the `htmlFor`-only examples in `packages/react/src/components/Switch/Switch.usage.md` — labeled examples must pair `<Label htmlFor id>` with `aria-labelledby` on `<Switch>`; prose around the examples also needs the humanizer pass (see Polish phase)
+- [ ] T008 [P] [US1] Name the unnamed thumb in the basic `@example` block in `packages/react/src/components/Slider/Slider.tsx` — the single `<Slider.Thumb />` example adds `aria-label="Value"` (matches every other Slider story and the Range-thumb naming convention); the existing range `@example` already names each thumb and stays as-is
+- [ ] T009 [P] [US1] Update `packages/react/src/components/Slider/Slider.usage.md` — confirm the single-thumb example names its thumb; if it teaches an unnamed `<Slider.Thumb />`, add `aria-label`; prose also needs the humanizer pass (see Polish phase)
+- [ ] T010 [P] [US1] Audit `packages/react/src/components/Select/Select.tsx` and `packages/react/src/components/Select/Select.usage.md` — confirm no example teaches a native-label pattern for the Base UI trigger (which is named by its value/placeholder content); the expected outcome is confirm-only (research.md D7), so correct only if the audit surfaces an actual broken example
+- [ ] T011 [P] [US1] Audit `packages/react/src/components/Input/Input.tsx` and `packages/react/src/components/Input/Input.usage.md` — a native `<input>` is correctly named by `<label htmlFor>`, so no change is expected; confirm the file-input story carries `aria-label` (it does per research.md D7); correct only if the audit surfaces an actual broken example
+
+**Checkpoint**: US1 is independently verifiable — `rg` shows no bare native-label naming of ARIA-role controls; `validate-sidecars.ts` passes; the a11y gate (`pnpm --filter @unbranded-ds/storybook test:storybook`) stays green.
+
+---
+
+## Phase 4: User Story 2 — The Range slider example names both thumbs distinctly (Priority: P2)
+
+**Goal**: The Range story's two thumbs carry distinct, meaningful names ("Minimum" and "Maximum") instead of the spec-019 placeholder pair ("Value" / "Value").
+
+**Independent Test**: `rg -n 'aria-label' packages/react/src/components/Slider/Slider.stories.tsx` — the Range story block shows `"Minimum"` and `"Maximum"`.
+
+- [ ] T012 [P] [US2] Rename the two `aria-label` values on the Range story's `<Slider.Thumb>` elements from `"Value"` to `"Minimum"` and `"Maximum"` respectively in `packages/react/src/components/Slider/Slider.stories.tsx` (lines 95–116)
+
+**Checkpoint**: US2 is independently verifiable — the Range story renders with two thumbs whose accessible names are "Minimum" and "Maximum"; `test:storybook` a11y gate passes.
+
+---
+
+## Phase 5: User Story 3 — A dev-time warning catches an unnamed control at the source (Priority: P3)
+
+**Goal**: Checkbox, Switch, and SliderThumb each call `useAccessibleNameWarning`, emit the warning from `useEffect` in development, and stay silent in production and when named. Component tests assert the wiring.
+
+**Dependency note**: T013–T015 have two hard prerequisites each:
+- The shared hook (T002 from Phase 2) must exist.
+- The `@example` fix for the same file (T004 → T013, T006 → T014, T008 → T015) should be committed first so each PR touches the file once, not twice.
+
+T013, T014, and T015 are in different files and can run in parallel once both prerequisites are met. T016–T018 each depend on the corresponding wiring task but can also run in parallel with each other.
+
+### Implementation for User Story 3
+
+- [ ] T013 [P] [US3] Add `'use client'` directive and call `useAccessibleNameWarning('Checkbox', props)` in `packages/react/src/components/Checkbox/Checkbox.tsx` — import from `../../lib/use-accessible-name-warning`; `Checkbox.tsx` currently has no directive, so the banner goes at line 1 (consistent with Switch and Slider per research.md D8). Before finishing: check whether a spec-017 `'use client'` directive-coverage test exists (e.g. one enumerating which components carry the banner); if it does, add Checkbox to it so the new banner doesn't break or get missed by that assertion
+- [ ] T014 [P] [US3] Call `useAccessibleNameWarning('Switch', props)` in `packages/react/src/components/Switch/Switch.tsx` — Switch already carries `'use client'`; just add the hook call and import
+- [ ] T015 [P] [US3] Call `useAccessibleNameWarning('Slider', props)` inside the `SliderThumb` component in `packages/react/src/components/Slider/Slider.tsx` — the detection site is `SliderThumb` (the `role="slider"` element), not `SliderRoot`; pass the thumb's own `aria-label`/`aria-labelledby` props (research.md D3)
+- [ ] T016 [P] [US3] Update `packages/react/src/components/Checkbox/Checkbox.test.tsx` — add tests asserting the hook wiring: render with no naming props → `warn` spy called once with `{ component: 'Checkbox', issue: 'missing-accessible-name' }`; render with `aria-label` → `warn` not called; render with `aria-labelledby` → `warn` not called. Render without StrictMode so the dev double-invoke doesn't make "called once" flaky (research.md D4)
+- [ ] T017 [P] [US3] Update `packages/react/src/components/Switch/Switch.test.tsx` — same wiring assertions as T016 (including the render-without-StrictMode note) but for `Switch`
+- [ ] T018 [P] [US3] Update `packages/react/src/components/Slider/Slider.test.tsx` — assert per-thumb wiring: a single unnamed thumb → one warn; a named thumb (`aria-label="Value"`) → no warn; two unnamed Range thumbs → two warns (one per thumb). Render without StrictMode (research.md D4)
+
+**Checkpoint**: US3 is independently verifiable — `pnpm --filter @unbranded-ds/react test` passes for the hook unit test and all three component wiring tests; no production bundle contains the string `"missing-accessible-name"` (`pnpm --filter @unbranded-ds/react build && rg -n 'missing-accessible-name' packages/react/dist` should print nothing).
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Humanize the human-facing prose changes (Constitution XI.1) and run the quickstart verification gates.
+
+- [ ] T019 Run the `humanizer` skill on all changed sidecar prose in `packages/react/src/components/Checkbox/Checkbox.usage.md`, `packages/react/src/components/Switch/Switch.usage.md`, and `packages/react/src/components/Slider/Slider.usage.md` — the surrounding prose (not the code blocks) must pass the audit-and-revise loop before merge
+- [ ] T020 Run the seven quickstart.md verification steps end to end: `rg` for corrected naming patterns; Range story thumb names; `pnpm --filter @unbranded-ds/react test`; `pnpm --filter @unbranded-ds/storybook test:storybook`; `pnpm tsx scripts/validate-sidecars.ts`; prod bundle check; changeset presence (`ls .changeset/*.md`)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — create the changeset immediately.
+- **Phase 2 (Foundational)**: No dependencies — create the shared hook and its test in parallel with Phase 3/4 work.
+- **Phase 3 (US1)**: No dependencies — all seven tasks are in different files; start immediately.
+- **Phase 4 (US2)**: No dependencies — one file, one task; start immediately.
+- **Phase 5 (US3)**: T013–T015 require T002 AND their per-component US1 task (T004/T006/T008 respectively). T016–T018 require their corresponding wiring task (T013/T014/T015 respectively).
+- **Phase 6 (Polish)**: T019 requires T005/T007/T009; T020 requires all prior tasks.
+
+### Critical Same-File Ordering Constraints
+
+| File | US1 task (first) | US3 task (second) |
+|------|------------------|-------------------|
+| `Checkbox.tsx` | T004 | T013 |
+| `Switch.tsx` | T006 | T014 |
+| `Slider.tsx` | T008 | T015 |
+
+Do NOT start a US3 wiring task on a file until the US1 `@example` fix for that file is complete, to avoid conflicting edits.
+
+### Parallel Opportunities
+
+**Can start immediately (no dependencies):**
+- T001 (changeset)
+- T002 (shared hook)
+- T004 through T011 (all US1 tasks)
+- T012 (US2 Range story)
+
+**Can start once T002 is done AND the matching US1 @example fix is done:**
+- T013 (after T002 + T004)
+- T014 (after T002 + T006)
+- T015 (after T002 + T008)
+
+**Can start once the matching wiring task is done:**
+- T016 (after T013)
+- T017 (after T014)
+- T018 (after T015)
+
+---
+
+## Parallel Example: US3 Wiring Phase
+
+```bash
+# Once T002 + T004 + T006 + T008 are all complete, launch wiring in parallel:
+Task A: "Wire hook + 'use client' in Checkbox.tsx (T013)"
+Task B: "Wire hook in Switch.tsx (T014)"
+Task C: "Wire hook into SliderThumb in Slider.tsx (T015)"
+
+# Once A/B/C complete respectively, launch component tests in parallel:
+Task D: "Update Checkbox.test.tsx for hook wiring (T016)"
+Task E: "Update Switch.test.tsx for hook wiring (T017)"
+Task F: "Update Slider.test.tsx for hook wiring (T018)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. T001 (changeset — create early)
+2. T004–T011 in parallel (US1 doc corrections)
+3. T019 (humanize the changed sidecars)
+4. **STOP and VALIDATE**: `rg` + `validate-sidecars.ts` + `test:storybook` a11y gate
+5. Merge or demo US1 independently — the docs defect is fixed
+
+### Incremental Delivery
+
+1. US1 only → merge when green (the core value of the spec)
+2. Add US2 (T012, one task) → merge Range story fix
+3. Add Phase 2 + US3 (T002–T003 + T013–T018) → merge the dev warning with the patch bump
+
+### Full Delivery (Single PR)
+
+1. T001 + T002 in parallel
+2. T003 (hook test) after T002
+3. T004–T012 in parallel (US1 + US2)
+4. T013–T015 in parallel (after T002 + respective US1 task)
+5. T016–T018 in parallel (after respective wiring task)
+6. T019 (humanizer on sidecars)
+7. T020 (quickstart verification)
+
+---
+
+## Notes
+
+- `[P]` tasks touch different files with no shared-state dependency at the point they're listed
+- `[Story]` labels map tasks to user stories for traceability and independent delivery
+- Tasks T013–T015 have two prerequisites each (see the same-file ordering table above)
+- US1 and US2 have no runtime change; US3 is the sole reason the changeset (T001) carries a patch bump
+- The humanizer (T019) must run on the prose *around* code blocks, not inside them; the code blocks themselves are exempt
+- Commit after each logical group (per-component, or per story); do not batch all 20 tasks into one commit


### PR DESCRIPTION
## Summary

Spec 019's a11y gate surfaced a docs defect. Checkbox, Switch, and Slider render an element with an ARIA role rather than a native form control, so a native `<label>` toggles them but never names them. The `@example` blocks and usage sidecars taught exactly that pattern, so a developer who copied one shipped a control with no accessible name. This corrects the guidance and adds a guard that catches the mistake in development. It ships as one patch.

The docs are the core fix. Every `@example` and usage sidecar for the three controls now shows the working pattern: `aria-label` for an unlabeled control, or a visible `<Label id>` paired with `aria-labelledby` for a labeled one. The wrapping `<label>` (Checkbox) and `htmlFor` association (Switch) stay for click-to-toggle. The Slider basic example names its thumb, and the Range story's two thumbs read "Minimum" and "Maximum" instead of the "Value"/"Value" placeholder spec 019 used only to clear the gate. Select and Input were audited and need no change — the Select trigger is named by its content, and Input is a native field that `htmlFor` names correctly.

The warning is the supporting layer. A new shared hook warns once, in development, when a Checkbox, Switch, or Slider thumb mounts with no `aria-label` or `aria-labelledby`. It reads props only, emits from `useEffect` so SSR stays clean, and gates on `NODE_ENV` so a consumer's production build drops it. The check lives on the Slider thumb (the `role="slider"` element), so a range slider warns once per unnamed handle.

## One off-plan note

This is the package's first use of `process.env.NODE_ENV`, which the sidecar validator (compiling with `types: []`) couldn't resolve. A module-scoped `declare const process` types it without taking a dependency on `@types/node` and keeps the expression bundler-replaceable, so the dev branch still strips in a consumer's production build.
