### PR TITLE
ci: drop --with-deps from Playwright install to stop apt hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,13 +151,21 @@ jobs:
           pnpm --filter @unbranded-ds/example-nextjs typecheck
 
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
+      # The ubuntu-24.04 image already ships Chromium's system libraries (Chrome is
+      # preinstalled), so we skip --with-deps and the flaky apt round-trip it triggers.
+      # On a cache hit the browser binary is already restored, so the install is a
+      # no-op we skip. timeout-minutes caps a stalled download so it can't ride the
+      # 6-hour job default.
       - name: Install Playwright browser
-        run: pnpm --filter @unbranded-ds/example-nextjs exec playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 5
+        run: pnpm --filter @unbranded-ds/example-nextjs exec playwright install chromium
 
       # The Playwright webServer runs `next build` then `next start` itself.
       - name: Playwright e2e (production build)
@@ -192,13 +200,21 @@ jobs:
         run: pnpm --filter @unbranded-ds/tokens --filter @unbranded-ds/react build
 
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
+      # The ubuntu-24.04 image already ships Chromium's system libraries (Chrome is
+      # preinstalled), so we skip --with-deps and the flaky apt round-trip it triggers.
+      # On a cache hit the browser binary is already restored, so the install is a
+      # no-op we skip. timeout-minutes caps a stalled download so it can't ride the
+      # 6-hour job default.
       - name: Install Playwright browser
-        run: pnpm --filter @unbranded-ds/storybook exec playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 5
+        run: pnpm --filter @unbranded-ds/storybook exec playwright install chromium
 
       - name: Storybook test-runner (interaction + a11y)
         run: pnpm --filter @unbranded-ds/storybook test:storybook


### PR DESCRIPTION
## What

`playwright install --with-deps` was occasionally wedging the example-e2e and storybook-test jobs for 15+ minutes (and would ride the 6-hour default) on an apt step. This drops the apt round-trip.

## Why

The `--with-deps` flag runs `apt-get update` + `apt-get install` to put Chromium's system libraries on the runner. When the runner's Azure apt mirror degrades, apt retries and stalls, and with no timeout the step hangs until the 6-hour job default. PR #132's browser cache doesn't help, because `--with-deps` runs apt regardless of the cache.

The ubuntu-24.04 runner image already ships those libraries (it preinstalls Google Chrome), so installing them again is redundant.

## Change

For both Playwright jobs:
- Drop `--with-deps`; use plain `playwright install chromium` (no apt).
- Skip the install on a browser cache hit (the binary is already restored).
- Add `timeout-minutes` so a stalled download fails fast.

## Verification

CI on this PR is the proof. Chromium has to launch in both example-e2e and storybook-test; if a library were actually missing from the image, Playwright would fail immediately with the exact lib named. A green run means the deps are present.