### PR TITLE
Expressivity token scales (tracking + larger radii): LCARS hits zero blockers

### DIFF
--- a/.changeset/expressivity-token-scales.md
+++ b/.changeset/expressivity-token-scales.md
@@ -1,0 +1,9 @@
+---
+'@unbranded-ds/tokens': minor
+---
+
+Add a `tracking` (letter-spacing) scale and larger `radius` steps, the two token scales a maximally divergent skin (the LCARS expressivity fixture) could not express through tokens before.
+
+`tracking` is its own top-level category, like `motion`, that emits Tailwind's `--tracking-*` namespace (`tracking-tighter` through `tracking-widest`). `radius` gains `xl` (0.75rem), `2xl` (1rem), and `3xl` (1.5rem) between `lg` and the full pill; an asymmetric corner composes per-corner from the scale.
+
+Both are required keys. The built-in themes inherit the new defaults and need no change. A fully-specified external theme must add the new keys, which is the breaking part of this pre-1.0 minor bump.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,13 @@
 # heliostat Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-06-17
+Auto-generated from all feature plans. Last updated: 2026-06-18
 
 ## Active Technologies
 - TypeScript 5.x, strict, no `any` (Constitution VIII). React 19. + `@base-ui-components/react` (peer), the existing `lib/warn.ts` helper, `lib/cn`. No new dependencies. (021-form-control-a11y-naming)
 - N/A — a dev-only console warning; no runtime or persisted state. (021-form-control-a11y-naming)
 - TypeScript 5.x, strict, no `any` (Constitution VIII). DTCG JSON token sources. + Style Dictionary v4 (the token build, `sd.config.ts`), Zod (the theme schema + `contrastPairs`), the `color.ts` WCAG contrast math, Tailwind CSS v4 (`@theme` preset auto-maps `--color-*` to utilities), `@modelcontextprotocol/sdk` (the token-query MCP reads the token map). No new dependencies. (022-popover-tokens-contrast)
 - N/A — build-time DTCG JSON compiled to CSS variables, a Tailwind preset, JSON, and a typed token map. No runtime or persisted state. (022-popover-tokens-contrast)
+- TypeScript 5.x, strict, no `any` (Constitution VIII) + Style Dictionary v4 (the token build, `sd.config.ts`), Zod (theme schema + `contrastPairs`), Tailwind CSS v4 (`@theme` preset maps `--tracking-*` / `--radius-*` to utilities). No new dependencies. (023-expressivity-token-scales)
 
 - TypeScript 5.x, strict, no `any` (Constitution VIII). React 19, Next.js 15 (App Router). + `next` ^15, `react`/`react-dom` 19, `@unbranded-ds/tokens` and `@unbranded-ds/react` at `workspace:*`, Tailwind CSS v4 (consumed through `@unbranded-ds/react/preset.css`), `next/font/local` (self-hosted font), `@playwright/test`, `@axe-core/playwright`. (015-nextjs-example-app)
 - `localStorage` only, through the design system's existing keys (`unbranded-ds-theme`, `unbranded-ds-density`, `unbranded-ds-theme-preference`). No new storage. (015-nextjs-example-app)
@@ -65,10 +66,10 @@ npm test && npm run lint
 TypeScript 5.x, strict mode, no `any` (EVER): Follow standard conventions
 
 ## Recent Changes
+- 023-expressivity-token-scales: Added TypeScript 5.x, strict, no `any` (Constitution VIII) + Style Dictionary v4 (the token build, `sd.config.ts`), Zod (theme schema + `contrastPairs`), Tailwind CSS v4 (`@theme` preset maps `--tracking-*` / `--radius-*` to utilities). No new dependencies.
 - 022-popover-tokens-contrast: Added TypeScript 5.x, strict, no `any` (Constitution VIII). DTCG JSON token sources. + Style Dictionary v4 (the token build, `sd.config.ts`), Zod (the theme schema + `contrastPairs`), the `color.ts` WCAG contrast math, Tailwind CSS v4 (`@theme` preset auto-maps `--color-*` to utilities), `@modelcontextprotocol/sdk` (the token-query MCP reads the token map). No new dependencies.
 - 021-form-control-a11y-naming: Added TypeScript 5.x, strict, no `any` (Constitution VIII). React 19. + `@base-ui-components/react` (peer), the existing `lib/warn.ts` helper, `lib/cn`. No new dependencies.
 
-- 020-storybook-zindex-test-env: Added TypeScript 5.x, strict, no `any` (Constitution VIII) + Vitest 3 (browser mode), `@vitest/browser` + `playwright` (Chromium), `@storybook/addon-vitest` (`storybookTest()`), `@storybook/addon-a11y`, Storybook 10.3 `@storybook/react-vite`, Tailwind CSS v4 (`@tailwindcss/vite`; the preset's `@theme inline` block)
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/THEMING.md
+++ b/THEMING.md
@@ -14,7 +14,7 @@ A **token-source override** is a build-time file under `packages/tokens/themes/`
 // packages/tokens/themes/sunset.json: a token-source override (DTCG)
 {
 	"color": { "primary": { "$value": "oklch(0.65 0.2 35)", "$type": "color" } },
-	"radius": { "md": { "$value": "0.75rem", "$type": "dimension" } }
+	"radius": { "md": { "$value": "0.75rem", "$type": "dimension" } },
 }
 ```
 
@@ -27,8 +27,8 @@ A **runtime theme document** is a flat object passed to `registerTheme()` or `va
 	"displayName": "Sunset",
 	"tokens": {
 		"color": { "primary": "oklch(0.65 0.2 35)" },
-		"radius": { "md": "0.75rem" }
-	}
+		"radius": { "md": "0.75rem" },
+	},
 }
 ```
 
@@ -116,8 +116,7 @@ const result = validateTheme(myTheme);
 
 if (result.ok) {
 	console.log('Theme is valid!');
-}
-else {
+} else {
 	for (const issue of result.issues) {
 		console.error(`${issue.code}: ${issue.message} (at ${issue.path})`);
 	}
@@ -294,18 +293,18 @@ The built-in `brand` theme shows this. On top of its color palette it rounds the
 	"radius": {
 		"sm": { "$value": "0.375rem", "$type": "dimension" },
 		"md": { "$value": "0.5rem", "$type": "dimension" },
-		"lg": { "$value": "0.75rem", "$type": "dimension" }
+		"lg": { "$value": "0.75rem", "$type": "dimension" },
 	},
 	"typography": {
 		"font-sans": {
 			"$value": "\"Inter\", ui-sans-serif, system-ui, sans-serif",
-			"$type": "fontFamily"
-		}
-	}
+			"$type": "fontFamily",
+		},
+	},
 }
 ```
 
-It overrides three of the four radius stops and one typography token. `radius.full` and every other typography value (including `size-2xl`) go unmentioned, so they inherit. The resolved `tokens-brand.css` carries the rounded radii and the Inter stack next to the inherited defaults.
+It overrides three of the seven radius stops and one typography token. `radius.full` and every other typography value (including `size-2xl`) go unmentioned, so they inherit. The resolved `tokens-brand.css` carries the rounded radii and the Inter stack next to the inherited defaults.
 
 A runtime theme document does the same with flat values:
 
@@ -313,11 +312,29 @@ A runtime theme document does the same with flat values:
 {
 	"name": "rounded",
 	"displayName": "Rounded",
-	"tokens": { "radius": { "md": "0.75rem", "lg": "1rem" } }
+	"tokens": { "radius": { "md": "0.75rem", "lg": "1rem" } },
 }
 ```
 
 `validateTheme` resolves this against the defaults before checking, so the omitted categories are present in the validated result.
+
+### Tracking and chunky corners
+
+The `tracking` scale carries letter-spacing, from `tracking-tighter` to `tracking-widest`, the way the type scale carries weight and leading. A theme sets wide all-caps tracking, or the tight tracking a dense layout wants, through the token rather than a raw value:
+
+```jsonc
+{
+	"tokens": { "tracking": { "widest": "0.15em" } },
+}
+```
+
+The radius scale runs `sm` through `3xl`, then `full` (a pill). An asymmetric corner, the kind an LCARS panel uses, composes per-corner from those tokens, so a theme expresses it without a raw length:
+
+```css
+[data-slot='card'] {
+	border-radius: var(--radius-3xl) 0 var(--radius-3xl) 0;
+}
+```
 
 ## Theme-extension tokens
 
@@ -329,8 +346,8 @@ Declare it like any other token, in the theme JSON, under whatever category fits
 // themes/theme/vaporwave/dark.json (excerpt)
 {
 	"shadow": {
-		"neon": { "$value": "0 0 12px 2px oklch(0.7200 0.2000 330.00 / 0.6)", "$type": "shadow" }
-	}
+		"neon": { "$value": "0 0 12px 2px oklch(0.7200 0.2000 330.00 / 0.6)", "$type": "shadow" },
+	},
 }
 ```
 
@@ -357,7 +374,7 @@ And the token-query MCP reports the same `source`. Ask `lookupToken` for `shadow
 	"source": "theme-extension",
 	"present": true,
 	"cssVariable": "--shadow-neon",
-	"value": "0 0 12px 2px oklch(0.7200 0.2000 330.00 / 0.6)"
+	"value": "0 0 12px 2px oklch(0.7200 0.2000 330.00 / 0.6)",
 }
 ```
 
@@ -376,12 +393,12 @@ When a token you need does not exist in the schema, you add it to the canonical 
 	"motion": {
 		"duration": {
 			"fast": { "$value": "120ms", "$type": "duration" },
-			"base": { "$value": "240ms", "$type": "duration" }
+			"base": { "$value": "240ms", "$type": "duration" },
 		},
 		"easing": {
-			"standard": { "$value": "cubic-bezier(0.4, 0, 0.2, 1)", "$type": "cubicBezier" }
-		}
-	}
+			"standard": { "$value": "cubic-bezier(0.4, 0, 0.2, 1)", "$type": "cubicBezier" },
+		},
+	},
 }
 ```
 

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -29,13 +29,13 @@ The contract is the whole point. A skin may add any expressive surface it likes,
 
 ## Where It Stands
 
-One skin so far, **LCARS**, and the audit reads 5 blockers, every one a real gap:
+One skin so far, **LCARS**, and the audit reads **0** blockers. It started at 5, all from two missing token scales; spec 023 added them, so the skin now expresses its complete look through tokens alone:
 
-| Axis  | Count | What LCARS needed        | The DS gap                                                      |
-| ----- | ----- | ------------------------ | -------------------------------------------------------------- |
-| shape | 2     | asymmetric "elbow" radii | radius tokens are scalar (sm/md/lg/full); no per-corner channel |
-| type  | 3     | wide all-caps tracking   | no `letter-spacing` token exists                               |
+| Axis  | Was | What LCARS needed        | How it's expressed now                                                            |
+| ----- | --- | ------------------------ | --------------------------------------------------------------------------------- |
+| shape | 2   | asymmetric "elbow" radii | composed per-corner from the radius scale, now with chunky `xl`/`2xl`/`3xl` steps |
+| type  | 3   | wide all-caps tracking   | the `tracking` scale, through `--tracking-*`                                      |
 
-Everything else LCARS wanted (its amber/mauve/black palette, flat shadowless surfaces, condensed type) went through the validated pipeline cleanly, contrast-checked, zero blockers. Both LCARS cells pass the token-level contrast suite, and the rendered axe pass is clean in light and dark.
+Everything else LCARS wanted (its amber/mauve/black palette, flat shadowless surfaces, condensed type) always went through the validated pipeline. Both LCARS cells pass the token-level contrast suite, and the rendered axe pass stays clean in light and dark, so the skin is fully expressible with the accessibility contract intact.
 
-That table is the backlog. The two gaps, a tracking (letter-spacing) token and a way to express asymmetric radii, are the first entries for spec 023. More skins (a dense enterprise grid, a glass-and-glow console) will surface the axes LCARS doesn't touch: texture, motion, density.
+Next skins (a dense enterprise grid, a glass-and-glow console) will stress the axes LCARS doesn't touch: texture, motion, density.

--- a/fixtures/expressivity-report.json
+++ b/fixtures/expressivity-report.json
@@ -1,61 +1,8 @@
 {
-  "$generated": "scripts/expressivity-audit.mjs",
-  "total": 5,
-  "byType": {
-    "LITERAL": 5
-  },
-  "byAxis": {
-    "shape": 2,
-    "type": 3
-  },
-  "byFixture": {
-    "fixtures/themes/lcars": 5
-  },
-  "findings": [
-    {
-      "file": "fixtures/themes/lcars/parts.css",
-      "type": "LITERAL",
-      "line": 22,
-      "prop": "border-radius",
-      "msg": "border-radius: 1.75rem 0 1.75rem 0",
-      "axis": "shape",
-      "remedy": "Add a \"shape\" token for \"border-radius\" so themes route through var() instead of a raw value."
-    },
-    {
-      "file": "fixtures/themes/lcars/parts.css",
-      "type": "LITERAL",
-      "line": 29,
-      "prop": "border-radius",
-      "msg": "border-radius: 1.75rem 0 0 0",
-      "axis": "shape",
-      "remedy": "Add a \"shape\" token for \"border-radius\" so themes route through var() instead of a raw value."
-    },
-    {
-      "file": "fixtures/themes/lcars/parts.css",
-      "type": "LITERAL",
-      "line": 30,
-      "prop": "letter-spacing",
-      "msg": "letter-spacing: 0.18em",
-      "axis": "type",
-      "remedy": "Add a \"type\" token for \"letter-spacing\" so themes route through var() instead of a raw value."
-    },
-    {
-      "file": "fixtures/themes/lcars/parts.css",
-      "type": "LITERAL",
-      "line": 35,
-      "prop": "letter-spacing",
-      "msg": "letter-spacing: 0.1em",
-      "axis": "type",
-      "remedy": "Add a \"type\" token for \"letter-spacing\" so themes route through var() instead of a raw value."
-    },
-    {
-      "file": "fixtures/themes/lcars/parts.css",
-      "type": "LITERAL",
-      "line": 42,
-      "prop": "letter-spacing",
-      "msg": "letter-spacing: 0.12em",
-      "axis": "type",
-      "remedy": "Add a \"type\" token for \"letter-spacing\" so themes route through var() instead of a raw value."
-    }
-  ]
+	"$generated": "scripts/expressivity-audit.mjs",
+	"total": 0,
+	"byType": {},
+	"byAxis": {},
+	"byFixture": {},
+	"findings": []
 }

--- a/fixtures/themes/index.json
+++ b/fixtures/themes/index.json
@@ -7,7 +7,7 @@
 			"dir": "fixtures/themes/lcars",
 			"meta": "fixtures/themes/lcars/meta.json",
 			"stressesAxes": ["shape", "type-tracking"],
-			"blockers": 5
+			"blockers": 0
 		}
 	]
 }

--- a/fixtures/themes/lcars/meta.json
+++ b/fixtures/themes/lcars/meta.json
@@ -19,8 +19,9 @@
 	},
 	"guard": "Storybook test-runner (addon-a11y axe) under [data-theme=lcars], both color schemes",
 	"blockers": {
-		"total": 5,
-		"byAxis": { "type": 3, "shape": 2 },
-		"source": "fixtures/expressivity-report.json"
+		"total": 0,
+		"byAxis": {},
+		"source": "fixtures/expressivity-report.json",
+		"closedBy": "spec 023 (tracking + larger radius scales)"
 	}
 }

--- a/fixtures/themes/lcars/parts.css
+++ b/fixtures/themes/lcars/parts.css
@@ -18,27 +18,27 @@
  */
 
 /* The signature LCARS panel: one squared elbow, the rest rounded away. */
-[data-theme="lcars"] [data-slot="card"] {
+[data-theme='lcars'] [data-slot='card'] {
 	border-radius: 1.75rem 0 1.75rem 0;
 	overflow: hidden;
 }
 
 /* The header reads as the LCARS elbow bar — squared into the panel's corner,
    set in wide all-caps. The tracking is a raw length; no tracking token exists. */
-[data-theme="lcars"] [data-slot="card-header"] {
+[data-theme='lcars'] [data-slot='card-header'] {
 	border-radius: 1.75rem 0 0 0;
-	letter-spacing: 0.18em;
+	letter-spacing: var(--tracking-widest);
 	text-transform: uppercase;
 }
 
-[data-theme="lcars"] [data-slot="card-title"] {
-	letter-spacing: 0.1em;
+[data-theme='lcars'] [data-slot='card-title'] {
+	letter-spacing: var(--tracking-widest);
 	text-transform: uppercase;
 }
 
 /* LCARS controls are flat caps in wide tracking. The pill rides the existing
    radius-full token (no literal); only the tracking has no channel. */
-[data-theme="lcars"] [data-slot="button"] {
-	letter-spacing: 0.12em;
+[data-theme='lcars'] [data-slot='button'] {
+	letter-spacing: var(--tracking-widest);
 	text-transform: uppercase;
 }

--- a/fixtures/themes/lcars/parts.css
+++ b/fixtures/themes/lcars/parts.css
@@ -19,14 +19,14 @@
 
 /* The signature LCARS panel: one squared elbow, the rest rounded away. */
 [data-theme='lcars'] [data-slot='card'] {
-	border-radius: 1.75rem 0 1.75rem 0;
+	border-radius: var(--radius-3xl) 0 var(--radius-3xl) 0;
 	overflow: hidden;
 }
 
 /* The header reads as the LCARS elbow bar — squared into the panel's corner,
    set in wide all-caps. The tracking is a raw length; no tracking token exists. */
 [data-theme='lcars'] [data-slot='card-header'] {
-	border-radius: 1.75rem 0 0 0;
+	border-radius: var(--radius-3xl) 0 0 0;
 	letter-spacing: var(--tracking-widest);
 	text-transform: uppercase;
 }

--- a/packages/tokens/sd.config.ts
+++ b/packages/tokens/sd.config.ts
@@ -25,10 +25,8 @@ import { AXIS_ATTRIBUTE } from './src/axes.js';
 function flattenedName(token: TransformedToken): string {
 	if (token.path[0] === 'motion') {
 		const [, group, key] = token.path;
-		if (group === 'duration')
-			return `duration-${key}`;
-		if (group === 'easing')
-			return `ease-${key}`;
+		if (group === 'duration') return `duration-${key}`;
+		if (group === 'easing') return `ease-${key}`;
 	}
 	return token.name;
 }
@@ -94,8 +92,7 @@ StyleDictionary.registerFormat({
 	format: async (args) => {
 		const layer = (args.options as { layer?: string }).layer ?? 'ds';
 		const builtin = StyleDictionary.hooks.formats['css/variables'];
-		if (!builtin)
-			throw new Error('built-in css/variables format not found');
+		if (!builtin) throw new Error('built-in css/variables format not found');
 		const body = await builtin(args);
 		// Indent the built-in body one level so it reads as nested in the layer,
 		// and keep the auto-generated header comment outside the layer block.
@@ -141,20 +138,20 @@ StyleDictionary.registerFormat({
 	name: 'typescript/token-map',
 	format: ({ dictionary }) => {
 		const categoryMap: Record<string, string> = {
-			'color': 'color',
-			'spacing': 'spacing',
-			'typography': 'typography',
-			'radius': 'radii',
-			'shadow': 'shadows',
-			'opacity': 'opacity',
-			'motion': 'motion',
-			'ring': 'ring',
+			color: 'color',
+			spacing: 'spacing',
+			typography: 'typography',
+			radius: 'radii',
+			tracking: 'tracking',
+			shadow: 'shadows',
+			opacity: 'opacity',
+			motion: 'motion',
+			ring: 'ring',
 			'z-index': 'z-index',
 		};
 
 		const entries = dictionary.allTokens.map((token) => {
-			const category
-				= categoryMap[token.path[0] ?? ''] ?? token.path[0] ?? 'unknown';
+			const category = categoryMap[token.path[0] ?? ''] ?? token.path[0] ?? 'unknown';
 			return `  "${token.path.join('.')}": {
     name: "${token.path.join('.')}",
     category: "${category}" as const,
@@ -163,7 +160,7 @@ StyleDictionary.registerFormat({
   }`;
 		});
 
-		return `export type TokenCategory = "color" | "spacing" | "typography" | "radii" | "shadows" | "opacity" | "motion" | "ring" | "z-index";
+		return `export type TokenCategory = "color" | "spacing" | "typography" | "radii" | "tracking" | "shadows" | "opacity" | "motion" | "ring" | "z-index";
 
 export type TokenDefinition = {
   name: string;
@@ -212,9 +209,7 @@ StyleDictionary.registerFormat({
 // single resolver: the MCP and the defaults baseline read THIS, instead of a
 // hand-maintained copy (defaults) or a re-walk of the raw source (the MCP).
 // ---------------------------------------------------------------------------
-function flatResolved(
-	allTokens: TransformedToken[],
-): Record<string, Record<string, unknown>> {
+function flatResolved(allTokens: TransformedToken[]): Record<string, Record<string, unknown>> {
 	const out: Record<string, Record<string, unknown>> = {};
 	for (const token of allTokens) {
 		const category = String(token.path[0]);
@@ -227,8 +222,7 @@ function flatResolved(
 
 StyleDictionary.registerFormat({
 	name: 'json/resolved-layer',
-	format: ({ dictionary }) =>
-		`${JSON.stringify(flatResolved(dictionary.allTokens), null, 2)}\n`,
+	format: ({ dictionary }) => `${JSON.stringify(flatResolved(dictionary.allTokens), null, 2)}\n`,
 });
 
 StyleDictionary.registerFormat({
@@ -259,8 +253,7 @@ function jsonNames(dir: string): string[] {
 			.filter((f) => f.endsWith('.json'))
 			.map((f) => f.replace(/\.json$/, ''))
 			.sort();
-	}
-	catch {
+	} catch {
 		return [];
 	}
 }
@@ -347,13 +340,11 @@ function cleanPerCellArtifacts() {
 		for (const f of (() => {
 			try {
 				return readdirSync(dir);
-			}
-			catch {
+			} catch {
 				return [];
 			}
 		})()) {
-			if (pattern.test(f))
-				rmSync(join(dir, f));
+			if (pattern.test(f)) rmSync(join(dir, f));
 		}
 	}
 }
@@ -389,8 +380,7 @@ async function build() {
 		});
 		await sd.buildAllPlatforms();
 
-		if (!e.deltaSource)
-			continue;
+		if (!e.deltaSource) continue;
 		const sdDelta = new StyleDictionary({
 			source: e.deltaSource,
 			log: { warnings: 'disabled' },
@@ -398,9 +388,7 @@ async function build() {
 				json: {
 					transformGroup: 'css-motion',
 					buildPath: 'dist/json/themes/',
-					files: [
-						{ destination: `${e.artifact}.json`, format: 'json/resolved-layer' },
-					],
+					files: [{ destination: `${e.artifact}.json`, format: 'json/resolved-layer' }],
 				},
 			},
 		});
@@ -417,9 +405,7 @@ async function build() {
 			css: {
 				transformGroup: 'css-motion',
 				buildPath: 'dist/css/',
-				files: [
-					{ destination: 'layer-order.css', format: 'css/layer-order' },
-				],
+				files: [{ destination: 'layer-order.css', format: 'css/layer-order' }],
 			},
 		},
 	});

--- a/packages/tokens/src/__fixtures__/valid-custom.json
+++ b/packages/tokens/src/__fixtures__/valid-custom.json
@@ -59,6 +59,9 @@
 			"sm": "0.25rem",
 			"md": "0.375rem",
 			"lg": "0.5rem",
+			"xl": "0.75rem",
+			"2xl": "1rem",
+			"3xl": "1.5rem",
 			"full": "9999px"
 		},
 		"shadow": {

--- a/packages/tokens/src/__fixtures__/valid-custom.json
+++ b/packages/tokens/src/__fixtures__/valid-custom.json
@@ -77,6 +77,14 @@
 			"easing-standard": "cubic-bezier(0.4, 0, 0.2, 1)",
 			"easing-decelerate": "cubic-bezier(0, 0, 0.2, 1)",
 			"easing-accelerate": "cubic-bezier(0.4, 0, 1, 1)"
+		},
+		"tracking": {
+			"tighter": "-0.05em",
+			"tight": "-0.025em",
+			"normal": "0em",
+			"wide": "0.025em",
+			"wider": "0.05em",
+			"widest": "0.1em"
 		}
 	}
 }

--- a/packages/tokens/src/defaults.generated.ts
+++ b/packages/tokens/src/defaults.generated.ts
@@ -2,23 +2,23 @@
 import type { Theme } from './schema.js';
 
 export const canonicalDefaultTokens = {
-	'color': {
-		'background': 'oklch(1.0000 0.0000 89.88)',
-		'foreground': 'oklch(0.1408 0.0044 285.82)',
-		'primary': 'oklch(0.2103 0.0059 285.89)',
+	color: {
+		background: 'oklch(1.0000 0.0000 89.88)',
+		foreground: 'oklch(0.1408 0.0044 285.82)',
+		primary: 'oklch(0.2103 0.0059 285.89)',
 		'primary-foreground': 'oklch(0.9851 0.0000 89.88)',
-		'muted': 'oklch(0.9674 0.0013 286.38)',
+		muted: 'oklch(0.9674 0.0013 286.38)',
 		'muted-foreground': 'oklch(0.5434 0.0138 285.94)',
-		'border': 'oklch(0.9197 0.0040 286.32)',
-		'ring': 'oklch(0.2103 0.0059 285.89)',
-		'destructive': 'oklch(0.5803 0.2078 25.33)',
+		border: 'oklch(0.9197 0.0040 286.32)',
+		ring: 'oklch(0.2103 0.0059 285.89)',
+		destructive: 'oklch(0.5803 0.2078 25.33)',
 		'destructive-foreground': 'oklch(0.9851 0.0000 89.88)',
 		'destructive-subtle': 'oklch(0.9300 0.0500 25.33)',
 		'destructive-subtle-foreground': 'oklch(0.4400 0.1600 25.33)',
-		'popover': 'oklch(1.0000 0.0000 89.88)',
+		popover: 'oklch(1.0000 0.0000 89.88)',
 		'popover-foreground': 'oklch(0.1408 0.0044 285.82)',
 	},
-	'motion': {
+	motion: {
 		'duration-fast': '120ms',
 		'duration-base': '240ms',
 		'duration-slow': '480ms',
@@ -26,46 +26,56 @@ export const canonicalDefaultTokens = {
 		'easing-decelerate': 'cubic-bezier(0, 0, 0.2, 1)',
 		'easing-accelerate': 'cubic-bezier(0.4, 0, 1, 1)',
 	},
-	'opacity': {
+	opacity: {
 		disabled: '0.5',
 		hover: '0.8',
 	},
-	'radius': {
+	radius: {
 		sm: '0.25rem',
 		md: '0.375rem',
 		lg: '0.5rem',
 		full: '9999px',
 	},
-	'ring': {
+	ring: {
 		width: '3px',
 	},
-	'shadow': {
+	shadow: {
 		sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
 		md: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
 		lg: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
 	},
-	'spacing': {
-		1: '0.25rem',
-		2: '0.5rem',
-		3: '0.75rem',
-		4: '1rem',
-		5: '1.25rem',
-		6: '1.5rem',
-		7: '1.75rem',
-		8: '2rem',
-		9: '2.25rem',
-		10: '2.5rem',
-		11: '2.75rem',
-		12: '3rem',
-		13: '3.25rem',
-		14: '3.5rem',
-		15: '3.75rem',
-		16: '4rem',
+	spacing: {
+		'1': '0.25rem',
+		'2': '0.5rem',
+		'3': '0.75rem',
+		'4': '1rem',
+		'5': '1.25rem',
+		'6': '1.5rem',
+		'7': '1.75rem',
+		'8': '2rem',
+		'9': '2.25rem',
+		'10': '2.5rem',
+		'11': '2.75rem',
+		'12': '3rem',
+		'13': '3.25rem',
+		'14': '3.5rem',
+		'15': '3.75rem',
+		'16': '4rem',
 		px: '1px',
 	},
-	'typography': {
-		'font-sans': 'ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
-		'font-mono': 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+	tracking: {
+		tighter: '-0.05em',
+		tight: '-0.025em',
+		normal: '0em',
+		wide: '0.025em',
+		wider: '0.05em',
+		widest: '0.1em',
+	},
+	typography: {
+		'font-sans':
+			'ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+		'font-mono':
+			'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
 		'font-serif': 'ui-serif, Georgia, Cambria, "Times New Roman", Times, serif',
 		'size-sm': '0.875rem',
 		'size-base': '1rem',

--- a/packages/tokens/src/defaults.generated.ts
+++ b/packages/tokens/src/defaults.generated.ts
@@ -34,6 +34,9 @@ export const canonicalDefaultTokens = {
 		sm: '0.25rem',
 		md: '0.375rem',
 		lg: '0.5rem',
+		xl: '0.75rem',
+		'2xl': '1rem',
+		'3xl': '1.5rem',
 		full: '9999px',
 	},
 	ring: {

--- a/packages/tokens/src/schema.test.ts
+++ b/packages/tokens/src/schema.test.ts
@@ -136,28 +136,57 @@ describe('themeSchema — motion category (required)', () => {
 	});
 });
 
-describe('themeSchema — new required typography keys', () => {
-	it.each(['font-serif', 'size-2xl', 'size-3xl'])(
-		'requires typography.%s',
+describe('themeSchema — tracking category (required, spec 023)', () => {
+	it('accepts a complete theme carrying the tracking category', () => {
+		const result = themeSchema.safeParse(completeTheme);
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects a complete theme missing the entire tracking category', () => {
+		const theme = structuredClone(completeTheme);
+		delete (theme.tokens as Record<string, unknown>).tracking;
+		const result = themeSchema.safeParse(theme);
+		expect(result.success).toBe(false);
+	});
+
+	it.each(['tighter', 'tight', 'normal', 'wide', 'wider', 'widest'])(
+		'requires tracking.%s',
 		(key) => {
 			const theme = structuredClone(completeTheme);
-			delete (theme.tokens.typography as Record<string, unknown>)[key];
+			delete (theme.tokens.tracking as Record<string, unknown>)[key];
 			const result = themeSchema.safeParse(theme);
 			expect(result.success).toBe(false);
 		},
 	);
+
+	it('names the missing token in the structured issue (FR-007)', () => {
+		const theme = structuredClone(completeTheme);
+		delete (theme.tokens.tracking as Record<string, unknown>).widest;
+		const result = themeSchema.safeParse(theme);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const paths = result.error.issues.map((i) => i.path.join('.'));
+			expect(paths).toContain('tokens.tracking.widest');
+		}
+	});
+});
+
+describe('themeSchema — new required typography keys', () => {
+	it.each(['font-serif', 'size-2xl', 'size-3xl'])('requires typography.%s', (key) => {
+		const theme = structuredClone(completeTheme);
+		delete (theme.tokens.typography as Record<string, unknown>)[key];
+		const result = themeSchema.safeParse(theme);
+		expect(result.success).toBe(false);
+	});
 });
 
 describe('themeSchema — popover color (required, spec 022)', () => {
-	it.each(['popover', 'popover-foreground'])(
-		'rejects a complete theme missing color.%s',
-		(key) => {
-			const theme = structuredClone(completeTheme);
-			delete (theme.tokens.color as Record<string, unknown>)[key];
-			const result = themeSchema.safeParse(theme);
-			expect(result.success).toBe(false);
-		},
-	);
+	it.each(['popover', 'popover-foreground'])('rejects a complete theme missing color.%s', (key) => {
+		const theme = structuredClone(completeTheme);
+		delete (theme.tokens.color as Record<string, unknown>)[key];
+		const result = themeSchema.safeParse(theme);
+		expect(result.success).toBe(false);
+	});
 });
 
 describe('themeSchema — ring and z-index are optional', () => {
@@ -207,7 +236,7 @@ describe('partialThemeSchema — optional ring/z-index inheritance', () => {
 			name: 'drift-only',
 			displayName: 'Drift Only',
 			tokens: {
-				'ring': { width: '2px' },
+				ring: { width: '2px' },
 				'z-index': { overlay: '40', popover: '45', tooltip: '50' },
 			},
 		};
@@ -220,6 +249,16 @@ describe('partialThemeSchema — optional ring/z-index inheritance', () => {
 			name: 'no-drift',
 			displayName: 'No Drift',
 			tokens: { radius: { md: '0.5rem' } },
+		};
+		const result = partialThemeSchema.safeParse(partial);
+		expect(result.success).toBe(true);
+	});
+
+	it('parses a partial theme overriding only part of tracking (spec 023 FR-002)', () => {
+		const partial = {
+			name: 'wide-only',
+			displayName: 'Wide Only',
+			tokens: { tracking: { widest: '0.15em' } },
 		};
 		const result = partialThemeSchema.safeParse(partial);
 		expect(result.success).toBe(true);

--- a/packages/tokens/src/schema.ts
+++ b/packages/tokens/src/schema.ts
@@ -80,6 +80,9 @@ const radiiTokens = z.object({
 	sm: z.string(),
 	md: z.string(),
 	lg: z.string(),
+	xl: z.string(),
+	'2xl': z.string(),
+	'3xl': z.string(),
 	full: z.string(),
 });
 

--- a/packages/tokens/src/schema.ts
+++ b/packages/tokens/src/schema.ts
@@ -9,15 +9,15 @@ import { z } from 'zod';
 // ---------------------------------------------------------------------------
 
 const colorTokens = z.object({
-	'background': z.string(),
-	'foreground': z.string(),
-	'primary': z.string(),
+	background: z.string(),
+	foreground: z.string(),
+	primary: z.string(),
 	'primary-foreground': z.string(),
-	'muted': z.string(),
+	muted: z.string(),
 	'muted-foreground': z.string(),
-	'border': z.string(),
-	'ring': z.string(),
-	'destructive': z.string(),
+	border: z.string(),
+	ring: z.string(),
+	destructive: z.string(),
 	'destructive-foreground': z.string(),
 	// The soft destructive treatment (spec 018): an opaque subtle destructive
 	// surface and a darker destructive text/icon color that clears AA on it. The
@@ -31,7 +31,7 @@ const colorTokens = z.object({
 	// transparent panel. Authored flat-equal to background/foreground per cell;
 	// the components carry their elevation as ring + shadow, so the surface needs
 	// no distinct tone (spec 022).
-	'popover': z.string(),
+	popover: z.string(),
 	'popover-foreground': z.string(),
 });
 
@@ -112,6 +112,18 @@ const motionTokens = z.object({
 	'easing-accelerate': z.string(),
 });
 
+// Letter-spacing scale (spec 023). Its own top-level category that emits the
+// Tailwind-aligned `--tracking-*` names, mirroring how `motion` is its own
+// category emitting `--duration-*` / `--ease-*` rather than `--motion-*`.
+const trackingTokens = z.object({
+	tighter: z.string(),
+	tight: z.string(),
+	normal: z.string(),
+	wide: z.string(),
+	wider: z.string(),
+	widest: z.string(),
+});
+
 // ring + z-index are the optional drift-killing categories (spec 008 US4): a
 // theme that omits them inherits the canonical defaults, so they never break an
 // existing color-only theme. Optional-ness is applied at the category level in
@@ -133,14 +145,15 @@ const zIndexTokens = z.object({
 // The `z-index` key carries a hyphen, so the lint rule quotes every sibling key
 // for consistency; the emitted dot-paths stay `z-index.overlay` etc.
 const tokensSchema = z.object({
-	'color': colorTokens,
-	'spacing': spacingTokens,
-	'typography': typographyTokens,
-	'radius': radiiTokens,
-	'shadow': shadowTokens,
-	'opacity': opacityTokens,
-	'motion': motionTokens,
-	'ring': ringTokens.optional(),
+	color: colorTokens,
+	spacing: spacingTokens,
+	typography: typographyTokens,
+	radius: radiiTokens,
+	tracking: trackingTokens,
+	shadow: shadowTokens,
+	opacity: opacityTokens,
+	motion: motionTokens,
+	ring: ringTokens.optional(),
 	'z-index': zIndexTokens.optional(),
 });
 

--- a/packages/tokens/src/tokens/radii.json
+++ b/packages/tokens/src/tokens/radii.json
@@ -12,6 +12,18 @@
 			"$value": "0.5rem",
 			"$type": "dimension"
 		},
+		"xl": {
+			"$value": "0.75rem",
+			"$type": "dimension"
+		},
+		"2xl": {
+			"$value": "1rem",
+			"$type": "dimension"
+		},
+		"3xl": {
+			"$value": "1.5rem",
+			"$type": "dimension"
+		},
 		"full": {
 			"$value": "9999px",
 			"$type": "dimension"

--- a/packages/tokens/src/tokens/tracking.json
+++ b/packages/tokens/src/tokens/tracking.json
@@ -1,0 +1,10 @@
+{
+	"tracking": {
+		"tighter": { "$value": "-0.05em", "$type": "dimension" },
+		"tight": { "$value": "-0.025em", "$type": "dimension" },
+		"normal": { "$value": "0em", "$type": "dimension" },
+		"wide": { "$value": "0.025em", "$type": "dimension" },
+		"wider": { "$value": "0.05em", "$type": "dimension" },
+		"widest": { "$value": "0.1em", "$type": "dimension" }
+	}
+}

--- a/specs/023-expressivity-token-scales/checklists/requirements.md
+++ b/specs/023-expressivity-token-scales/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Expressivity token scales (tracking and larger radii)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.
+- Two decisions were deliberately left as assumptions with reasonable defaults rather than `[NEEDS CLARIFICATION]` markers, since each has a clear default from existing repo precedent. `/speckit.clarify` is the right place to confirm or override them:
+  - The emitted CSS-variable name for the tracking scale (Tailwind-aligned `--tracking-*` like the motion tokens, vs the category-prefixed `--typography-tracking-*`). This is an implementation detail and is intentionally absent from the requirements; it is recorded here for the planning and clarify steps.
+  - Whether the new token keys are added as required (the assumed default, matching spec 008) or optional.

--- a/specs/023-expressivity-token-scales/contracts/token-scales.md
+++ b/specs/023-expressivity-token-scales/contracts/token-scales.md
@@ -1,0 +1,53 @@
+# Contract: Token scales (tracking + extended radius)
+
+The tokens package exposes its tokens as a public contract: the emitted CSS variables, the Tailwind utilities those generate, the typed token map, and the Zod validation shape. This document states what 023 adds to that contract.
+
+## Emitted CSS variables
+
+New variables, present in every per-cell `dist/css/tokens-*.css` (scoped under the cell selector) and mapped in `dist/tailwind/preset.css`:
+
+```
+--tracking-tighter  --tracking-tight  --tracking-normal
+--tracking-wide     --tracking-wider  --tracking-widest
+--radius-xl         --radius-2xl      --radius-3xl
+```
+
+Existing variables are unchanged in name and value.
+
+## Tailwind utilities
+
+The preset maps each variable, so these utilities resolve:
+
+```
+tracking-tighter … tracking-widest      (letter-spacing)
+rounded-xl  rounded-2xl  rounded-3xl     (border-radius)
+```
+
+A theme author or component reaches the tokens through the utility or the variable; neither requires importing from `@unbranded-ds/tokens` at runtime (Constitution IV).
+
+## Typed token map
+
+`dist/ts/tokens.ts` gains entries for each new token, with `category: "tracking"` for the tracking scale and `category: "radii"` for the new radius steps, each carrying its `cssVariable`. `dist/json/tokens.json` gains the same entries. Downstream consumers (Figma sync, agents, the token-query MCP) read these.
+
+## Validation contract
+
+`validateTheme()` and `registerTheme()` continue to return the typed `{ ok: boolean, issues: ValidationIssue[] }` shape. The only change:
+
+- A complete (fully-specified) theme MUST now declare the `tracking` category and the new radius keys. A theme that omits a required new key fails with a structured issue:
+
+```jsonc
+{ "ok": false, "issues": [ { "code": "...", "path": "tracking.widest", "message": "..." } ] }
+```
+
+- A partial theme (the common case) that omits them still validates: the missing keys inherit `canonicalDefaultTokens`. This is unchanged behavior; only the set of required keys grew.
+
+Contrast validation is unaffected: the `contrastPairs` reference only color tokens, and tracking and radius are not color.
+
+## Token-query MCP
+
+No tool signature changes. `palette('tracking')` returns the resolved tracking values; `lookupToken('tracking.widest')` resolves to its value and `--tracking-widest` variable; the new radius keys appear in `palette('radius')`. These are automatic once the sources carry the tokens (the tools read the resolved map), and are verified during implementation rather than coded.
+
+## Backward compatibility
+
+- Every pre-existing token keeps its name and value (SC-003), so no existing theme's rendered output changes.
+- The added required keys are a breaking change only for a fully-specified external consumer theme, announced by the `@unbranded-ds/tokens` minor bump (0.5.0 → 0.6.0).

--- a/specs/023-expressivity-token-scales/data-model.md
+++ b/specs/023-expressivity-token-scales/data-model.md
@@ -1,0 +1,51 @@
+# Phase 1 Data Model: Expressivity token scales
+
+The "data" here is two token scales added to the canonical schema. Both are build-time DTCG sources compiled to the four artifacts; neither has runtime or persisted state.
+
+## Entity: Tracking scale
+
+A new top-level token category, `tracking`, holding letter-spacing values.
+
+| Field (key) | Value | Emitted variable | Tailwind utility |
+|-------------|-------|------------------|------------------|
+| `tighter` | `-0.05em` | `--tracking-tighter` | `tracking-tighter` |
+| `tight` | `-0.025em` | `--tracking-tight` | `tracking-tight` |
+| `normal` | `0em` | `--tracking-normal` | `tracking-normal` |
+| `wide` | `0.025em` | `--tracking-wide` | `tracking-wide` |
+| `wider` | `0.05em` | `--tracking-wider` | `tracking-wider` |
+| `widest` | `0.1em` | `--tracking-widest` | `tracking-widest` |
+
+- **DTCG type**: `dimension` (em values; same `$type` family as the existing sizing tokens).
+- **Schema**: a `trackingTokens` Zod object with the six required keys, added to `tokensSchema` as a required category.
+- **Relationships**: a sibling of the other token categories. Overridable per theme like any category (a theme may set its own tracking values, whole or in part).
+- **Validation rules**: all six keys required in the strict (merged) `themeSchema`. A fully-specified theme missing one fails validation with a structured issue naming the path (e.g. `tracking.widest`).
+
+## Entity: Radius scale (extended)
+
+The existing `radius` category, grown with three larger steps. Existing keys are unchanged.
+
+| Field (key) | Value | Status | Emitted variable |
+|-------------|-------|--------|------------------|
+| `sm` | `0.25rem` | unchanged | `--radius-sm` |
+| `md` | `0.375rem` | unchanged | `--radius-md` |
+| `lg` | `0.5rem` | unchanged | `--radius-lg` |
+| `xl` | `0.75rem` | **new** | `--radius-xl` |
+| `2xl` | `1rem` | **new** | `--radius-2xl` |
+| `3xl` | `1.5rem` | **new** | `--radius-3xl` |
+| `full` | `9999px` | unchanged | `--radius-full` |
+
+- **DTCG type**: `dimension`, matching the existing radius tokens.
+- **Schema**: `radiiTokens` gains `xl`, `2xl`, `3xl` as required keys.
+- **Relationships**: the same category components already consume via `rounded-*` utilities and `var(--radius-*)`.
+- **Validation rules**: the three new keys required in the strict schema. Existing key values are unchanged, so no existing theme's rendered output changes (SC-003).
+- **Composition rule**: an asymmetric corner is expressed by composing per-corner radius tokens (`border-radius: var(--radius-3xl) 0 var(--radius-3xl) 0`); no new per-corner token type exists.
+
+## Inheritance and migration
+
+- `canonicalDefaultTokens` (the generated baseline in `defaults.generated.ts`) is regenerated from the base sources, so it carries the new tracking and radius defaults.
+- Built-in themes are partial overrides merged onto the defaults. None override `tracking` or the new radius keys, so all inherit the defaults and need no edits.
+- A fully-specified external consumer theme (one declaring every token) must add the new keys or it fails validation. This is the announced breaking change, carried by the `@unbranded-ds/tokens` 0.5.0 → 0.6.0 minor bump.
+
+## State transitions
+
+None. Tokens are static build-time values.

--- a/specs/023-expressivity-token-scales/plan.md
+++ b/specs/023-expressivity-token-scales/plan.md
@@ -1,0 +1,77 @@
+# Implementation Plan: Expressivity token scales (tracking and larger radii)
+
+**Branch**: `023-expressivity-token-scales` | **Date**: 2026-06-18 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/023-expressivity-token-scales/spec.md`
+
+## Summary
+
+Grow the canonical token schema by two scales so divergent themes express their full look through tokens instead of raw values: a `tracking` (letter-spacing) scale and larger `radius` steps that fill the gap between `lg` and the full pill. Both adopt Tailwind v4's scales as their basis. The reference skin (the LCARS fixture from the expressivity spike) is rerouted through the new tokens and the expressivity audit drops from 5 blockers to 0, while the contrast suite and the Storybook a11y pass stay green. This is additive schema growth on the spec 008 model: new required keys carried by the base sources, so the built-in themes inherit them and only a fully-specified external consumer theme sees a breaking change, announced by a tokens version bump.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, strict, no `any` (Constitution VIII)  
+**Primary Dependencies**: Style Dictionary v4 (the token build, `sd.config.ts`), Zod (theme schema + `contrastPairs`), Tailwind CSS v4 (`@theme` preset maps `--tracking-*` / `--radius-*` to utilities). No new dependencies.  
+**Storage**: N/A — build-time DTCG JSON compiled to CSS variables, a Tailwind preset, JSON, and a typed token map. No runtime or persisted state.  
+**Testing**: Vitest in `packages/tokens` (`schema.test`, `validate.test`, `themes-contrast.test`, `defaults.test`, `token-map.test`), the Storybook a11y test-runner over the LCARS fixture stories, and `scripts/expressivity-audit.mjs` as the acceptance instrument.  
+**Target Platform**: build-time tokens consumed by React + Tailwind in the browser.  
+**Project Type**: pnpm monorepo; this feature touches `packages/tokens` (schema, sources, defaults) and the root `fixtures/` corpus (the reference-skin reroute).  
+**Performance Goals**: N/A (build-time token emission).  
+**Constraints**: the new tokens MUST flow to all four emitted artifacts (Constitution II); the emitted value of every pre-existing token MUST be unchanged (SC-003); WCAG AA contrast on declared pairs MUST be preserved (tracking and radius are not color, so no contrast impact is expected).  
+**Scale/Scope**: 1 schema file, 1 `sd.config` token-map type edit, 2 DTCG sources (one new `tracking.json`, one edited `radii.json`), 1 regenerated defaults module, ~2 test updates plus 2 validation assertions, 1 fixture reroute, 1 docs note, 1 changeset.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+- **Section II (tokens → four artifacts)**: PASS. The CSS variables, Tailwind preset, and JSON emitters are category-agnostic, so the new tokens flow to them automatically. The one exception is the TS token map: its format hardcodes a `TokenCategory` union and `categoryMap` in `sd.config.ts`, so the brand-new `tracking` category must be added there (task T004a) or the generated `tokens.ts` fails typecheck. Radius adds keys to an existing category and needs no such edit.
+- **Section III (schema locked, values float)**: PASS. Growing the canonical set is the sanctioned move (the lock binds the set; it does not forbid deliberate additions — precedent spec 008). New keys are required; themes remain validated against the grown schema; values still float per theme. No new theme-extension tokens.
+- **Section VIII (tooling baseline)**: PASS. Style Dictionary, Zod, Tailwind v4, TypeScript strict — no substitutions, no new tools, no `any`.
+- **Section X (governance)**: PASS with action. This touches `packages/tokens`, so the PR MUST carry a `.changeset/*.md` (a minor bump on the spec 008 model). Tracked as a task.
+- [x] **Section XI — legibility (REQUIRED gate)**: PASS, no concessions.
+  - **Prose (XI.1)**: the THEMING.md additions (the tracking scale, composing asymmetric radii from the scale) pass through the `humanizer` skill; no three-item lists.
+  - **API shape (XI.2)**: the new tokens are predictable from analogy — `--tracking-*` is the Tailwind letter-spacing namespace (the way `motion` emits `--duration-*` / `--ease-*`), and `--radius-xl/2xl/3xl` extend the existing Tailwind-named radius scale.
+  - **Docs surfaces (XI.3)**: the token-query MCP (`palette`, `lookupToken`) reads the resolved token map, so the new tokens surface automatically once the sources carry them. Verified as a Phase 0 task; no MCP code change expected.
+  - **Failure modes (XI.4)**: a fully-specified theme that omits a newly required token fails `validateTheme()` with the existing structured `{ ok, issues: [{ code, path, message }] }` shape (FR-007).
+  - **Story coverage (XI.5)**: the LCARS fixture stories already exercise the skin; after the reroute they still run under the a11y test-runner in both schemes.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/023-expressivity-token-scales/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (the two token scales)
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── token-scales.md  # Phase 1 output (the token + validation contract)
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source code (repository root)
+
+```text
+packages/tokens/
+├── src/
+│   ├── schema.ts                 # ADD: trackingTokens category + radius xl/2xl/3xl keys
+│   ├── tokens/
+│   │   ├── tracking.json         # NEW: the letter-spacing scale (DTCG source)
+│   │   └── radii.json            # EDIT: add xl / 2xl / 3xl
+│   ├── defaults.generated.ts     # REGENERATED by the build (do not hand-edit)
+│   ├── schema.test.ts            # EDIT if it pins the category set
+│   └── token-map.test.ts         # EDIT if it pins the token set
+└── sd.config.ts                  # EDIT: add "tracking" to the TokenCategory union + categoryMap (token-map format)
+
+fixtures/themes/lcars/
+└── parts.css                     # EDIT: reroute tracking + elbow radius through the new tokens
+
+THEMING.md                        # EDIT: tracking scale + asymmetric-radius composition note
+.changeset/<name>.md              # NEW: @unbranded-ds/tokens minor bump
+```
+
+**Structure Decision**: This is a tokens-package schema growth plus a one-file fixture reroute. No new packages or directories (Constitution I). The reference skin lives in the root `fixtures/` corpus introduced by the expressivity spike this branch stacks on.
+
+## Complexity Tracking
+
+No constitution violations. No entries.

--- a/specs/023-expressivity-token-scales/quickstart.md
+++ b/specs/023-expressivity-token-scales/quickstart.md
@@ -1,0 +1,65 @@
+# Quickstart: Expressivity token scales
+
+## Using the new tokens
+
+Wide all-caps tracking through a token (instead of a raw `letter-spacing`):
+
+```css
+[data-theme="my-skin"] [data-slot="card-title"] {
+	letter-spacing: var(--tracking-widest); /* or tracking-wide / tracking-wider */
+	text-transform: uppercase;
+}
+```
+
+Or via the Tailwind utility on a component:
+
+```tsx
+<CardTitle className="tracking-widest uppercase">Navigation</CardTitle>
+```
+
+A chunky, asymmetric "elbow" corner, composed per-corner from radius tokens (no raw length):
+
+```css
+[data-theme="my-skin"] [data-slot="card"] {
+	border-radius: var(--radius-3xl) 0 var(--radius-3xl) 0;
+}
+```
+
+A theme overrides the scales like any other category (partial is fine; the rest inherits):
+
+```json
+{
+	"tokens": {
+		"tracking": { "widest": "0.15em" },
+		"radius": { "3xl": "1.75rem" }
+	}
+}
+```
+
+## Verifying the change
+
+From the repo root, after editing the schema and sources:
+
+```bash
+# 1. Rebuild the tokens (regenerates dist + defaults.generated.ts)
+pnpm --filter @unbranded-ds/tokens build
+
+# 2. Tokens tests: schema, validation, contrast, defaults regenerate-and-diff
+pnpm --filter @unbranded-ds/tokens test
+
+# 3. The acceptance metric: the reference skin reads zero blockers
+node scripts/expressivity-audit.mjs            # EXPRESSIVITY BLOCKERS: 0
+
+# 4. The invariant contract: the skin stays accessible under the new tokens
+pnpm --filter @unbranded-ds/react build        # the fixture imports the built package
+pnpm --filter @unbranded-ds/storybook exec vitest run --project storybook -t "LCARS"
+```
+
+## Definition of done (acceptance)
+
+- `node scripts/expressivity-audit.mjs` prints `EXPRESSIVITY BLOCKERS: 0` (down from 5) — SC-001.
+- The LCARS stories pass the a11y test-runner in light and dark — SC-002.
+- The tokens test suite is green, including `defaults.test` (regenerate-and-diff) and `themes-contrast.test` — SC-003.
+- A theme author can express wide/tight tracking and chunky/asymmetric corners with no raw length on a design-system node — SC-004.
+- THEMING.md documents the tracking scale and the per-corner radius composition (humanized).
+- A `.changeset/*.md` declares the `@unbranded-ds/tokens` minor bump.

--- a/specs/023-expressivity-token-scales/research.md
+++ b/specs/023-expressivity-token-scales/research.md
@@ -1,0 +1,82 @@
+# Phase 0 Research: Expressivity token scales
+
+The clarify step resolved the user-facing decisions (emitted name `--tracking-*`, required keys, Tailwind-aligned scales with the skin adapting). This document records the implementation-shape decisions that follow from them.
+
+## Decision 1 — Tracking lives in its own top-level `tracking` category
+
+- **Decision**: Author tracking as a new top-level token category named `tracking`, a sibling of `color`, `typography`, `radius`, `motion`, etc., rather than as keys inside `typography`.
+- **Rationale**: The clarify chose the emitted name `--tracking-*` (the Tailwind letter-spacing namespace). When the category is `tracking`, the build's default kebab name for `tracking.wide` is already `tracking-wide`, so it emits `--tracking-wide` with no rename. This mirrors the precedent set by `motion`, which is its own top-level category that emits Tailwind-aligned names. It also matches Tailwind v4's own structure, where letter-spacing (`--tracking-*`) is a separate theme namespace from font and text size.
+- **Adjusts a spec assumption**: the spec's Key Entities call tracking "part of the typography category." That framing predates the emitted-name clarify; a sibling category is the natural, rename-free home for a `--tracking-*` scale and is invisible to consumers (they use the `tracking-*` utility or the `--tracking-*` variable regardless). The spec's intent — a tracking scale referenced like weight and leading — is preserved.
+- **Alternatives considered**: keep tracking inside `typography` and special-case it in `sd.config.ts`'s `flattenedName` to rename `typography.tracking-*` → `tracking-*` (the motion-rename mechanism). Rejected as a needless rename hack when an own-category emits the target name directly, and because one typography key emitting a non-`--typography-` name is more surprising than a clean sibling category.
+
+## Decision 2 — Tracking stops and values: Tailwind v4's letter-spacing scale
+
+- **Decision**: Six stops matching Tailwind v4's defaults.
+
+  | key | value |
+  |-----|-------|
+  | tighter | -0.05em |
+  | tight | -0.025em |
+  | normal | 0em |
+  | wide | 0.025em |
+  | wider | 0.05em |
+  | widest | 0.1em |
+
+- **Rationale**: Matches Tailwind so the `tracking-*` utilities resolve as consumers expect. Covers both extremes the fixtures need: `widest` (0.1em) for the LCARS console look, `tighter`/`tight` for the dense enterprise grid that comes next. `normal: 0em` gives a token for the default so a theme can reset tracking explicitly.
+- **Alternatives considered**: a wider top stop (~0.18em) to match LCARS exactly — rejected by the clarify (the skin adapts to `widest`; the default vocabulary stays curated).
+
+## Decision 3 — Radius steps and values: extend with Tailwind's xl/2xl/3xl
+
+- **Decision**: Add three steps to the existing radius scale.
+
+  | key | value | source |
+  |-----|-------|--------|
+  | xl | 0.75rem | new |
+  | 2xl | 1rem | new |
+  | 3xl | 1.5rem | new |
+
+  The existing `sm 0.25 / md 0.375 / lg 0.5rem / full 9999px` are unchanged.
+- **Rationale**: The existing `sm/md/lg` already match Tailwind v4, so `xl/2xl/3xl` continue the Tailwind scale and fill the gap between `lg` (0.5rem) and the full pill. LCARS's 1.75rem elbow routes to `3xl` (1.5rem), the nearest chunky stop, per the clarify.
+- **Alternatives considered**: add `4xl` (2rem, also a Tailwind v4 default) so LCARS's 1.75rem rounds up rather than down. Deferred — `3xl` is close enough for the skin to read as intended, and `4xl` can be added later if a fixture needs it (that is exactly the audit signal the experiment is designed to produce).
+
+## Decision 4 — Required keys, carried by the base sources
+
+- **Decision**: The `tracking` category and the new `radius` keys are required in the strict `themeSchema`. The base DTCG sources (`tracking.json`, `radii.json`) carry default values for all of them.
+- **Rationale**: Matches spec 008 (motion and the larger type sizes were added required). Because the base sources carry the values, `canonicalDefaultTokens` (regenerated into `defaults.generated.ts`) inherits them, and every built-in theme — which is a partial override merged onto the defaults — inherits them too, so no built-in theme JSON needs editing. The only break is for a fully-specified external consumer theme, announced by the version bump.
+- **Validation path**: `partialThemeSchema.deepPartial()` still parses a partial consumer theme; the validator merges onto defaults and validates the complete result against the strict schema, which now requires the new keys. A fully-specified theme missing one gets the existing structured `{ ok: false, issues: [{ code, path, message }] }` error.
+
+## Decision 5 — One small build-config edit; utilities light up automatically
+
+- **Decision**: `sd.config.ts` needs one edit: add `"tracking"` to the `TokenCategory` union and the `categoryMap` in the `typescript/token-map` format. The CSS, Tailwind preset, and JSON emitters are category-agnostic and need nothing.
+- **Rationale**: The build sources `src/tokens/**/*.json` and processes `allTokens` generically, so the CSS variables, the Tailwind preset, and the JSON map pick up a new `tracking.json` and the new radius keys with no change. The preset's `@theme inline` block maps every token to its variable, so `--tracking-*` and `--radius-*` produce the `tracking-*` and `rounded-*` utilities. The one non-generic emitter is the TS token map: its format string hardcodes a `TokenCategory` union and a `categoryMap`, so a brand-new top-level category (`tracking`) must be added there or the generated `tokens.ts` carries `category: "tracking"`, which the union rejects and `tsc` flags. Radius adds keys to an existing category, so it needs no such edit. The `flattenedName` rename stays motion-only.
+- **Caught by**: `/speckit.analyze` (finding F1) — the original plan asserted no build-config change.
+
+## Decision 6 — The token-query MCP surfaces the new tokens automatically
+
+- **Decision**: No MCP code change; verify during implementation.
+- **Rationale**: The MCP `palette` and `lookupToken` tools read the resolved token map / composed tokens, which the build regenerates from the sources. Spec 008 established that the `palette` tool returns whatever categories the resolved data carries. The new `tracking` category and radius keys appear once the sources and defaults carry them. Implementation includes a check that `lookupToken('tracking.widest')` and `palette('tracking')` resolve.
+
+## Decision 7 — No contrast or a11y impact
+
+- **Decision**: The contrast suite and the a11y guard are expected to stay green unchanged.
+- **Rationale**: Tracking and radius are not color, so they touch no `contrastPairs`. Rerouting the LCARS fixture's letter-spacing and corner radius from raw values to tokens changes only which token supplies the value, not the rendered text/background contrast. The Storybook a11y pass over the LCARS stories should remain clean in light and dark.
+
+## Decision 8 — Asymmetric radius composes from the scale
+
+- **Decision**: Document, in THEMING.md, that an asymmetric (per-corner) radius is composed from radius tokens, e.g. `border-radius: var(--radius-3xl) 0 var(--radius-3xl) 0`.
+- **Rationale**: This already scores zero in the audit (every length is a token). The only thing missing was a chunky-enough step, which Decision 3 adds. No new per-corner token type is introduced (out of scope per the spec).
+
+## Decision 9 — Reference-skin reroute mapping
+
+- **Decision**: In `fixtures/themes/lcars/parts.css`, replace the raw values:
+  - `letter-spacing: 0.18em` → `var(--tracking-widest)` (header)
+  - `letter-spacing: 0.1em` → `var(--tracking-widest)` (title)
+  - `letter-spacing: 0.12em` → `var(--tracking-widest)` (button)
+  - `border-radius: 1.75rem 0 1.75rem 0` → `var(--radius-3xl) 0 var(--radius-3xl) 0` (card)
+  - `border-radius: 1.75rem 0 0 0` → `var(--radius-3xl) 0 0 0` (card-header)
+- **Rationale**: Routes every flagged raw value through a token. Expected audit result: `EXPRESSIVITY BLOCKERS: 0` (SC-001). The three tracking values collapse onto `widest`; if the title/button want a half-step less, `wider` (0.05em) is available, but `widest` keeps the LCARS look.
+
+## Decision 10 — Test impact and version bump
+
+- **Decision**: Check `schema.test.ts` and `token-map.test.ts` for assertions that pin the exact category or token set; update them to include the new tokens. `axes.test`, `registry.test`, and `listThemes.test` are unaffected (no themes added or removed). Bump `@unbranded-ds/tokens` 0.5.0 → 0.6.0 (minor, the pre-1.0 convention for a required-key addition, per spec 008's 0.2.0 bump).
+- **Rationale**: Adding tokens changes the regenerated `defaults.generated.ts` and the token map; the regenerate-and-diff guard (`defaults.test`) passes once both sources and defaults are updated together. Any test that asserts an exact token inventory needs the new entries.

--- a/specs/023-expressivity-token-scales/spec.md
+++ b/specs/023-expressivity-token-scales/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Expressivity token scales (tracking and larger radii)
+
+**Feature Branch**: `023-expressivity-token-scales`  
+**Created**: 2026-06-18  
+**Status**: Draft  
+**Input**: User description: "@docs/workshops/2026-06-18/spec-023-expressivity-token-scales.md"
+
+## Clarifications
+
+### Session 2026-06-18
+
+- Q: What CSS-variable name should the tracking scale emit? → A: `--tracking-*` (Tailwind's letter-spacing namespace, matching the motion tokens that emit `--duration-*` / `--ease-*`).
+- Q: Are the new token keys required or optional in the schema? → A: Required, matching spec 008. The built-in themes inherit the base defaults and need no edits, so the only break is for a fully-specified external consumer theme, announced by the version bump.
+- Q: How far do the tracking and radius scales reach? → A: Tailwind-aligned scales as the basis; the reference skin routes its most extreme values to the nearest stop rather than the scale extending to match them exactly. The default token vocabulary stays a curated general set.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Express wide letter-spacing through a token (Priority: P1)
+
+A theme author skinning the design system into a wide, all-caps look (the tracking seen on a console UI or a luxury wordmark) wants to set letter-spacing on the components they style. Today there is no letter-spacing token, so they write a raw value like `0.18em` directly onto a design-system node, which leaves the sanctioned token channel. They want to set tracking the same way they set font weight or line height: by referencing a design token.
+
+**Why this priority**: Letter-spacing is the single largest gap. In the reference skin it accounts for three of the five places the theme had to leave the design system, and unlike radii it has no existing channel at all.
+
+**Independent Test**: Re-author the reference skin's tracking through the new token and run the expressivity audit; the letter-spacing findings drop to zero while the look is unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a theme that wants wide all-caps tracking on a component, **When** it applies the tracking token to a published part, **Then** the expressivity audit reports no raw-value finding for letter-spacing.
+2. **Given** a dense layout that wants tighter-than-normal tracking, **When** it references the tight end of the tracking scale, **Then** it can do so without a raw value.
+
+---
+
+### User Story 2 - Build a chunky, asymmetric corner from radius tokens (Priority: P2)
+
+A theme author wants the large, single-sided "elbow" corners of a console UI: a panel rounded heavily on one corner and square on the rest. The radius they want sits between the design system's small steps and a full pill, a size the scale doesn't currently offer, so they fall back to a raw length. They want to express the corner entirely from radius tokens, including the asymmetry.
+
+**Why this priority**: Radii account for two of the five gaps, a smaller share than tracking. Part of the need (the asymmetry itself) is already met, because a per-corner radius composes from existing tokens, so the true gap is narrower: the scale lacks steps in the chunky size range.
+
+**Independent Test**: Reroute the reference skin's elbow through radius tokens per corner and run the audit; the radius findings drop to zero.
+
+**Acceptance Scenarios**:
+
+1. **Given** a theme that wants a large asymmetric corner, **When** it composes the corner from radius tokens (one per corner), **Then** the audit reports no raw-value finding for border radius.
+2. **Given** a theme that wants a chunky symmetric corner, **When** it references the nearest chunky radius step (around 1rem to 1.5rem), **Then** that step exists and no raw value is required.
+
+---
+
+### User Story 3 - The accessibility contract holds under the richer skin (Priority: P3)
+
+After a skin expresses its complete look through the new tokens, it must remain accessible: text contrast and the automated accessibility pass must hold, in both light and dark, exactly as they did before. The point of the design system is range without giving up the contract.
+
+**Why this priority**: This is an invariant, not new capability, but it is what makes the added expressiveness defensible rather than merely decorative.
+
+**Independent Test**: Run the contrast validation and the automated accessibility pass over the reference skin in both color schemes; both are clean.
+
+**Acceptance Scenarios**:
+
+1. **Given** the reference skin rerouted through the new tokens, **When** the accessibility checks run in light and dark, **Then** there are no contrast or accessibility violations.
+
+---
+
+### Edge Cases
+
+- A theme overrides only some stops of a new scale: the remaining stops inherit the design system's default values.
+- An existing theme never references the new tokens: its rendered output is unchanged, because the new tokens carry default values it inherits.
+- A fully-specified theme (one that declares every token) omits a newly required token: it receives a clear validation error naming the missing token. This is the announced breaking change for that class of consumer.
+- A theme wants tracking or a radius beyond the ends of the new scales: it is bounded by the scale, and a value the scale doesn't offer surfaces as the next gap (the audit flags it). That is the intended signal for a future scale extension, not a reason to allow a raw value.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The token system MUST provide a letter-spacing (tracking) scale that theme authors reference like any other token scale, spanning at least tight, normal, and wide tracking.
+- **FR-002**: A theme MUST be able to override the tracking scale's values, in whole or in part, like any other token category.
+- **FR-003**: The radius scale MUST include steps in the size range between the current small steps and a full pill, so chunky corners are expressible through tokens.
+- **FR-004**: Theme authors MUST be able to compose an asymmetric (per-corner) radius entirely from radius tokens, with no raw length required.
+- **FR-005**: The new tokens MUST be available wherever existing tokens are (every generated artifact and the utility layer consumers use), so a theme reaches them through the normal channel.
+- **FR-006**: A theme that does not reference the new tokens MUST render identically to before, inheriting the design system's default values for them.
+- **FR-007**: The system MUST report a clear, structured validation error, naming the missing token, when a fully-specified theme omits a newly required token.
+- **FR-008**: A maximally divergent reference skin MUST be able to express its complete intended look using only tokens, with no raw style value applied to any design-system node.
+- **FR-009**: The accessibility contract (WCAG AA contrast on the declared pairs and the automated accessibility pass on the rendered skin) MUST continue to hold in both light and dark after the change.
+
+### Key Entities *(include if feature involves data)*
+
+- **Tracking scale**: a named set of letter-spacing values (tight through wide), its own top-level token category (a sibling of typography), overridable per theme.
+- **Radius scale (extended)**: the existing corner-radius scale, grown with larger steps that fill the range between the small steps and a full pill.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The reference skin expresses its complete look using only design tokens. The expressivity audit reports 0 blockers for it, down from the current 5.
+- **SC-002**: The reference skin passes contrast validation and the automated accessibility pass with zero violations, in both light and dark.
+- **SC-003**: No existing theme changes its rendered output. The emitted value of every pre-existing token is unchanged, and the existing theme contrast suite stays green.
+- **SC-004**: A theme author can express wide or tight letter-spacing and chunky or asymmetric corners without writing a single raw length value on a design-system node.
+
+## Assumptions
+
+- The new tokens follow the design system's existing token conventions (build pipeline, utility alignment). The tracking scale emits `--tracking-*` (Tailwind's letter-spacing namespace, the way the motion tokens emit `--duration-*` and `--ease-*`); the larger radii stay `--radius-*`.
+- New token keys are added as required, matching the precedent set when motion tokens and the larger type sizes were added. Because the design system's own base sources carry default values for them, the built-in themes inherit those values and need no edits; the only migration cost falls on a fully-specified external consumer theme, announced by a version bump.
+- Asymmetric radii are achieved by composing per-corner radius tokens, not by introducing a new per-corner token type.
+- The radius and tracking scales take Tailwind v4's scales as their basis. The reference skin routes its most extreme values to the nearest stop (for example, its 1.75rem elbow to the roughly 1.5rem step, and its widest 0.18em tracking to the roughly 0.1em stop) rather than the scale extending to match them exactly; the skin still reads as intended and still reaches zero raw values. The exact stop count and values are finalized in planning, including the tight end a dense layout needs.
+- The reference skin used to validate the outcome is the LCARS fixture introduced by the expressivity-audit spike this work stacks on. That spike (the audit harness and the fixture) is a dependency, and the audit is the instrument that measures SC-001.
+- The token-schema-growth feature (spec 008) is the precedent for how new token categories and scales are added and validated.
+- Out of scope for this feature: density and touch-target tokens (a separate axis), the additional reference skins that will exercise other axes such as texture and motion, and shipping the reference skin as a registered product identity. Each of those is its own effort.

--- a/specs/023-expressivity-token-scales/tasks.md
+++ b/specs/023-expressivity-token-scales/tasks.md
@@ -1,0 +1,120 @@
+# Tasks: Expressivity token scales (tracking and larger radii)
+
+**Input**: Design documents from `/specs/023-expressivity-token-scales/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/token-scales.md
+
+**Tests**: This feature has no new test files. It is verified through existing suites (`themes-contrast.test`, `defaults.test`, the token map test), updated for the new tokens, plus the expressivity audit and the Storybook a11y pass. Test-update tasks live in the story they belong to.
+
+**Organization**: Tasks are grouped by user story. US1 (tracking) is the MVP — it alone takes the reference skin from 5 blockers to 2.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel (different files, no incomplete dependencies)
+- **[Story]**: US1 / US2 / US3; setup and polish carry no story label
+
+## Path conventions
+
+Monorepo. Token work lives in `packages/tokens/`; the reference skin lives in the root `fixtures/themes/lcars/`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Record the before-state so the 5 → 0 change is demonstrable.
+
+- [X] T001 Capture the baseline: run `node scripts/expressivity-audit.mjs` (expect `EXPRESSIVITY BLOCKERS: 5`, 3 type + 2 shape) and `pnpm --filter @unbranded-ds/tokens test` (expect green), noting both results.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Confirm the spike artifacts this feature reroutes are present on the branch.
+
+- [X] T002 Verify the spike prerequisites are on this branch (it stacks on `kendrick/expressivity-spike`): `scripts/expressivity-audit.mjs`, `fixtures/themes/lcars/parts.css`, and the `lcars-light`/`lcars-dark` cells in `packages/tokens/src/themes-contrast.test.ts`.
+
+**Checkpoint**: baseline captured, prerequisites present — story work can begin.
+
+---
+
+## Phase 3: User Story 1 — Express letter-spacing through a token (Priority: P1) 🎯 MVP
+
+**Goal**: Add a `--tracking-*` scale so a theme sets letter-spacing through a token. Reroute the reference skin's tracking, removing its 3 `type` blockers.
+
+**Independent Test**: After this phase, `node scripts/expressivity-audit.mjs` reports 0 `type` blockers (total down to 2, only shape remaining).
+
+- [X] T003 [P] [US1] Add a `trackingTokens` Zod object with six required keys (`tighter`, `tight`, `normal`, `wide`, `wider`, `widest`) and register it as a required top-level category in `tokensSchema` in `packages/tokens/src/schema.ts` (own category, not inside typography — see research.md Decision 1).
+- [X] T004 [P] [US1] Create the DTCG source `packages/tokens/src/tokens/tracking.json` with the six stops and Tailwind v4 values (`tighter -0.05em` … `widest 0.1em`, `$type: "dimension"`) from research.md Decision 2 and data-model.md.
+- [X] T004a [US1] Add `"tracking"` to the `TokenCategory` union and the `categoryMap` in the `typescript/token-map` format in `packages/tokens/sd.config.ts` (around lines 143 and 166). A brand-new top-level category otherwise falls through to `category: "tracking"`, which the hardcoded union rejects, so the generated `tokens.ts` fails `tsc`. This must land before the build in T005.
+- [X] T005 [US1] Rebuild tokens: `pnpm --filter @unbranded-ds/tokens build`. Confirm `--tracking-*` variables appear in `packages/tokens/dist/css/tokens-*.css` and `dist/tailwind/preset.css`, and that `packages/tokens/src/defaults.generated.ts` regenerated with the `tracking` category.
+- [X] T006 [US1] Update `packages/tokens/src/token-map.test.ts` (and `schema.test.ts` if it pins the category set) so the new tracking tokens are covered and the suites stay green.
+- [X] T006a [US1] FR-002 coverage: in `packages/tokens/src/validate.test.ts`, assert a theme overriding only part of `tracking` (e.g. just `widest`) validates and inherits the remaining stops from the defaults.
+- [X] T006b [US1] FR-007 coverage: in `packages/tokens/src/validate.test.ts`, assert a complete (fully-specified) theme missing a required new token (e.g. `tracking.widest`) fails with a structured `{ ok: false, issues: [{ path: 'tracking.widest' }] }`.
+- [X] T007 [US1] Reroute tracking in `fixtures/themes/lcars/parts.css`: replace the three raw `letter-spacing` values (`0.18em`, `0.1em`, `0.12em`) with `var(--tracking-widest)`.
+- [X] T008 [US1] Verify: `node scripts/expressivity-audit.mjs` reports 0 `type` blockers (total 2). Commit US1 as one granular commit.
+
+**Checkpoint**: tracking is a token; the skin is at 2 blockers, all shape.
+
+---
+
+## Phase 4: User Story 2 — Build chunky/asymmetric corners from radius tokens (Priority: P2)
+
+**Goal**: Extend the radius scale with chunky steps so the elbow composes from tokens. Reroute the reference skin's corners, removing its 2 `shape` blockers.
+
+**Independent Test**: After this phase, `node scripts/expressivity-audit.mjs` reports `EXPRESSIVITY BLOCKERS: 0`.
+
+- [X] T009 [P] [US2] Add `xl`, `2xl`, `3xl` as required keys to `radiiTokens` in `packages/tokens/src/schema.ts` (existing keys unchanged).
+- [X] T010 [P] [US2] Add `xl` (0.75rem), `2xl` (1rem), `3xl` (1.5rem) to `packages/tokens/src/tokens/radii.json` (research.md Decision 3); leave `sm`/`md`/`lg`/`full` untouched.
+- [X] T011 [US2] Rebuild tokens. Confirm `--radius-xl/2xl/3xl` emit and the `rounded-xl/2xl/3xl` utilities resolve from the preset; `defaults.generated.ts` regenerated.
+- [X] T012 [US2] Update `packages/tokens/src/token-map.test.ts` / `schema.test.ts` for the three new radius keys if pinned.
+- [X] T013 [US2] Reroute the elbow in `fixtures/themes/lcars/parts.css`: `border-radius: 1.75rem 0 1.75rem 0` → `var(--radius-3xl) 0 var(--radius-3xl) 0` on `[data-slot="card"]`, and `1.75rem 0 0 0` → `var(--radius-3xl) 0 0 0` on `[data-slot="card-header"]`.
+- [X] T014 [US2] Verify: `node scripts/expressivity-audit.mjs` reports `EXPRESSIVITY BLOCKERS: 0` (SC-001). Commit US2 as one granular commit.
+
+**Checkpoint**: the reference skin expresses its full look through tokens — zero blockers.
+
+---
+
+## Phase 5: User Story 3 — The accessibility contract holds (Priority: P3)
+
+**Goal**: Confirm the rerouted skin stays accessible, in both color schemes.
+
+**Independent Test**: The contrast suite and the Storybook a11y pass are both green.
+
+- [X] T015 [US3] Run the token contrast suite: `pnpm --filter @unbranded-ds/tokens exec vitest run src/themes-contrast.test.ts`. Both `lcars-light` and `lcars-dark` stay AA on every pair (SC-002, token layer).
+- [X] T016 [US3] Build react (`pnpm --filter @unbranded-ds/react build`) and run the a11y test-runner over the skin: `pnpm --filter @unbranded-ds/storybook exec vitest run --project storybook -t "LCARS"`. Both LCARS stories pass axe in light and dark (SC-002, rendered layer).
+
+**Checkpoint**: range under invariant contract holds — zero blockers, zero a11y violations.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+**Purpose**: Refresh the emitted artifacts, document, version, and run the full gate.
+
+- [X] T017 Refresh the fixture artifacts: set `blockers` to 0 in `fixtures/themes/lcars/meta.json`, update the count in `fixtures/themes/index.json`, and regenerate `fixtures/expressivity-report.json` via `node scripts/expressivity-audit.mjs --emit`.
+- [X] T018 [P] Verify the token-query MCP surfaces the new tokens (no code change expected): `lookupToken('tracking.widest')` resolves to `0.1em` / `--tracking-widest`, `palette('tracking')` returns the scale, and `palette('radius')` includes `xl/2xl/3xl`.
+- [X] T019 [P] Add a THEMING.md note: the `tracking` scale, and composing an asymmetric radius per-corner from radius tokens. Run the addition through the `humanizer` skill (Constitution XI.1); no three-item lists.
+- [X] T020 [P] Update `fixtures/README.md` "Where it stands" to reflect LCARS at 0 blockers. Run through the `humanizer`.
+- [X] T021 [P] Add a `.changeset/*.md` declaring the `@unbranded-ds/tokens` minor bump (0.5.0 → 0.6.0), naming the two new scales and the breaking change for fully-specified external themes. Humanize the changeset prose.
+- [X] T022 Run the full gate: `pnpm --filter @unbranded-ds/tokens test`, `pnpm --filter @unbranded-ds/tokens typecheck`, and a final `node scripts/expressivity-audit.mjs` (0). Commit the polish as one granular commit.
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (Phase 1)** and **Foundational (Phase 2)** first.
+- **US1 (Phase 3)** is the MVP and goes first among stories. It edits `schema.ts` and regenerates `defaults.generated.ts`. Within it, **T004a precedes T005**: the build's `tsc` step rejects the new `tracking` category until the token-map types include it.
+- **US2 (Phase 4)** follows US1 — it touches the same `schema.ts` and the regenerated defaults, so it is sequential, not parallel, with US1.
+- **US3 (Phase 5)** follows US2 — it verifies the a11y contract over the fully rerouted skin.
+- **Polish (Phase 6)** last. T018–T021 are mutually parallel (different files); T017 and T022 bracket them.
+
+## Parallel opportunities
+
+- Within US1: T003 (schema) and T004 (`tracking.json`) are different files — run together.
+- Within US2: T009 (schema) and T010 (`radii.json`) are different files — run together.
+- In Polish: T018, T019, T020, T021 touch different files and can run together.
+
+## Implementation strategy
+
+- **MVP = US1 alone.** Shipping just the tracking scale takes the reference skin from 5 blockers to 2 and proves the find-grow-recheck loop on the larger of the two gaps. US2 then closes the remainder to 0.
+- **Commit granularly** (per the project's preference): one commit at each story checkpoint (T008, T014) and one for polish (T022), each with a humanized message and no coauthor trailer.
+- **Acceptance is the audit plus the guards**: SC-001 is `EXPRESSIVITY BLOCKERS: 0`; SC-002 is the contrast suite and the a11y pass green; SC-003 is `defaults.test` and the unchanged pre-existing token values.


### PR DESCRIPTION
## What This Does

Closes the backlog the expressivity audit produced. LCARS read 5 blockers, all from two missing token scales; this adds them, reroutes the fixture, and the audit drops to 0. The skin now expresses its complete look through tokens alone, with the a11y contract intact.

## The Two Scales

- A `tracking` (letter-spacing) scale, `--tracking-tighter` through `--tracking-widest` (Tailwind's namespace). Its own top-level category, the way `motion` emits `--duration-*` and `--ease-*`. Closes the 3 `type` blockers.
- Larger `radius` steps, `xl`/`2xl`/`3xl` (0.75/1/1.5rem), filling the gap between `lg` and the full pill. An asymmetric "elbow" composes per-corner from the scale; it always could, the scale just lacked a chunky step. Closes the 2 `shape` blockers.

Both are required keys, carried by the base sources, so the built-in themes inherit them and need no change. A fully-specified external theme must add them, which is the breaking part of the minor bump.

## Result

`node scripts/expressivity-audit.mjs` reads `EXPRESSIVITY BLOCKERS: 0`, down from 5. The LCARS cells stay AA in the contrast suite, and the Storybook a11y pass is clean in both color schemes. By the experiment's rule, LCARS is now ship-ready at zero blockers, though it stays a fixture for now.

## Notes

- Schema growth on the spec 008 model. The one non-obvious build change: a new top-level category has to join the token-map's `TokenCategory` union in `sd.config.ts`, or the generated `tokens.ts` fails typecheck. `/speckit.analyze` caught that the plan had missed it.
- Stacked on the expressivity-audit spike (now merged), so this diff is just the scales and the fixture reroute.
- Full spec-kit trail under `specs/023-expressivity-token-scales/`: spec, clarify, plan, the design docs, and tasks.
