### PR TITLE
test(react)+ci: fix the jsdom teardown flake, exempt test-only changes from the changeset gate

### DIFF
--- a/.changeset/fix-test-teardown-flake.md
+++ b/.changeset/fix-test-teardown-flake.md
@@ -1,0 +1,5 @@
+---
+'@unbranded-ds/react': patch
+---
+
+Fix an intermittent unit-test crash. The suite occasionally failed with "window is not defined" after the jsdom environment was disposed, because a component left mounted at teardown let React's scheduler fire a queued callback against a window that was already gone. The setup file now unmounts each test's tree, so that work runs while the window is still alive. No change to shipped components.

--- a/.changeset/fix-test-teardown-flake.md
+++ b/.changeset/fix-test-teardown-flake.md
@@ -1,5 +1,0 @@
----
-'@unbranded-ds/react': patch
----
-
-Fix an intermittent unit-test crash. The suite occasionally failed with "window is not defined" after the jsdom environment was disposed, because a component left mounted at teardown let React's scheduler fire a queued callback against a window that was already gone. The setup file now unmounts each test's tree, so that work runs while the window is still alive. No change to shipped components.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -36,8 +36,17 @@ jobs:
 
       - name: Detect package changes
         id: detect
+        # A changeset is only required when a PR changes something that ships. Test
+        # files and the vitest config live under packages/ but never land in the
+        # published dist, so editing them can't affect consumers. Filter them out
+        # before deciding, so a test-only PR isn't forced into a version bump.
         run: |
-          if git diff --name-only origin/main...HEAD | grep -qE '^packages/(tokens|react)/'; then
+          PUBLISHABLE=$(git diff --name-only origin/main...HEAD \
+            | grep -E '^packages/(tokens|react)/' \
+            | grep -vE '\.test\.[jt]sx?$' \
+            | grep -vE '(^|/)vitest\.[^/]+$' \
+            || true)
+          if [ -n "$PUBLISHABLE" ]; then
             echo "package_changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "package_changed=false" >> "$GITHUB_OUTPUT"

--- a/packages/react/vitest.setup.ts
+++ b/packages/react/vitest.setup.ts
@@ -1,1 +1,13 @@
 import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// Unmount after every test. We run without `globals`, so RTL's auto-cleanup never
+// self-registers (it only hooks a global afterEach). A component left mounted at
+// teardown causes the intermittent "window is not defined" crash: this jsdom env
+// has no MessageChannel, so React 19's scheduler falls back to setImmediate, and
+// the queued performWorkUntilDeadline callback fires after Vitest has torn down
+// window. Cleaning up drains that work while window is still alive.
+afterEach(() => {
+	cleanup();
+});


### PR DESCRIPTION
## What

Two things, one motivated by the other.

1. Fix the intermittent `ReferenceError: window is not defined` in the `@unbranded-ds/react` unit suite. All 150 tests pass, but the run exits 1 on unhandled errors. It surfaced on the Changesets release PR's CI job, but it's main's code and can hit any run; locally it reproduced about once in three runs.
2. Stop the `changeset-check` gate from demanding a changeset for test-only changes, so a fix like this one doesn't force a version bump.

## Why the flake happens

The unit project runs without `globals`, so `@testing-library/react`'s auto-cleanup never self-registers (it only hooks a global `afterEach`). A component left mounted at file teardown is the trigger: this jsdom environment has no `MessageChannel`, so React 19's scheduler falls back to `setImmediate`, and that queued callback fires after Vitest has torn down `window`. Dialog (Base UI: portal, transitions, focus) leaves the most scheduler work queued, which is why the error always cited `Dialog.test.tsx`.

## The fix

Register `afterEach(cleanup)` in `vitest.setup.ts` so each test's tree unmounts and its pending work drains while `window` is still alive.

## The gate change

Test files and the vitest config live under `packages/` but never ship in `dist`, so editing them can't reach consumers. The gate now filters `*.test.*` and `vitest.*` out of its change detection, so a test-only PR isn't pushed into a version bump. Because the flake fix touches only `vitest.setup.ts`, this PR carries no changeset.

## Verification

- Unit suite 15x on this branch: zero `window` errors, zero failures (the flake previously hit ~1 in 3).
- `pnpm build` then `pnpm test:unit` the way CI sequences it: 4/4 tasks clean.
- `pnpm --filter @unbranded-ds/react typecheck`: clean.
- Simulated the new detect step against this branch's diff: `package_changed=false`, so the changeset gate skips.