### PR TITLE
Define the popover surface token and fix the Dialog description contrast

### DIFF
--- a/.changeset/popover-surface-token.md
+++ b/.changeset/popover-surface-token.md
@@ -1,0 +1,10 @@
+---
+"@unbranded-ds/tokens": minor
+"@unbranded-ds/react": patch
+---
+
+Define the popover surface token so Dialog, Tooltip, and Select content render on a real, opaque background.
+
+The Dialog, Tooltip, and Select content components style themselves with `bg-popover` / `text-popover-foreground`, but the color schema never defined a `popover` token, so those surfaces resolved to unset CSS variables and rendered transparent. The accessibility gate then measured the Dialog description's muted-foreground text against the overlay showing through instead of a solid panel. That read 3.98:1, below the 4.5:1 floor for WCAG AA.
+
+`popover` and `popover-foreground` are now canonical color tokens, authored per theme cell as a flat copy of that cell's `background` / `foreground`; elevation stays visual, from the components' ring and shadow. Because `muted-foreground` on `background` already passes AA, the description clears the threshold with no `muted-foreground` change. Two new declared contrast pairs guard `popover-foreground` / `popover` and `muted-foreground` / `popover` across all six identity-by-scheme cells, so a theme that omits the pair or drifts below 4.5:1 fails the build with a structured issue. The spec-020 color-contrast quarantine on the two Dialog stories is gone.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,8 @@ Auto-generated from all feature plans. Last updated: 2026-06-17
 ## Active Technologies
 - TypeScript 5.x, strict, no `any` (Constitution VIII). React 19. + `@base-ui-components/react` (peer), the existing `lib/warn.ts` helper, `lib/cn`. No new dependencies. (021-form-control-a11y-naming)
 - N/A — a dev-only console warning; no runtime or persisted state. (021-form-control-a11y-naming)
+- TypeScript 5.x, strict, no `any` (Constitution VIII). DTCG JSON token sources. + Style Dictionary v4 (the token build, `sd.config.ts`), Zod (the theme schema + `contrastPairs`), the `color.ts` WCAG contrast math, Tailwind CSS v4 (`@theme` preset auto-maps `--color-*` to utilities), `@modelcontextprotocol/sdk` (the token-query MCP reads the token map). No new dependencies. (022-popover-tokens-contrast)
+- N/A — build-time DTCG JSON compiled to CSS variables, a Tailwind preset, JSON, and a typed token map. No runtime or persisted state. (022-popover-tokens-contrast)
 
 - TypeScript 5.x, strict, no `any` (Constitution VIII). React 19, Next.js 15 (App Router). + `next` ^15, `react`/`react-dom` 19, `@unbranded-ds/tokens` and `@unbranded-ds/react` at `workspace:*`, Tailwind CSS v4 (consumed through `@unbranded-ds/react/preset.css`), `next/font/local` (self-hosted font), `@playwright/test`, `@axe-core/playwright`. (015-nextjs-example-app)
 - `localStorage` only, through the design system's existing keys (`unbranded-ds-theme`, `unbranded-ds-density`, `unbranded-ds-theme-preference`). No new storage. (015-nextjs-example-app)
@@ -63,10 +65,10 @@ npm test && npm run lint
 TypeScript 5.x, strict mode, no `any` (EVER): Follow standard conventions
 
 ## Recent Changes
+- 022-popover-tokens-contrast: Added TypeScript 5.x, strict, no `any` (Constitution VIII). DTCG JSON token sources. + Style Dictionary v4 (the token build, `sd.config.ts`), Zod (the theme schema + `contrastPairs`), the `color.ts` WCAG contrast math, Tailwind CSS v4 (`@theme` preset auto-maps `--color-*` to utilities), `@modelcontextprotocol/sdk` (the token-query MCP reads the token map). No new dependencies.
 - 021-form-control-a11y-naming: Added TypeScript 5.x, strict, no `any` (Constitution VIII). React 19. + `@base-ui-components/react` (peer), the existing `lib/warn.ts` helper, `lib/cn`. No new dependencies.
 
 - 020-storybook-zindex-test-env: Added TypeScript 5.x, strict, no `any` (Constitution VIII) + Vitest 3 (browser mode), `@vitest/browser` + `playwright` (Chromium), `@storybook/addon-vitest` (`storybookTest()`), `@storybook/addon-a11y`, Storybook 10.3 `@storybook/react-vite`, Tailwind CSS v4 (`@tailwindcss/vite`; the preset's `@theme inline` block)
-- 019-storybook-test-runner-ci: Added TypeScript 5.x, strict, no `any` (Constitution VIII) + Vitest 3 (browser mode), `@vitest/browser` (^3, the optional peer that is currently absent), `playwright` (Chromium; `playwright@1.61.0` is already in the workspace store), `@storybook/addon-vitest` ^10.3 (`storybookTest()` plugin, already a devDep), `@storybook/addon-a11y` ^10.3 (axe, `test: 'error'` already set), Storybook 10.3 `@storybook/react-vite`, GitHub Actions
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/packages/react/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/Dialog/Dialog.stories.tsx
@@ -94,12 +94,6 @@ export const OpenCloseInteraction: Story = {
 					'Interaction test that clicks the trigger and verifies the portal-rendered panel becomes visible with the title announced.',
 			},
 		},
-		// Quarantine the color-contrast axe rule here. Spec 020 made the runner apply real
-		// token styling for the first time, which surfaced a genuine pre-existing failure:
-		// DialogDescription's `text-muted-foreground` (#6f6f78) lands at 3.98:1, below AA.
-		// Tracked as a real DS bug rather than loosened silently:
-		// docs/workshops/2026-06-16/spec-022-popover-tokens-and-dialog-contrast.md
-		a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
 	},
 	render: () => (
 		<Dialog>
@@ -132,11 +126,6 @@ export const TooltipStacksAboveDialog: Story = {
 					'Regression test for the nested-overlay stacking fix (spec 010). A tooltip opened on a control inside an open dialog renders above the dialog: the tooltip reads the `z-index.tooltip` stop (60) and the dialog reads `z-index.overlay` (50), so the tooltip wins. Before the fix, both stacked at a shared `z-50` with no defined order.',
 			},
 		},
-		// Same color-contrast quarantine as OpenCloseInteraction: the open dialog shows
-		// DialogDescription's muted-foreground text, which fails AA at 3.98:1. The z-index
-		// interaction assertion below still runs; only the contrast rule is suppressed.
-		// docs/workshops/2026-06-16/spec-022-popover-tokens-and-dialog-contrast.md
-		a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
 	},
 	render: () => (
 		<Dialog>

--- a/packages/tokens/src/__fixtures__/valid-custom.json
+++ b/packages/tokens/src/__fixtures__/valid-custom.json
@@ -14,7 +14,9 @@
 			"destructive": "#dc3545",
 			"destructive-foreground": "#ffffff",
 			"destructive-subtle": "#f8d7da",
-			"destructive-subtle-foreground": "#842029"
+			"destructive-subtle-foreground": "#842029",
+			"popover": "#f8f9fa",
+			"popover-foreground": "#212529"
 		},
 		"spacing": {
 			"px": "1px",

--- a/packages/tokens/src/defaults.generated.ts
+++ b/packages/tokens/src/defaults.generated.ts
@@ -15,6 +15,8 @@ export const canonicalDefaultTokens = {
 		'destructive-foreground': 'oklch(0.9851 0.0000 89.88)',
 		'destructive-subtle': 'oklch(0.9300 0.0500 25.33)',
 		'destructive-subtle-foreground': 'oklch(0.4400 0.1600 25.33)',
+		'popover': 'oklch(1.0000 0.0000 89.88)',
+		'popover-foreground': 'oklch(0.1408 0.0044 285.82)',
 	},
 	'motion': {
 		'duration-fast': '120ms',

--- a/packages/tokens/src/schema.test.ts
+++ b/packages/tokens/src/schema.test.ts
@@ -73,9 +73,10 @@ describe('themeSchema', () => {
 });
 
 describe('contrastPairs', () => {
-	it('declares 6 foreground/background pairs', () => {
-		// 6 since spec 018 added destructive-subtle-foreground/destructive-subtle.
-		expect(contrastPairs).toHaveLength(6);
+	it('declares 8 foreground/background pairs', () => {
+		// 8 since spec 022 added the two popover pairs (popover-foreground/popover
+		// and muted-foreground/popover) on top of spec 018's destructive-subtle pair.
+		expect(contrastPairs).toHaveLength(8);
 	});
 
 	it('includes the destructive-subtle pair (spec 018)', () => {
@@ -141,6 +142,18 @@ describe('themeSchema — new required typography keys', () => {
 		(key) => {
 			const theme = structuredClone(completeTheme);
 			delete (theme.tokens.typography as Record<string, unknown>)[key];
+			const result = themeSchema.safeParse(theme);
+			expect(result.success).toBe(false);
+		},
+	);
+});
+
+describe('themeSchema — popover color (required, spec 022)', () => {
+	it.each(['popover', 'popover-foreground'])(
+		'rejects a complete theme missing color.%s',
+		(key) => {
+			const theme = structuredClone(completeTheme);
+			delete (theme.tokens.color as Record<string, unknown>)[key];
 			const result = themeSchema.safeParse(theme);
 			expect(result.success).toBe(false);
 		},

--- a/packages/tokens/src/schema.ts
+++ b/packages/tokens/src/schema.ts
@@ -25,6 +25,14 @@ const colorTokens = z.object({
 	// destructive content on a quiet surface reuses them, like muted/muted-foreground.
 	'destructive-subtle': z.string(),
 	'destructive-subtle-foreground': z.string(),
+	// The popover surface that Dialog, Tooltip, and Select content render on.
+	// Required, not optional: every shipped cell must declare it, so a consumer
+	// theme that omits it fails validation loudly instead of rendering a
+	// transparent panel. Authored flat-equal to background/foreground per cell;
+	// the components carry their elevation as ring + shadow, so the surface needs
+	// no distinct tone (spec 022).
+	'popover': z.string(),
+	'popover-foreground': z.string(),
 });
 
 const spacingTokens = z.object({
@@ -226,6 +234,21 @@ export const contrastPairs: ContrastPair[] = [
 	{
 		foreground: 'color.destructive-subtle-foreground',
 		background: 'color.destructive-subtle',
+		threshold: 4.5,
+	},
+	// The popover surface (spec 022). Two pairs mirror the coverage `background`
+	// has: its own foreground on it, plus muted-foreground (the Dialog
+	// description's color) on it. Guarding both keeps a future identity that
+	// diverges popover from background from silently shipping an inaccessible
+	// surface.
+	{
+		foreground: 'color.popover-foreground',
+		background: 'color.popover',
+		threshold: 4.5,
+	},
+	{
+		foreground: 'color.muted-foreground',
+		background: 'color.popover',
 		threshold: 4.5,
 	},
 ];

--- a/packages/tokens/src/token-map.ts
+++ b/packages/tokens/src/token-map.ts
@@ -59,6 +59,8 @@ const schemaTokenMap: Record<string, TokenDefinition> = {
 	'color.destructive-foreground': { name: 'color.destructive-foreground', category: 'color', type: 'color', cssVariable: '--color-destructive-foreground', source: 'schema' },
 	'color.destructive-subtle': { name: 'color.destructive-subtle', category: 'color', type: 'color', cssVariable: '--color-destructive-subtle', source: 'schema' },
 	'color.destructive-subtle-foreground': { name: 'color.destructive-subtle-foreground', category: 'color', type: 'color', cssVariable: '--color-destructive-subtle-foreground', source: 'schema' },
+	'color.popover': { name: 'color.popover', category: 'color', type: 'color', cssVariable: '--color-popover', source: 'schema' },
+	'color.popover-foreground': { name: 'color.popover-foreground', category: 'color', type: 'color', cssVariable: '--color-popover-foreground', source: 'schema' },
 
 	// Spacing tokens
 	'spacing.px': { name: 'spacing.px', category: 'spacing', type: 'dimension', cssVariable: '--spacing-px', source: 'schema' },

--- a/packages/tokens/src/tokens/color.json
+++ b/packages/tokens/src/tokens/color.json
@@ -47,6 +47,14 @@
 		"destructive-subtle-foreground": {
 			"$value": "oklch(0.4400 0.1600 25.33)",
 			"$type": "color"
+		},
+		"popover": {
+			"$value": "oklch(1.0000 0.0000 89.88)",
+			"$type": "color"
+		},
+		"popover-foreground": {
+			"$value": "oklch(0.1408 0.0044 285.82)",
+			"$type": "color"
 		}
 	}
 }

--- a/packages/tokens/themes/color-scheme/dark.json
+++ b/packages/tokens/themes/color-scheme/dark.json
@@ -47,6 +47,14 @@
 		"destructive-subtle-foreground": {
 			"$value": "oklch(0.8600 0.0900 27.33)",
 			"$type": "color"
+		},
+		"popover": {
+			"$value": "oklch(0.1408 0.0044 285.82)",
+			"$type": "color"
+		},
+		"popover-foreground": {
+			"$value": "oklch(0.9851 0.0000 89.88)",
+			"$type": "color"
 		}
 	}
 }

--- a/packages/tokens/themes/theme/brand/dark.json
+++ b/packages/tokens/themes/theme/brand/dark.json
@@ -11,7 +11,9 @@
 		"destructive": { "$value": "oklch(0.5858 0.2220 17.58)", "$type": "color" },
 		"destructive-foreground": { "$value": "oklch(1.0000 0.0000 89.88)", "$type": "color" },
 		"destructive-subtle": { "$value": "oklch(0.2700 0.0800 17.58)", "$type": "color" },
-		"destructive-subtle-foreground": { "$value": "oklch(0.8600 0.0900 17.58)", "$type": "color" }
+		"destructive-subtle-foreground": { "$value": "oklch(0.8600 0.0900 17.58)", "$type": "color" },
+		"popover": { "$value": "oklch(0.1900 0.0250 293.00)", "$type": "color" },
+		"popover-foreground": { "$value": "oklch(0.9700 0.0100 308.00)", "$type": "color" }
 	},
 	"radius": {
 		"sm": { "$value": "0.375rem", "$type": "dimension" },

--- a/packages/tokens/themes/theme/brand/light.json
+++ b/packages/tokens/themes/theme/brand/light.json
@@ -47,6 +47,14 @@
 		"destructive-subtle-foreground": {
 			"$value": "oklch(0.4400 0.1600 17.58)",
 			"$type": "color"
+		},
+		"popover": {
+			"$value": "oklch(0.9768 0.0142 308.30)",
+			"$type": "color"
+		},
+		"popover-foreground": {
+			"$value": "oklch(0.2352 0.0362 290.58)",
+			"$type": "color"
 		}
 	},
 	"radius": {

--- a/packages/tokens/themes/theme/vaporwave/dark.json
+++ b/packages/tokens/themes/theme/vaporwave/dark.json
@@ -11,7 +11,9 @@
 		"destructive": { "$value": "oklch(0.5771 0.2152 20.00)", "$type": "color" },
 		"destructive-foreground": { "$value": "oklch(0.9851 0.0000 89.88)", "$type": "color" },
 		"destructive-subtle": { "$value": "oklch(0.2700 0.0800 20.00)", "$type": "color" },
-		"destructive-subtle-foreground": { "$value": "oklch(0.8600 0.0900 20.00)", "$type": "color" }
+		"destructive-subtle-foreground": { "$value": "oklch(0.8600 0.0900 20.00)", "$type": "color" },
+		"popover": { "$value": "oklch(0.1800 0.0700 300.00)", "$type": "color" },
+		"popover-foreground": { "$value": "oklch(0.9600 0.0300 330.00)", "$type": "color" }
 	},
 	"shadow": {
 		"neon": { "$value": "0 0 12px 2px oklch(0.7200 0.2000 330.00 / 0.6)", "$type": "shadow" }

--- a/packages/tokens/themes/theme/vaporwave/light.json
+++ b/packages/tokens/themes/theme/vaporwave/light.json
@@ -11,7 +11,9 @@
 		"destructive": { "$value": "oklch(0.5800 0.2200 20.00)", "$type": "color" },
 		"destructive-foreground": { "$value": "oklch(1.0000 0.0000 89.88)", "$type": "color" },
 		"destructive-subtle": { "$value": "oklch(0.9300 0.0500 20.00)", "$type": "color" },
-		"destructive-subtle-foreground": { "$value": "oklch(0.4400 0.1600 20.00)", "$type": "color" }
+		"destructive-subtle-foreground": { "$value": "oklch(0.4400 0.1600 20.00)", "$type": "color" },
+		"popover": { "$value": "oklch(0.9800 0.0150 330.00)", "$type": "color" },
+		"popover-foreground": { "$value": "oklch(0.2500 0.0600 300.00)", "$type": "color" }
 	},
 	"shadow": {
 		"neon": { "$value": "0 0 12px 2px oklch(0.6500 0.2200 330.00 / 0.6)", "$type": "shadow" }

--- a/specs/022-popover-tokens-contrast/checklists/requirements.md
+++ b/specs/022-popover-tokens-contrast/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Popover tokens and the Dialog description contrast fix
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The component names (Dialog, Tooltip, Select), the "popover surface", and the "muted-foreground" color appear because they are the user-facing subject of the contrast defect, not implementation choices. The defect and the fix are described by observable behavior (opaque surface, WCAG AA contrast ratios, gate passes with no rules disabled), not by token names, file paths, or framework calls.
+- The approach forks were resolved in `/speckit.clarify` (Session 2026-06-17): define a new canonical `color.popover` + `color.popover-foreground` token pair (not a repoint or a preset alias), set it flat to each theme's `background` / `foreground` so the Dialog description passes via the already-validated `muted-foreground` / `background` pair with no `muted-foreground` change, and guard both `popover-foreground` / `popover` and `muted-foreground` / `popover` in the contrast suite. See the spec's Clarifications section.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/022-popover-tokens-contrast/contracts/popover-token.md
+++ b/specs/022-popover-tokens-contrast/contracts/popover-token.md
@@ -1,0 +1,49 @@
+# Contract: the popover surface token
+
+The observable contract of the new tokens — what a consumer, an agent, or the token-query MCP can rely on, and what the build enforces.
+
+## Emitted tokens
+
+After the build, the design system emits two new CSS custom properties wherever it emits color tokens (the base layer and every theme cell):
+
+```css
+--color-popover: <that cell's background value>;
+--color-popover-foreground: <that cell's foreground value>;
+```
+
+Tailwind v4's `@theme` maps these to the `bg-popover` and `text-popover-foreground` utilities automatically, so the existing `Dialog`, `Tooltip`, and `Select` content classes resolve to a real, opaque surface with no component change.
+
+## Token map / MCP
+
+`token-map.ts` gains two entries, both `source: 'schema'`:
+
+```jsonc
+{
+  "color.popover":            { "cssVariable": "--color-popover",            "category": "color", "type": "color", "source": "schema" },
+  "color.popover-foreground": { "cssVariable": "--color-popover-foreground", "category": "color", "type": "color", "source": "schema" }
+}
+```
+
+The token-query MCP reads the map, so `popover` and `popover-foreground` become queryable (palette, semantic lookup) with no MCP code change. They report as canonical schema tokens, not theme extensions.
+
+## Validation contract
+
+| Condition | Result |
+|-----------|--------|
+| A bundled cell omits `popover` or `popover-foreground` | `validateComposedTheme` fails that cell with a coded completeness issue; the build does not ship. |
+| Either popover pair measures below 4.5:1 in any cell | `themes-contrast.test.ts` fails that cell with the pair and ratio; the build does not ship. |
+| A consumer *partial* theme omits popover | Inherits `canonicalDefaultTokens.color.popover` (the default surface); no failure. |
+| A consumer theme declares popover below AA | Theme validation returns `{ ok: false, issues }` with the pair, consistent with the existing contract. |
+
+## Behavior the fix guarantees
+
+- The `Dialog`, `Tooltip`, and `Select` content surfaces render fully opaque; nothing behind them shows through.
+- The Dialog description (`muted-foreground` on the popover surface) clears WCAG AA, because the surface equals `background` and `muted-foreground`/`background` already passes.
+- No existing token value changes, so no other validated text/background pair moves.
+
+## Non-goals (explicit)
+
+- No distinct "elevated" popover tone — the value is flat-equal to `background`; elevation stays visual (ring + shadow).
+- No `muted-foreground` change, global or scoped.
+- No component public-API or rendered-structure change beyond the surface becoming opaque.
+- No new `card` or other surface token; this defines `popover` only.

--- a/specs/022-popover-tokens-contrast/data-model.md
+++ b/specs/022-popover-tokens-contrast/data-model.md
@@ -1,0 +1,50 @@
+# Phase 1 Data Model: Popover tokens and the Dialog description contrast fix
+
+This feature has no runtime data. The "entities" are the new token pair, the contrast pairs that guard it, and the matrix of cells each must hold across. All are build-time token definitions.
+
+## The popover token pair
+
+Two new canonical color tokens added to `colorTokens` in `schema.ts`:
+
+| Token | CSS variable | Type | Value per cell |
+|-------|--------------|------|----------------|
+| `color.popover` | `--color-popover` | color | equal to that cell's `color.background` |
+| `color.popover-foreground` | `--color-popover-foreground` | color | equal to that cell's `color.foreground` |
+
+Both carry `source: 'schema'` in the token map (they are canonical, not theme-extension). The `--z-index-popover` token is unrelated and unchanged — different prefix, no collision.
+
+## The contrast pairs
+
+Two entries appended to the exported `contrastPairs` array, both at the AA threshold for normal text:
+
+| Foreground | Background | Threshold |
+|------------|------------|-----------|
+| `color.popover-foreground` | `color.popover` | 4.5 |
+| `color.muted-foreground` | `color.popover` | 4.5 |
+
+This mirrors the two-pair coverage `background` already has (`foreground`/`background` and `muted-foreground`/`background`). The array length moves from 6 to 8. `themes-contrast.test.ts` derives its checks from this array, so both pairs are validated across every cell with no test edit.
+
+## The cell matrix
+
+Each cell is one shipped color-scheme × identity combination, authored as a complete palette file. Every cell must declare the popover pair from its own background/foreground:
+
+| Cell | File | popover source |
+|------|------|----------------|
+| default · light | `src/tokens/color.json` | this file's `background` / `foreground` |
+| default · dark | `themes/color-scheme/dark.json` | this file's `background` / `foreground` |
+| brand · light | `themes/theme/brand/light.json` | this file's `background` / `foreground` |
+| brand · dark | `themes/theme/brand/dark.json` | this file's `background` / `foreground` |
+| vaporwave · light | `themes/theme/vaporwave/light.json` | this file's `background` / `foreground` |
+| vaporwave · dark | `themes/theme/vaporwave/dark.json` | this file's `background` / `foreground` |
+
+Density is a fourth axis but carries no color, so it multiplies the cells without adding popover values. Because `popover` equals `background` and `popover-foreground`/`popover` therefore equals the already-passing `foreground`/`background` relationship per cell, every cell passes AA by construction; the matrix test confirms it rather than assuming it.
+
+## Validation rules
+
+- **Completeness**: `popover` and `popover-foreground` are required keys in the strict `themeSchema`. A composed theme missing either fails `validateComposedTheme` (a coded issue, not a silent pass). Consumer *partial* themes merge onto `canonicalDefaultTokens` first, so a consumer who omits popover inherits the default rather than failing.
+- **Contrast**: each new pair must reach 4.5:1 in every cell, enforced by the matrix loop in `themes-contrast.test.ts` via the `contrastPairs` array.
+- **No regression**: the existing six pairs must stay green; adding a surface equal to `background` cannot lower any of them, and the matrix re-runs all pairs to confirm.
+
+## State transitions
+
+None. The tokens are static build-time values; the validation is a build-time gate.

--- a/specs/022-popover-tokens-contrast/plan.md
+++ b/specs/022-popover-tokens-contrast/plan.md
@@ -1,0 +1,91 @@
+# Implementation Plan: Popover tokens and the Dialog description contrast fix
+
+**Branch**: `022-popover-tokens-contrast` | **Date**: 2026-06-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/022-popover-tokens-contrast/spec.md`
+
+## Summary
+
+Define the popover surface the design system's overlay components already reference but never declare. `Dialog`, `Tooltip`, and `Select` content all style themselves with `bg-popover` / `text-popover-foreground`, yet the color schema has no `popover` token, so those surfaces resolve to unset CSS variables and render transparent. That transparency, not the text color, is why the Storybook a11y gate measured the Dialog description at 3.98:1 against the overlay bleed-through.
+
+Add `popover` and `popover-foreground` as canonical color tokens, authored per theme cell as a flat copy of that cell's `background` / `foreground` (elevation already comes from the components' ring and shadow). Because `muted-foreground` on `background` is already a validated AA pair, the description passes with no `muted-foreground` change. Guard two new contrast pairs across the theme matrix, then remove the spec-020 `color-contrast` quarantine from the two Dialog stories. One changeset: minor on `@unbranded-ds/tokens`, patch on `@unbranded-ds/react`.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, strict, no `any` (Constitution VIII). DTCG JSON token sources.  
+**Primary Dependencies**: Style Dictionary v4 (the token build, `sd.config.ts`), Zod (the theme schema + `contrastPairs`), the `color.ts` WCAG contrast math, Tailwind CSS v4 (`@theme` preset auto-maps `--color-*` to utilities), `@modelcontextprotocol/sdk` (the token-query MCP reads the token map). No new dependencies.  
+**Storage**: N/A — build-time DTCG JSON compiled to CSS variables, a Tailwind preset, JSON, and a typed token map. No runtime or persisted state.  
+**Testing**: Vitest unit (`schema.test.ts`, `defaults.test.ts`, `themes-contrast.test.ts` matrix, `token-map` coverage) and the Storybook test-runner a11y gate on the un-quarantined Dialog stories (Constitution VI).  
+**Target Platform**: the `@unbranded-ds/tokens` artifacts consumed by `@unbranded-ds/react` and any downstream app via the Tailwind preset.  
+**Project Type**: design-token package (`packages/tokens`) plus a stories-only change in the component library (`packages/react`).  
+**Performance Goals**: N/A — build-time token emission; no runtime path.  
+**Constraints**: every shipped color-scheme × identity × density cell must stay WCAG AA (Constitution III); no component public-API or rendered-DOM change beyond the now-opaque surface the token supplies (FR-007); the canonical schema grows by spec, not ad hoc.  
+**Scale/Scope**: 2 new tokens across 6 palette files; 2 new contrast pairs; 2 hand-authored token-map entries; generated artifacts regenerate from the build; 1 stories file de-quarantined; 1 changeset. No new package, no new component.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+- [x] **Section II (tokens independent of React)**: the change lives in `packages/tokens` DTCG sources, the Zod schema, and the token map. Nothing pulls React, Storybook, or Base UI into the tokens graph. A tokens-only consumer gets the new surface.
+- [x] **Section III (theming: schema locked, values float, WCAG AA validated)**: this grows the canonical set by spec — the sanctioned mechanism, as in specs 008/016/018 — and keeps the lock honest by validating the two new pairs across the full matrix. `system` and the cascade layers are untouched. The new pair floats per theme like every other color.
+- [x] **Section IV (components thin/unopinionated)**: no component changes; the components already reference the popover surface. The component set is unchanged.
+- [x] **Section VI (three test layers)**: the token-level contrast unit test gains the two pairs across all six cells; the a11y story layer re-enforces on the two de-quarantined Dialog stories. Interaction tests are unaffected.
+- [x] **Section VIII (tooling, strict TS, no `any`)**: Style Dictionary, Zod, and the existing contrast math, used as-is. No new tooling, no `any`.
+- [x] **Section IX (DoD, SSR)**: a build-time token change with no runtime code, so SSR is unaffected. The Dialog/Tooltip/Select stories must pass axe with the quarantine gone.
+- [x] **Section X (changeset + compliance)**: one `.changeset/*.md` declaring `@unbranded-ds/tokens` minor (additive token; partial consumer themes inherit, so non-breaking) and `@unbranded-ds/react` patch (consumer-visible opaque surface; the PR touches `packages/react`).
+- [x] **Section XI.1 (prose humanized)**: the changeset and any new code comment (a short note on why popover equals background) are human-facing and pass the `humanizer` skill before merge.
+- [x] **Section XI.2 (API shape)**: no new component props. `popover` / `popover-foreground` follow the existing `<surface>` / `<surface>-foreground` naming the schema already uses (`primary`/`primary-foreground`, `destructive-subtle`/`destructive-subtle-foreground`).
+- [x] **Section XI.4 (structured failure output)**: theme validation already returns the typed `{ ok, issues }` shape; the new pair flows through it, so a missing or sub-AA popover surfaces a coded issue, not just prose.
+- [x] **Section XI.3 (docs surfaces)**: the token-query MCP and the typed token map auto-expose the new tokens once they are in `token-map.ts`; no separate doc surface needs hand-editing.
+
+No violations. Complexity Tracking is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/022-popover-tokens-contrast/
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions grounded in the token build
+├── data-model.md        # Phase 1 — the token pair, the contrast pairs, the cell matrix
+├── quickstart.md        # Phase 1 — how to verify
+├── contracts/
+│   └── popover-token.md  # Phase 1 — the token + validation contract
+└── tasks.md             # Phase 2 — created by /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+packages/tokens/
+├── src/
+│   ├── schema.ts                 # add `popover` + `popover-foreground` to colorTokens; add 2 contrastPairs (len 6 → 8)
+│   ├── token-map.ts              # add color.popover + color.popover-foreground entries (source: 'schema')
+│   ├── schema.test.ts            # update contrastPairs length assertion (6 → 8); any color-token-count assertion
+│   ├── defaults.test.ts          # confirm regenerated defaults include the pair (compares generated to source)
+│   ├── defaults.generated.ts     # AUTO-GENERATED — regenerated by the build, not hand-edited
+│   ├── themes-contrast.test.ts   # NO edit — its loop derives from contrastPairs and covers the new pairs
+│   └── tokens/
+│       └── color.json            # default light base: add popover = background, popover-foreground = foreground
+└── themes/
+    ├── color-scheme/dark.json            # default dark: add the pair from this cell's background/foreground
+    ├── theme/brand/light.json            # brand light: add the pair
+    ├── theme/brand/dark.json             # brand dark: add the pair
+    ├── theme/vaporwave/light.json        # vaporwave light: add the pair
+    └── theme/vaporwave/dark.json         # vaporwave dark: add the pair
+
+packages/react/
+└── src/components/Dialog/Dialog.stories.tsx   # remove the color-contrast quarantine from the two stories
+
+.changeset/<name>.md             # NEW — tokens minor, react patch
+
+# Regenerated by `pnpm --filter @unbranded-ds/tokens build` (not hand-edited):
+#   dist/tailwind/preset.css (gains --color-popover → bg-popover utility)
+#   dist/css/tokens-*.css, dist/json/themes/*.json (resolved deltas), defaults.generated.ts
+```
+
+**Structure Decision**: Existing monorepo layout (Constitution I). The feature is almost entirely a `packages/tokens` change — schema, six palettes, token map, and the regenerated artifacts — with a single stories-only edit in `packages/react`. No new package or top-level directory. Any test that hard-codes a color-token or contrast-pair count is updated in the same pass.
+
+## Complexity Tracking
+
+No Constitution violations. Section not applicable.

--- a/specs/022-popover-tokens-contrast/quickstart.md
+++ b/specs/022-popover-tokens-contrast/quickstart.md
@@ -1,0 +1,67 @@
+# Quickstart: verifying spec 022
+
+How to confirm the feature is correct, end to end.
+
+## 1. The schema and contrast pairs grew
+
+```bash
+# colorTokens declares the pair; contrastPairs has the two popover entries.
+rg -n "popover" packages/tokens/src/schema.ts
+```
+
+Expected: `popover` and `popover-foreground` in `colorTokens`, and `popover-foreground`/`popover` plus `muted-foreground`/`popover` in `contrastPairs`.
+
+## 2. Every cell authors the pair from its own background
+
+```bash
+rg -n '"popover"|"popover-foreground"' \
+  packages/tokens/src/tokens/color.json \
+  packages/tokens/themes/color-scheme/dark.json \
+  packages/tokens/themes/theme/brand/light.json \
+  packages/tokens/themes/theme/brand/dark.json \
+  packages/tokens/themes/theme/vaporwave/light.json \
+  packages/tokens/themes/theme/vaporwave/dark.json
+```
+
+Expected: all six files declare both, each value matching that file's `background` / `foreground`.
+
+## 3. The build regenerates artifacts and emits the variable
+
+```bash
+pnpm --filter @unbranded-ds/tokens build
+rg -n "color-popover" packages/tokens/dist/tailwind/preset.css
+rg -n "popover" packages/tokens/src/defaults.generated.ts
+```
+
+Expected: `--color-popover` and `--color-popover-foreground` in the preset; the regenerated defaults baseline carries the pair. (`defaults.generated.ts` is build-written, never hand-edited.)
+
+## 4. The token suite passes, matrix included
+
+```bash
+pnpm --filter @unbranded-ds/tokens test
+```
+
+Expected: `schema.test.ts` passes with `contrastPairs` length 8; `themes-contrast.test.ts` passes all six cells against the two new popover pairs; `defaults.test.ts` matches the regenerated baseline.
+
+## 5. The a11y gate passes with the quarantine gone
+
+```bash
+rg -n "color-contrast" packages/react/src/components/Dialog/Dialog.stories.tsx || echo "quarantine removed — correct"
+pnpm --filter @unbranded-ds/storybook test:storybook
+```
+
+Expected: no `color-contrast` suppression remains on `OpenCloseInteraction` or `TooltipStacksAboveDialog`; the gate is green, with no `color-contrast` violation on any Dialog, Tooltip, or Select story.
+
+## 6. The components still render unchanged in structure
+
+```bash
+pnpm --filter @unbranded-ds/react test
+```
+
+Expected: green. No component source changed; the Dialog/Tooltip/Select surfaces are now opaque via the token, not via markup.
+
+## 7. The changeset is present
+
+```bash
+ls .changeset/*.md   # tokens minor, react patch
+```

--- a/specs/022-popover-tokens-contrast/research.md
+++ b/specs/022-popover-tokens-contrast/research.md
@@ -1,0 +1,58 @@
+# Phase 0 Research: Popover tokens and the Dialog description contrast fix
+
+All decisions below are grounded in the current code (read 2026-06-17), not assumption. The clarify session (2026-06-17) already settled the three shaping decisions; this research records how they land against the actual token build.
+
+## D1 — The popover surface is a new canonical color token pair
+
+**Decision**: Add `popover` and `popover-foreground` to the `colorTokens` Zod object in `packages/tokens/src/schema.ts`, alongside the existing `background`/`foreground`/`muted`/`destructive-subtle` surface tokens.
+
+**Rationale**: `Dialog.tsx:277`, `Tooltip.tsx:200`, and `Select.tsx:303` all style their content surface with `bg-popover` / `text-popover-foreground`, but `colorTokens` defines no `popover` — the only `popover` token anywhere is `--z-index-popover`. So those classes resolve to unset CSS variables and the surfaces have no fill. The constitution's rule (Section III/IV) is that components reference canonical token names only; the honest fix is making `popover` canonical, which the schema has grown by spec before (`destructive-subtle` in spec 018, the matrix split in spec 016). The `--z-index-popover` and `--color-popover` names share the `popover` stem but different prefixes, so they do not collide.
+
+**Alternatives considered**: Repoint the three components to `background`/`foreground` (rejected in clarify — bakes "popover == background" permanently and drops a surface concept shadcn/Base UI assumes). A preset-level CSS alias (rejected — leaves popover non-canonical and unvalidatable). Both are recorded in the spec's Clarifications.
+
+## D2 — Each cell's popover equals its own background; no shared color changes
+
+**Decision**: In every palette file, set `popover` to that file's `background` value and `popover-foreground` to its `foreground` value. Change no existing token, `muted-foreground` included.
+
+**Rationale**: `muted-foreground` / `background` is already one of the six validated `contrastPairs` (`schema.ts:192`), so it clears AA in every shipped cell today. With `popover` equal to `background`, the Dialog description's `muted-foreground` text resolves to that already-passing relationship. The 3.98:1 failure the gate reported was never about the text color; it was the transparent surface letting the overlay (`#e6e6e7`) show through. The components already carry their elevation as `ring-1 ring-foreground/10` + `shadow-md`, so a flat fill reads as raised without a distinct tone. This matches shadcn's default, where popover mirrors the base surface.
+
+**Alternatives considered**: A distinct elevated popover tone (rejected in clarify — adds per-cell authoring and contrast work for no visual need given the ring/shadow). Darkening `muted-foreground` globally the way spec 018 tuned the destructive pair (unnecessary here, and it would ripple to every other muted-text usage).
+
+## D3 — The six palette files that must each gain the pair
+
+**Decision**: Add the two tokens to all six authored color palettes, each using that palette's own `background`/`foreground`:
+
+- `packages/tokens/src/tokens/color.json` (default identity, light — the canonical base)
+- `packages/tokens/themes/color-scheme/dark.json` (default, dark)
+- `packages/tokens/themes/theme/brand/light.json`
+- `packages/tokens/themes/theme/brand/dark.json`
+- `packages/tokens/themes/theme/vaporwave/light.json`
+- `packages/tokens/themes/theme/vaporwave/dark.json`
+
+**Rationale**: Each file carries a complete color palette (every color key is re-declared with that cell's values), not a sparse delta — confirmed by reading `dark.json` and `brand/light.json`. Because `popover` differs per cell (it equals each cell's distinct `background`), every cell must declare it explicitly; inheriting the base would give dark and brand the light popover. Completeness is enforced on the composed theme by `validateComposedTheme`, so a missing pair fails the build, not ships.
+
+## D4 — The matrix contrast test covers the new pairs for free
+
+**Decision**: Add two entries to the `contrastPairs` array in `schema.ts` — `popover-foreground` / `popover` and `muted-foreground` / `popover`, both at threshold 4.5 — and add nothing to `themes-contrast.test.ts`.
+
+**Rationale**: `themes-contrast.test.ts` loops its six cells through `validateComposedTheme`, which validates "every declared contrast pair." It derives the pairs from the exported `contrastPairs`, so the two new entries are automatically checked across all six cells. This mirrors how `background` is guarded by two pairs (`foreground`/`background` and `muted-foreground`/`background`), the coverage the clarify session chose so a future identity that diverges popover from background cannot silently ship inaccessible. `schema.test.ts:78` asserts `contrastPairs` has length 6 and must move to 8.
+
+## D5 — defaults.generated.ts, the preset, and CSS emission regenerate from the build
+
+**Decision**: Do not hand-edit generated artifacts. After editing the schema, the six palettes, and the token map, run `pnpm --filter @unbranded-ds/tokens build` to regenerate `defaults.generated.ts`, the Tailwind preset, the per-theme CSS, and the resolved-delta JSON.
+
+**Rationale**: `defaults.generated.ts` carries the banner "AUTO-GENERATED by sd.config.ts — do not edit"; `sd.config.ts` writes it (`destination: 'defaults.generated.ts'`) and emits the CSS variables via the `name/kebab` transform, so `color.popover` becomes `--color-popover`. Tailwind v4's `@theme` then auto-generates the `bg-popover` / `text-popover-foreground` utilities the components already use, so no component class changes. `token-map.ts` is hand-authored (one literal per token), so it needs two new `source: 'schema'` entries (`color.popover`, `color.popover-foreground`); the token-query MCP reads the map, so it then exposes the new tokens with no MCP code change.
+
+## D6 — The React side is the quarantine removal only
+
+**Decision**: The only `packages/react` change is removing the spec-020 `color-contrast` quarantine from the two Dialog stories (`Dialog.stories.tsx`, `OpenCloseInteraction` and `TooltipStacksAboveDialog`). No component source changes.
+
+**Rationale**: The components already reference the popover surface; once the token emits, they render opaque with no code edit (FR-007). The Dialog panel's visible fix arrives entirely through the tokens package's emitted CSS. Tooltip and Select content gain the same real surface and must stay green on their existing stories.
+
+## D7 — Versioning: minor on tokens, patch on react
+
+**Decision**: One changeset declaring `@unbranded-ds/tokens` minor and `@unbranded-ds/react` patch.
+
+**Rationale**: Growing the canonical token set is an additive, non-breaking feature for the tokens package — a consumer's partial theme merges onto `canonicalDefaultTokens`, so a consumer who never declares `popover` inherits the default rather than breaking. That is a minor bump, consistent with how the schema has grown before. The react bump is a patch: its published bundle is effectively unchanged (only a stories file, which is not shipped), but the Dialog, Tooltip, and Select surfaces now render opaque for consumers, a user-visible fix worth recording in react's changelog, and the constitution's per-PR changeset rule applies because the PR touches `packages/react`.
+
+**Alternatives considered**: Major on tokens (rejected — no consumer breakage, partial themes inherit). No react entry (rejected — the PR touches `packages/react` and consumers see the surface change through the components, so it belongs in react's changelog).

--- a/specs/022-popover-tokens-contrast/spec.md
+++ b/specs/022-popover-tokens-contrast/spec.md
@@ -1,0 +1,129 @@
+# Feature Specification: Popover tokens and the Dialog description contrast fix
+
+**Feature Branch**: `022-popover-tokens-contrast`  
+**Created**: 2026-06-17  
+**Status**: Draft  
+**Input**: User description: "@docs/workshops/2026-06-16/spec-022-popover-tokens-and-dialog-contrast.md"
+
+## Clarifications
+
+### Session 2026-06-17
+
+- Q: How should the popover surface be defined — a new canonical token, repointing to an existing surface, or a preset alias? → A: Add a canonical `color.popover` + `color.popover-foreground` token pair to the schema, authored per theme cell (light/dark × default/brand/vaporwave). The components keep referencing the popover surface unchanged; the gap is closed in the token set.
+- Q: What value should the popover surface take — flat (equal to `background`) or a distinct elevated surface? → A: Flat. `color.popover` takes each theme's `background` value and `color.popover-foreground` takes `foreground`; elevation stays visual via ring and shadow. Because `muted-foreground` on `background` is already a validated AA-passing pair, the Dialog description passes with no `muted-foreground` change.
+- Q: Which popover contrast pairs should the token validation suite guard? → A: Both `popover-foreground` / `popover` and `muted-foreground` / `popover`, mirroring the two-pair coverage the base `background` already has, so a future identity that diverges `popover` from `background` cannot silently ship an inaccessible surface.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Popover surfaces have a real, opaque background (Priority: P1)
+
+The Dialog, Tooltip, and Select content surfaces all ask for a "popover" background and foreground color, but the design system never defines that color pair. So those surfaces have no opaque fill of their own: a dialog panel is measured against whatever shows through it rather than against a solid color. This story gives the popover surface a real, defined, opaque background and a matching foreground, so every component built on it sits on a solid color instead of a gap.
+
+**Why this priority**: This is the root cause. With no opaque popover background, the accessibility gate measures dialog text against bleed-through, which is both the likely source of the contrast failure and a real visual defect on its own. Fixing the surface is the foundation everything else builds on, and on the brief's own hypothesis it may resolve the contrast failure outright.
+
+**Independent Test**: Open a Dialog, a Tooltip, and a Select menu. Confirm each content surface resolves to a concrete, fully opaque background color (nothing behind the surface shows through) and a defined text color, in the default light theme.
+
+**Acceptance Scenarios**:
+
+1. **Given** an open Dialog, Tooltip, or Select menu, **When** its content surface renders, **Then** the surface has a defined, fully opaque background color and a defined foreground color rather than a missing or transparent one.
+2. **Given** the popover surface is defined, **When** a dialog panel overlaps page content, **Then** none of the page content behind the panel is visible through it.
+
+---
+
+### User Story 2 - Dialog description text meets WCAG AA (Priority: P1)
+
+A person reading an open dialog sees its description text. Today that text uses the muted-foreground color and fails WCAG AA contrast against the surface it resolves to (measured at 3.98:1, below the 4.5:1 floor for normal text). This story makes the description text, and any muted text on a popover surface, meet AA against that surface so it is legible.
+
+**Why this priority**: This is the headline accessibility defect the gate caught. Illegible description text is a real barrier for low-vision users, and it is the failure that forced the quarantine. It is P1 alongside Story 1 because the two together are the accessible-dialog outcome. With the popover surface set to the base `background` value (clarified 2026-06-17), the description passes via the already-validated `muted-foreground` / `background` pair, so this story is verification: confirm the description clears AA and that no muted text on a popover surface regresses.
+
+**Independent Test**: Open a dialog with a description and run the contrast check. Confirm the description text measures at least 4.5:1 against the popover surface in the default light theme.
+
+**Acceptance Scenarios**:
+
+1. **Given** an open dialog with a description, **When** contrast is measured, **Then** the description text meets at least 4.5:1 against the popover surface (3:1 if the text qualifies as large).
+2. **Given** any muted text rendered on a popover surface, **When** contrast is measured, **Then** it meets the WCAG AA threshold for its size.
+3. **Given** the popover surface equals the base `background` value, **When** the Dialog description renders, **Then** it clears AA through the existing `muted-foreground` / `background` relationship with no change to the `muted-foreground` value.
+
+---
+
+### User Story 3 - The fix holds across the whole theme matrix (Priority: P2)
+
+The design system ships multiple color schemes (light, dark), multiple identities (default, brand, vaporwave), and multiple densities. A contrast fix that passes only in the default light theme is not actually fixed. This story validates the popover surface and its on-surface text across every shipped combination, the way the existing token-level contrast checks guard other pairs, so the dialog is accessible in dark and in the brand and vaporwave identities too.
+
+**Why this priority**: The default light theme is one cell of a larger grid. Dark schemes and alternate identities ship their own palettes and routinely fail where light passes. Without matrix coverage the fix is unverified for most of what users actually see, but it sits below the P1 stories because the core correction must exist before it can be validated everywhere.
+
+**Independent Test**: Run the token-level contrast validation across every color-scheme, identity, and density combination. Confirm the popover surface pair and the on-surface muted-text pair pass in all of them, including dark, brand, and vaporwave.
+
+**Acceptance Scenarios**:
+
+1. **Given** the corrected popover surface and on-surface text colors, **When** they are validated across every shipped color-scheme, identity, and density combination, **Then** all combinations meet WCAG AA with none failing.
+2. **Given** a new or changed color pair, **When** the automated token-level contrast suite runs, **Then** it covers the popover pair so a future regression in any theme fails loudly.
+
+---
+
+### User Story 4 - The accessibility quarantine is removed (Priority: P3)
+
+Spec 020 had to quarantine the `color-contrast` rule on two Dialog stories to ship, pointing the suppression comments at this work. This story removes that quarantine and confirms the accessibility gate passes for those stories on its own merits, with no accessibility rules disabled.
+
+**Why this priority**: Removing the quarantine is the visible "done" signal and restores full gate enforcement on the affected stories. It is genuinely valuable but strictly downstream: it can only happen once the contrast actually passes, so it sits last.
+
+**Independent Test**: Remove the `color-contrast` suppression from the two affected Dialog stories and run the accessibility gate. Confirm both pass with no rules disabled.
+
+**Acceptance Scenarios**:
+
+1. **Given** the contrast fix is in place, **When** the `color-contrast` quarantine is removed from the two affected Dialog stories, **Then** the accessibility gate passes for both with no accessibility rules disabled.
+2. **Given** the quarantine is gone, **When** the full accessibility gate runs, **Then** no popover-surface contrast violation is reported on any Dialog, Tooltip, or Select story.
+
+---
+
+### Edge Cases
+
+- **Dark scheme**: dark themes often invert which pairs pass. The popover surface and its muted text must meet AA in dark, not only light, and the surface must stay fully opaque there.
+- **Alternate identities**: the brand and vaporwave identities ship their own authored palettes. Each must carry a valid popover surface pair, or theme validation must flag a missing or out-of-AA pair loudly rather than silently shipping an inaccessible surface.
+- **No shared-token change**: the fix sets the popover pair to each theme's existing `background` / `foreground` values and changes no shared color, so it cannot regress an existing pair. The matrix validation still re-runs every pair to confirm this rather than assuming it.
+- **Surfaces beyond Dialog**: Tooltip and Select content use the same popover surface. They must remain accessible after the change even though only the Dialog stories were quarantined; the fix must not improve Dialog at their expense.
+- **Consumer themes**: if the popover surface becomes a token the schema requires, a consumer-authored theme that omits it must fail validation loudly, consistent with how the design system already validates declared contrast pairs, rather than rendering a transparent or inaccessible surface.
+- **Large vs normal text**: the AA threshold is 4.5:1 for normal text and 3:1 for large text. The description is normal text and must clear 4.5:1; the validation must apply the right threshold per text role.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The popover surface used by the Dialog, Tooltip, and Select content components MUST resolve to a defined, fully opaque background color. No content behind the surface may show through it.
+- **FR-002**: The popover surface MUST have a defined foreground (text) color paired with that background.
+- **FR-003**: Text rendered on the popover surface — including the Dialog description that currently uses the muted-foreground color — MUST meet WCAG AA contrast against that surface: at least 4.5:1 for normal text and at least 3:1 for large text.
+- **FR-004**: The automated token-level contrast suite MUST add and validate two popover pairs — `popover-foreground` / `popover` and `muted-foreground` / `popover` — across every shipped combination of color scheme, identity, and density, mirroring the two-pair coverage the base `background` already has. Every combination MUST meet WCAG AA.
+- **FR-005**: The fix MUST NOT change `muted-foreground` or any other shared color value. It defines `color.popover` equal to each theme's `background` and `color.popover-foreground` equal to `foreground`, so the Dialog description passes through the existing `muted-foreground` / `background` relationship, and no text-on-background pair the design system already validates may regress.
+- **FR-006**: The `color-contrast` accessibility quarantine on the two affected Dialog stories MUST be removed, and the accessibility gate MUST pass for those stories with no accessibility rules disabled.
+- **FR-007**: The change MUST NOT alter the public API or rendered structure of the Dialog, Tooltip, or Select components. This is a token and styling correction, and the components continue to consume the popover surface the same way.
+- **FR-008**: The popover surface ships as a new canonical token pair (`color.popover` + `color.popover-foreground`) in the schema, authored per theme cell. Theme validation MUST cover the popover pairs so a theme that omits them or declares them below AA fails validation loudly rather than shipping silently.
+
+### Key Entities
+
+- **Popover surface**: the shared background-plus-foreground color pair that Dialog content, Tooltip content, and Select content render themselves on. Today the components reference it but the design system does not define it. This feature defines it as a new canonical token pair (`color.popover` + `color.popover-foreground`) in the schema, authored per theme cell.
+- **Muted-text-on-popover pair**: the combination of the muted-foreground text color and the popover background that the Dialog description renders. This is the pair that fails AA today and must pass after the fix.
+- **Theme matrix**: the full grid of shipped color-scheme, identity, and density combinations against which the corrected pairs must be validated. Light/default is one cell; dark, brand, and vaporwave are the cells most likely to expose a regression.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The Dialog description text, and any muted text on a popover surface, meets WCAG AA contrast (at least 4.5:1 for normal text) against its surface in every shipped theme combination.
+- **SC-002**: The Dialog, Tooltip, and Select content surfaces each render fully opaque, with none of the content behind them visible through the surface.
+- **SC-003**: 100% of the shipped color-scheme, identity, and density combinations pass the popover surface and on-surface text contrast check, with zero failing combinations.
+- **SC-004**: The two previously quarantined Dialog stories pass the accessibility gate with zero accessibility rules disabled.
+- **SC-005**: No text-on-background pair that passed before this change regresses below WCAG AA — the full token contrast validation stays green.
+
+## Assumptions
+
+- The popover surface is defined as a new canonical token pair (`color.popover` + `color.popover-foreground`) in the token schema, authored per color scheme and identity, rather than repointing the components to an existing surface token (clarified 2026-06-17). The components keep referencing the popover surface unchanged; the gap is closed in the token set.
+- The contrast fix follows the precedent set when the destructive Button pair was corrected: define or adjust the token values, then validate the affected pairs across the theme matrix with an automated check, rather than hand-tuning a single story.
+- Defining the opaque popover surface as each theme's `background` value resolves the contrast failure with no `muted-foreground` change (clarified 2026-06-17). The description's `muted-foreground` text then resolves to the already-validated `muted-foreground` / `background` pair, which clears AA in every shipped cell. The failure today is purely that the surface is transparent, so the muted text is measured against the overlay bleed-through rather than the base surface.
+- The change is confined to design tokens and the styling those tokens drive. No component public API, prop, or structural change is in scope.
+- Verification reuses the existing automated accessibility gate on stories and the existing token-level contrast validation across the theme matrix. No new test infrastructure is assumed.
+
+## Dependencies
+
+- Depends on spec 020 (the test-runner layer-order fix that made token styling resolve in the gate, which is what surfaced this failure). Without it the gate measures unstyled components and the defect stays hidden.
+- Follows the model of spec 018 (the destructive-Button AA contrast fix) for correcting a token-driven contrast pair and validating it across the theme matrix.
+- Blocks removal of the `color-contrast` quarantine that spec 020 added to the two affected Dialog stories.

--- a/specs/022-popover-tokens-contrast/tasks.md
+++ b/specs/022-popover-tokens-contrast/tasks.md
@@ -1,0 +1,173 @@
+# Tasks: Popover tokens and the Dialog description contrast fix
+
+**Input**: Design documents from `/specs/022-popover-tokens-contrast/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/ ✓, quickstart.md ✓
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, US4)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Establish a clean baseline before any edits.
+
+- [X] T001 Run `pnpm --filter @unbranded-ds/tokens build && pnpm --filter @unbranded-ds/tokens test` from the repo root to confirm the tokens build and test suite pass clean before any changes
+
+**Checkpoint**: Baseline is green — story work can begin.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define the canonical popover token pair in the schema and token map — these changes gate all user story phases.
+
+**⚠️ CRITICAL**: All three tasks must complete before palette files or tests can be edited.
+
+- [X] T002 Add `popover` and `popover-foreground` keys to the `colorTokens` Zod object in `packages/tokens/src/schema.ts`, following the `background`/`foreground` pattern already present (both are required `z.string()` entries — required so a composed theme that omits either fails validation, which G1/FR-008 depend on)
+- [X] T003 Append two entries to the exported `contrastPairs` array in `packages/tokens/src/schema.ts`: `{ foreground: 'color.popover-foreground', background: 'color.popover', threshold: 4.5 }` and `{ foreground: 'color.muted-foreground', background: 'color.popover', threshold: 4.5 }` — array length grows from 6 to 8
+- [X] T004 [P] Add two hand-authored entries to `packages/tokens/src/token-map.ts`: one for `color.popover` and one for `color.popover-foreground`, each with `source: 'schema'`, `category: 'color'`, `type: 'color'`, and `cssVariable` set to `--color-popover` and `--color-popover-foreground` respectively, matching the existing `color.background` entry pattern
+
+**Checkpoint**: Schema and token map declare the pair — palette files can now be authored in parallel.
+
+---
+
+## Phase 3: User Story 1 — Popover surfaces have a real, opaque background (Priority: P1) 🎯 MVP
+
+**Goal**: Author the popover pair in all six shipped palette files so the token build emits `--color-popover` and `--color-popover-foreground` in every color-scheme × identity cell.
+
+**Independent Test**: Open a Dialog, Tooltip, and Select menu in the default light theme and confirm each content surface resolves to a concrete, fully opaque background color with no bleed-through.
+
+- [X] T005 [P] [US1] Read `packages/tokens/src/tokens/color.json` to find its `background` and `foreground` values, then add `"popover"` and `"popover-foreground"` DTCG entries (`$value` + `$type: "color"`) under the `color` object, each value equal to the matching base entry in this file
+- [X] T006 [P] [US1] Read `packages/tokens/themes/color-scheme/dark.json` to find its `background` and `foreground` values, then add `"popover"` and `"popover-foreground"` DTCG entries under the `color` object, each value equal to the matching entry in this file
+- [X] T007 [P] [US1] Read `packages/tokens/themes/theme/brand/light.json` to find its `background` and `foreground` values, then add `"popover"` and `"popover-foreground"` DTCG entries under the `color` object, each value equal to the matching entry in this file
+- [X] T008 [P] [US1] Read `packages/tokens/themes/theme/brand/dark.json` to find its `background` and `foreground` values, then add `"popover"` and `"popover-foreground"` DTCG entries under the `color` object, each value equal to the matching entry in this file
+- [X] T009 [P] [US1] Read `packages/tokens/themes/theme/vaporwave/light.json` to find its `background` and `foreground` values, then add `"popover"` and `"popover-foreground"` DTCG entries under the `color` object, each value equal to the matching entry in this file
+- [X] T010 [P] [US1] Read `packages/tokens/themes/theme/vaporwave/dark.json` to find its `background` and `foreground` values, then add `"popover"` and `"popover-foreground"` DTCG entries under the `color` object, each value equal to the matching entry in this file
+- [X] T011 [US1] Run `pnpm --filter @unbranded-ds/tokens build` to regenerate `packages/tokens/src/defaults.generated.ts`, the Tailwind preset at `packages/tokens/dist/tailwind/preset.css`, and the per-theme CSS artifacts — do not hand-edit these files; then run `rg -n "color-popover" packages/tokens/dist/tailwind/preset.css` to confirm the utilities are present
+
+**Checkpoint**: The build emits `--color-popover` and `--color-popover-foreground` in every theme cell and the preset exposes `bg-popover` / `text-popover-foreground`. User Story 1 is independently verifiable.
+
+---
+
+## Phase 4: User Story 2 — Dialog description text meets WCAG AA (Priority: P1)
+
+**Goal**: Update the test count assertions that would otherwise fail on the new pair count, then run the token test suite to confirm the contrast passes in the default-light cell.
+
+**Independent Test**: Run `pnpm --filter @unbranded-ds/tokens test` and confirm the suite passes green, including that the Dialog description's `muted-foreground`/`popover` pair measures at least 4.5:1 in the default-light cell.
+
+- [X] T012 [US2] Update the `toHaveLength(6)` assertion on `contrastPairs` to `toHaveLength(8)` in `packages/tokens/src/schema.test.ts`; also scan for any color-token-count assertion in that file and update it to account for the two new `colorTokens` keys
+- [X] T013 [US2] Read `packages/tokens/src/defaults.test.ts` and update any hard-coded token-count or baseline-shape assertions that would fail after `defaults.generated.ts` was regenerated by T011 to include `popover` and `popover-foreground`
+- [X] T014 [US2] Run `pnpm --filter @unbranded-ds/tokens test` and confirm `schema.test.ts`, `defaults.test.ts`, and `themes-contrast.test.ts` all pass green
+
+**Checkpoint**: Full token test suite passes. The Dialog description clears AA in default light through the existing `muted-foreground`/`background` relationship.
+
+---
+
+## Phase 5: User Story 3 — The fix holds across the whole theme matrix (Priority: P2)
+
+**Goal**: Confirm the matrix test auto-derives coverage for the two new pairs across all six cells — no edit to `themes-contrast.test.ts` is needed — add a completeness assertion for the omission case, and re-run the suite verbose to see each cell pass explicitly.
+
+**Independent Test**: Re-run `pnpm --filter @unbranded-ds/tokens test --reporter=verbose` and confirm `themes-contrast.test.ts` reports passing for `color.popover-foreground`/`color.popover` and `color.muted-foreground`/`color.popover` in all six cells (default-light, default-dark, brand-light, brand-dark, vaporwave-light, vaporwave-dark).
+
+- [X] T015 [P] [US3] Read `packages/tokens/src/themes-contrast.test.ts` and confirm the matrix loop derives its pairs from the exported `contrastPairs` array (it should iterate `contrastPairs` directly) — verify that no edit to this file is needed and document that the two new pairs are covered automatically by the T003 schema change
+- [X] T016 [US3] (Optional, closes FR-008's omission guarantee) Add a completeness assertion in `packages/tokens/src/schema.test.ts`: a composed/partial theme that omits `popover` or `popover-foreground` MUST fail `validateComposedTheme` (or the theme validator) with a coded completeness issue, not pass silently. If the existing required-key validation already has a generic completeness test that this case rides on, note that instead of duplicating it. (This file is also edited by T012 — sequence after it.)
+- [X] T017 [US3] Run `pnpm --filter @unbranded-ds/tokens test --reporter=verbose` and inspect the output to confirm all six theme cells report passing for both `color.popover-foreground`/`color.popover` and `color.muted-foreground`/`color.popover`, plus the T016 completeness assertion; if any cell fails, read that palette file and confirm its `popover` value matches its `background` exactly. Density is intentionally not a separate axis here: density tokens carry no color, so the popover/background contrast is invariant across densities — the six color-scheme × identity cells are the full color matrix (per data-model.md).
+
+**Checkpoint**: All six cells pass for both popover pairs and a theme omitting the pair fails loudly. No theme ships a transparent or below-AA popover surface.
+
+---
+
+## Phase 6: User Story 4 — The accessibility quarantine is removed (Priority: P3)
+
+**Goal**: Remove the two `color-contrast` suppressions from the Dialog stories and confirm the accessibility gate passes with no rules disabled.
+
+**Independent Test**: Run `pnpm --filter @unbranded-ds/react test` and confirm the react component tests pass after the stories change; then confirm `rg -n "color-contrast" packages/react/src/components/Dialog/Dialog.stories.tsx` returns no matches.
+
+- [X] T018 [US4] Remove the `color-contrast` accessibility suppression from the `OpenCloseInteraction` story in `packages/react/src/components/Dialog/Dialog.stories.tsx` — locate the `parameters.a11y.config.rules` block that disables `color-contrast` and delete it
+- [X] T019 [US4] Remove the `color-contrast` accessibility suppression from the `TooltipStacksAboveDialog` story in `packages/react/src/components/Dialog/Dialog.stories.tsx` — locate its `parameters.a11y.config.rules` block and delete it
+- [X] T020 [US4] Run `pnpm --filter @unbranded-ds/react test` and confirm the react component test suite passes; also confirm `rg -n "color-contrast" packages/react/src/components/Dialog/Dialog.stories.tsx` returns nothing
+
+**Checkpoint**: Quarantine is gone, gate is clean. Dialog accessibility is enforced on its own merits.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [X] T021 [P] Write `.changeset/<slug>.md` declaring `@unbranded-ds/tokens` minor and `@unbranded-ds/react` patch; describe the fix in the changeset body and run it through the humanizer skill before saving — the minor bump reflects the additive canonical token (partial consumer themes inherit the default rather than breaking); the react patch records the now-opaque surface in react's changelog. If T002/T003 or a palette file gained an explanatory comment or `$description` ("popover equals background"), run that prose through the humanizer in this pass too
+- [X] T022 Run the 7 verification steps in `specs/022-popover-tokens-contrast/quickstart.md` end to end to confirm the full feature is correct; address any step that fails before marking the feature complete
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 passing — **blocks all story phases**
+- **US1 (Phase 3)**: Depends on Phase 2; T005–T010 are parallel; T011 depends on T005–T010
+- **US2 (Phase 4)**: Depends on T011 (build must regenerate artifacts before test fixes make sense)
+- **US3 (Phase 5)**: T015 can start after T003 (schema change defines contrastPairs); T016 edits `schema.test.ts` so it sequences after T012; T017 depends on T014 and T016 (the final verify run covers the matrix and the completeness assertion)
+- **US4 (Phase 6)**: Can start in parallel with US2/US3 after Phase 2 — the stories change is independent of the test-count fixes; T018 and T019 edit the same file, so run them sequentially; T020 depends on T018 and T019
+- **Polish (Phase 7)**: Depends on all prior phases complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Foundational only — no dependency on other stories
+- **US2 (P1)**: Depends on US1 (T011 build) — test assertions reference the regenerated artifacts
+- **US3 (P2)**: T015 depends on Foundational; T016 (optional) edits `schema.test.ts`, so it follows T012; T017 depends on US2 (T014 test run) and T016
+- **US4 (P3)**: Depends on Foundational only — the stories change is independent; T020 confirms the whole fix works
+
+### Parallel Opportunities
+
+Within Phase 3, T005–T010 are six independent palette files — all six can run concurrently:
+
+```bash
+# Launch all six palette edits simultaneously:
+Task: "Add popover pair to packages/tokens/src/tokens/color.json"
+Task: "Add popover pair to packages/tokens/themes/color-scheme/dark.json"
+Task: "Add popover pair to packages/tokens/themes/theme/brand/light.json"
+Task: "Add popover pair to packages/tokens/themes/theme/brand/dark.json"
+Task: "Add popover pair to packages/tokens/themes/theme/vaporwave/light.json"
+Task: "Add popover pair to packages/tokens/themes/theme/vaporwave/dark.json"
+```
+
+T004 (token-map.ts) can run in parallel with T002/T003 (schema.ts) since they are different files.
+
+T018 and T019 both edit `Dialog.stories.tsx`, so they are **not** parallel — run them sequentially as two edits to the same file.
+
+---
+
+## Implementation Strategy
+
+### MVP (User Stories 1 + 2)
+
+1. Complete Phase 1: baseline check
+2. Complete Phase 2: schema + token map
+3. Complete Phase 3 (T005–T011): six palette files + build
+4. Complete Phase 4 (T012–T014): test count fixes + test run
+5. **Stop and validate**: token test suite passes green
+6. Story 1 (opaque surface) and Story 2 (AA in default light) are now done
+
+### Incremental Delivery
+
+1. Phase 1 + 2 → schema defines the pair
+2. Phase 3 → build emits `--color-popover` across all cells (US1 done, surfaces render opaque)
+3. Phase 4 → test suite confirms AA in default light (US2 done)
+4. Phase 5 → matrix coverage confirmed across all six cells, omission fails loudly (US3 done)
+5. Phase 6 → quarantine removed, gate clean (US4 done)
+6. Phase 7 → changeset written, quickstart verified
+
+---
+
+## Notes
+
+- `defaults.generated.ts` is auto-generated by `sd.config.ts` — never hand-edit it; it regenerates in T011
+- `themes-contrast.test.ts` requires no edit — its matrix loop auto-covers new `contrastPairs` entries
+- Each palette file is a complete color declaration; all six must carry the pair explicitly (the dark and brand cells have their own distinct `background` values, so they cannot inherit from the base)
+- The popover `$value` in each palette file must exactly match that file's `background` `$value` — copy it, do not retype
+- T020 (react tests) verifies component behavior only; the Storybook a11y gate (`pnpm --filter @unbranded-ds/storybook test:storybook`) is the definitive quarantine-removal proof and is covered in T022 via quickstart step 5


### PR DESCRIPTION
## Summary

`Dialog`, `Tooltip`, and `Select` content all style themselves with `bg-popover` / `text-popover-foreground`, but the color schema never defined a `popover` token; only `--z-index-popover` existed. Those classes resolved to unset CSS variables, so the surfaces rendered with no fill. That transparency, not the text color, is why the Storybook a11y gate measured the Dialog description at 3.98:1: it was reading `muted-foreground` against the overlay bleeding through, not against a real panel.

This adds `popover` and `popover-foreground` as canonical color tokens, authored per theme cell as a flat copy of that cell's `background` / `foreground`. Elevation stays visual, from the components' existing ring and shadow. Because `muted-foreground` on `background` is already a validated AA pair, the description clears AA on the new surface with no `muted-foreground` change.

## What Changed

- `colorTokens` gains `popover` / `popover-foreground` as required keys, plus two contrast pairs (`popover-foreground`/`popover` and `muted-foreground`/`popover`) so a theme that omits the pair or drifts below AA fails the build.
- All six shipped cells (default, brand, and vaporwave, each in light and dark) declare the pair from their own background and foreground. Each is a complete palette, so inheriting the base would hand the dark and brand cells the light surface.
- The token map registers both as `source: 'schema'`, so the token-query MCP exposes them with no MCP change.
- The spec-020 `color-contrast` quarantine comes off the two Dialog stories.

## Validation

- Token suite green (146 tests). The matrix contrast test auto-covers both new pairs across all six cells with no test edit, since it derives from `contrastPairs`. A new completeness test proves a theme omitting the pair fails `themeSchema` loudly.
- Storybook a11y gate passes for all four Dialog stories in Chromium with the quarantine gone, so the two formerly-suppressed stories now clear axe `color-contrast` on their own merits.
- React unit tests green (150). No component source changed; the surfaces go opaque through the emitted token, not through markup.

## Versioning

`@unbranded-ds/tokens` minor (additive canonical token; a consumer's partial theme inherits the default, so non-breaking) and `@unbranded-ds/react` patch (the surfaces render opaque for consumers, and the PR touches `packages/react`).
