### PR TITLE
ci(lint): re-home the DS lint gate so it actually runs (spec 025)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Lint runs before typecheck per the constitution's install → lint → typecheck
+      # job graph (Section VIII). errors-only is ESLint's default — the React-19 idiom
+      # warnings are intentionally non-blocking.
+      - name: Lint
+        run: pnpm lint
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # heliostat Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-06-18
+Auto-generated from all feature plans. Last updated: 2026-06-19
 
 ## Active Technologies
 - TypeScript 5.x, strict, no `any` (Constitution VIII). React 19. + `@base-ui-components/react` (peer), the existing `lib/warn.ts` helper, `lib/cn`. No new dependencies. (021-form-control-a11y-naming)
@@ -8,6 +8,8 @@ Auto-generated from all feature plans. Last updated: 2026-06-18
 - TypeScript 5.x, strict, no `any` (Constitution VIII). DTCG JSON token sources. + Style Dictionary v4 (the token build, `sd.config.ts`), Zod (the theme schema + `contrastPairs`), the `color.ts` WCAG contrast math, Tailwind CSS v4 (`@theme` preset auto-maps `--color-*` to utilities), `@modelcontextprotocol/sdk` (the token-query MCP reads the token map). No new dependencies. (022-popover-tokens-contrast)
 - N/A — build-time DTCG JSON compiled to CSS variables, a Tailwind preset, JSON, and a typed token map. No runtime or persisted state. (022-popover-tokens-contrast)
 - TypeScript 5.x, strict, no `any` (Constitution VIII) + Style Dictionary v4 (the token build, `sd.config.ts`), Zod (theme schema + `contrastPairs`), Tailwind CSS v4 (`@theme` preset maps `--tracking-*` / `--radius-*` to utilities). No new dependencies. (023-expressivity-token-scales)
+- TypeScript 5.x (strict, no `any`) for `eslint.config.ts` and the rule test; YAML for the workflow; Node 24 in CI. + ESLint 9 (flat config) via `@antfu/eslint-config` ^9 and its peer plugins (`@eslint-react/eslint-plugin`, `eslint-plugin-format`, `eslint-plugin-jsx-a11y`, `eslint-plugin-react-refresh`), the in-house `no-hardcoded-colors` rule (`packages/react/eslint/no-hardcoded-colors.js`), Prettier ^3 (delegated by antfu for CSS/HTML/Markdown only), Turborepo (`turbo lint`), Vitest 3 (the rule test), GitHub Actions. (025-re-home-lint)
+- N/A — CI and config change, no runtime or persisted state. (025-re-home-lint)
 
 - TypeScript 5.x, strict, no `any` (Constitution VIII). React 19, Next.js 15 (App Router). + `next` ^15, `react`/`react-dom` 19, `@unbranded-ds/tokens` and `@unbranded-ds/react` at `workspace:*`, Tailwind CSS v4 (consumed through `@unbranded-ds/react/preset.css`), `next/font/local` (self-hosted font), `@playwright/test`, `@axe-core/playwright`. (015-nextjs-example-app)
 - `localStorage` only, through the design system's existing keys (`unbranded-ds-theme`, `unbranded-ds-density`, `unbranded-ds-theme-preference`). No new storage. (015-nextjs-example-app)
@@ -66,9 +68,9 @@ npm test && npm run lint
 TypeScript 5.x, strict mode, no `any` (EVER): Follow standard conventions
 
 ## Recent Changes
+- 025-re-home-lint: Added TypeScript 5.x (strict, no `any`) for `eslint.config.ts` and the rule test; YAML for the workflow; Node 24 in CI. + ESLint 9 (flat config) via `@antfu/eslint-config` ^9 and its peer plugins (`@eslint-react/eslint-plugin`, `eslint-plugin-format`, `eslint-plugin-jsx-a11y`, `eslint-plugin-react-refresh`), the in-house `no-hardcoded-colors` rule (`packages/react/eslint/no-hardcoded-colors.js`), Prettier ^3 (delegated by antfu for CSS/HTML/Markdown only), Turborepo (`turbo lint`), Vitest 3 (the rule test), GitHub Actions.
 - 023-expressivity-token-scales: Added TypeScript 5.x, strict, no `any` (Constitution VIII) + Style Dictionary v4 (the token build, `sd.config.ts`), Zod (theme schema + `contrastPairs`), Tailwind CSS v4 (`@theme` preset maps `--tracking-*` / `--radius-*` to utilities). No new dependencies.
 - 022-popover-tokens-contrast: Added TypeScript 5.x, strict, no `any` (Constitution VIII). DTCG JSON token sources. + Style Dictionary v4 (the token build, `sd.config.ts`), Zod (the theme schema + `contrastPairs`), the `color.ts` WCAG contrast math, Tailwind CSS v4 (`@theme` preset auto-maps `--color-*` to utilities), `@modelcontextprotocol/sdk` (the token-query MCP reads the token map). No new dependencies.
-- 021-form-control-a11y-naming: Added TypeScript 5.x, strict, no `any` (Constitution VIII). React 19. + `@base-ui-components/react` (peer), the existing `lib/warn.ts` helper, `lib/cn`. No new dependencies.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ Storybook runs on `http://localhost:6006`. MCP endpoint is at `/mcp`.
 
 ## CI
 
-GitHub Actions runs on every PR and push to `main`. The pipeline has two jobs:
+GitHub Actions runs on every pull request and every push to `main`. A `changes` job runs first and flags docs-only PRs so the browser-heavy jobs can skip them. The rest:
 
-**verify** — lint, typecheck, unit tests, build every package, build Storybook, run the Storybook interaction and a11y tests. Any failure blocks the PR.
-
-**publish** — depends on verify. Publishes Storybook to Chromatic (with `skip: true` so no visual regression snapshots are consumed) and runs the MCP smoke test against the published endpoint.
+- `verify` — lint, typecheck, validate the sidecar docs, build every package, run the unit tests, and build Storybook. Lint covers the `tokens`, `react`, and `storybook` packages and fails on errors; the React 19 idiom warnings stay advisory. Any failure blocks the PR.
+- `storybook-test` — the Storybook interaction and accessibility tests, in a real browser via Playwright. Skipped on docs-only PRs.
+- `example-e2e` — lints and typechecks the example app, then runs its Playwright end-to-end suite against a production build. Skipped on docs-only PRs.
+- `publish` — depends on `verify`. Publishes Storybook to Chromatic (visual regression disabled, so no snapshots are consumed) and runs the MCP smoke test against the published endpoint.
 
 ### Chromatic setup
 

--- a/docs/workshops/2026-06-18/spec-025-re-home-lint.md
+++ b/docs/workshops/2026-06-18/spec-025-re-home-lint.md
@@ -1,0 +1,40 @@
+# Spec 025 — Re-home DS lint so it actually runs
+
+**Target version:** no package version change (CI + tooling config only)
+**Depends on:** nothing hard. #97 already restored the missing `no-hardcoded-colors` rule file, and the antfu peer plugins it choked on are now devDeps, so the original crash is likely gone
+**Blocks:** a real lint gate on the DS packages. Today the gate is advertised but absent
+**Status:** brief (not yet specified); needs a decision, see Options. The spec number is provisional.
+
+> Surfaced on 2026-06-18 triaging the old issue backlog (#98). Phase 7 pulled `pnpm lint` out of CI because the antfu config crashed, and it was never put back. The crash looks fixed now, but lint still runs nowhere for the DS's own packages, while both the CI job name and the README claim it does.
+
+## The problem
+
+Lint was removed from CI during Phase 7 for a real reason: `eslint.config.ts` referenced a `no-hardcoded-colors` rule file that didn't exist, and antfu's config wanted peer plugins that weren't installed. Both of those are resolved now. #97 brought the rule file back, `eslint.config.ts` wires `no-hardcoded-colors` as an `error`, and the peer plugins (`@eslint-react/eslint-plugin`, `eslint-plugin-format`, `eslint-plugin-react-refresh`, `eslint-plugin-jsx-a11y`) all sit in root devDeps. So the thing that justified pulling lint is gone.
+
+What didn't come back is lint itself. The `verify` job in `.github/workflows/ci.yml` is named "Lint, typecheck, test, build," and its steps are checkout, install, typecheck, sidecar validation, `pnpm build`, `pnpm test:unit`, and a Storybook build. There is no `pnpm lint` step. The only place eslint runs in CI is the example app's own job (`pnpm --filter @unbranded-ds/example-nextjs lint`). The husky hook is `pre-push` running typecheck, not a `pre-commit` eslint pass.
+
+So `@unbranded-ds/react` and `@unbranded-ds/tokens` are linted nowhere, neither in CI nor on commit. The `no-hardcoded-colors` rule, the one DS-specific check we actually care about, has never run end to end against component source. And the gap is hidden twice over: the CI job is literally named "Lint…" and the README's CI section says verify runs lint. A reader checking either would conclude the gate exists. It doesn't, and a silent absence is worse than an honest gap because it reads as covered.
+
+## Options (needs a decision)
+
+- Eslint stack. Keep antfu now that its peer deps are installed, or swap to a leaner `@typescript-eslint` + `eslint-plugin-jsx-a11y` + the in-house `no-hardcoded-colors` rule. #98 flagged antfu as possibly more opinion than this repo wants; that call is still open.
+- Where it runs. A blocking `pnpm lint` step inside `verify`, an advisory job (`continue-on-error: true`) that shows in PR checks without gating, a `pre-commit` lint-staged `eslint --fix`, or some combination. #98's original proposal paired lint-staged with an advisory CI job.
+- Blocking from day one, or advisory first and flip to required once it runs green across the whole tree.
+
+## Regardless of which option wins
+
+- The DS packages get linted somewhere reliable, not just the example app.
+- `no-hardcoded-colors` is confirmed to fire against real component source.
+- The CI job name and the README's CI section get corrected to match whatever actually ships, so the repo stops advertising a gate it doesn't have.
+
+## What it touches
+
+- `.github/workflows/ci.yml` (the lint step or job; rename `verify` if lint stays out of it).
+- Root `package.json`, the per-package `lint` scripts, and the `turbo lint` pipeline.
+- `eslint.config.ts` (confirm a clean run; possibly slim the stack).
+- `.husky/` and root config if a `pre-commit` lint-staged hook lands.
+- `README.md` (the CI section currently overstates what `verify` does).
+
+## Scope guardrails
+
+Tooling and CI plumbing, not product surface. No component or token changes. The job is to make the lint gate the repo already advertises actually exist, and to stop lying about it where it doesn't.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -23,6 +23,11 @@ export default antfu(
 			'camelcase': ['error', { ignoreImports: true }],
 			'style/multiline-ternary': 'off',
 			'style/arrow-parens': ['error', 'always'],
+			// antfu's quote-props consistency rule is pure churn on our token maps:
+			// it flagged 63 cosmetic "inconsistently quoted property" errors with no
+			// correctness value. Drop just this one rule; antfu still owns the rest of
+			// JS/TS formatting, and Prettier keeps CSS/HTML/Markdown.
+			'style/quote-props': 'off',
 
 			// eslint-plugin-pnpm (auto-enabled by antfu in pnpm monorepos) injects
 			// `trustPolicy: no-downgrade` into pnpm-workspace.yaml on every --fix,

--- a/packages/react/eslint/no-hardcoded-colors.test.ts
+++ b/packages/react/eslint/no-hardcoded-colors.test.ts
@@ -1,0 +1,39 @@
+import { RuleTester } from 'eslint';
+import { afterAll, describe, it } from 'vitest';
+import rule from './no-hardcoded-colors.js';
+
+// The constitution (Section IV) mandates this rule, but until now nothing exercised
+// it, so a regression that stopped it firing would have gone unnoticed. RuleTester is
+// the durable proof: ESLint runs the rule against each case and fails if a real color
+// slips through or a token-backed value gets flagged. Wire its lifecycle to Vitest so
+// each case registers as a test.
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const ruleTester = new RuleTester({
+	languageOptions: {
+		ecmaVersion: 2022,
+		sourceType: 'module',
+	},
+});
+
+ruleTester.run('no-hardcoded-colors', rule, {
+	valid: [
+		// Token-backed colors are the whole point of the rule — they must pass.
+		{ code: 'const c = "var(--color-primary)";' },
+		{ code: 'const className = "bg-primary text-muted-foreground";' },
+		// A plain string must not trip the named-color word match.
+		{ code: 'const label = "Save changes";' },
+	],
+	invalid: [
+		{ code: 'const c = "#ff0000";', errors: [{ messageId: 'hardcoded' }] },
+		{ code: 'const c = "#fff";', errors: [{ messageId: 'hardcoded' }] },
+		{ code: 'const c = "rgb(255, 0, 0)";', errors: [{ messageId: 'hardcoded' }] },
+		{ code: 'const c = "hsl(0, 100%, 50%)";', errors: [{ messageId: 'hardcoded' }] },
+		{ code: 'const c = "red";', errors: [{ messageId: 'hardcoded' }] },
+		// Template literals are checked through the TemplateElement visitor.
+		{ code: 'const c = `#abcdef`;', errors: [{ messageId: 'hardcoded' }] },
+	],
+});

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -9,7 +9,8 @@ export default defineConfig({
 					name: 'unit',
 					environment: 'jsdom',
 					setupFiles: ['./vitest.setup.ts'],
-					include: ['src/**/*.test.{ts,tsx}'],
+					// The lint-rule test lives next to the rule it covers, outside src/.
+					include: ['src/**/*.test.{ts,tsx}', 'eslint/**/*.test.{ts,tsx}'],
 				},
 			},
 		],

--- a/packages/tokens/src/browser-safety.test.ts
+++ b/packages/tokens/src/browser-safety.test.ts
@@ -16,6 +16,7 @@ const BROWSER_ENTRIES = ['client.ts', 'runtime.ts'];
 
 // `import type`/`export type` are erased before any bundler sees them, so a
 // type-only edge to a node module is harmless and must NOT be followed.
+// eslint-disable-next-line regexp/no-super-linear-backtracking -- runs only over this repo's own source at test time (trusted input), never user input, so the backtracking this rule guards against is not a DoS vector here
 const FROM_RE = /(?:import|export)\s+(?!type\b)[^'"]*?\sfrom\s*['"]([^'"]+)['"]/g;
 const SIDE_EFFECT_RE = /import\s+['"]([^'"]+)['"]/g;
 

--- a/packages/tokens/src/resolution-parity.test.ts
+++ b/packages/tokens/src/resolution-parity.test.ts
@@ -43,6 +43,7 @@ function normalize(value: string): string {
 function parseCssVars(themeName: string): Map<string, string> {
 	const css = readFileSync(join(cssDir, `tokens-${themeName}.css`), 'utf8');
 	const out = new Map<string, string>();
+	// eslint-disable-next-line regexp/no-super-linear-backtracking -- parses our own generated CSS at test time (trusted input), never user input, so the backtracking this rule guards against is not a DoS vector here
 	for (const m of css.matchAll(/(--[\w-]+):\s*([^;]+);/g))
 		out.set(m[1]!, m[2]!.trim());
 	return out;

--- a/specs/025-re-home-lint/checklists/requirements.md
+++ b/specs/025-re-home-lint/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Re-home DS lint so it actually runs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This is a CI and tooling spec, so the subject matter is itself a tool. Naming lint, the `no-hardcoded-colors` rule, the CI jobs, and the README is describing WHAT the feature governs, not leaking HOW to build it. The requirements stay at the behavior level (lint runs against the DS packages, errors block, job names and docs match reality).
+- The "non-technical stakeholders" item passes in the sense that the stakeholders for a CI gate are maintainers and contributors; the spec is written for that audience without assuming knowledge of the implementation.
+- No `[NEEDS CLARIFICATION]` markers remain. The three open decisions from the brief were resolved by `/speckit-clarify` (session 2026-06-19), which asked five questions covering stack, coverage, placement, blocking timing, and warnings policy. The answers are recorded in the spec's Clarifications section and woven into the requirements; the Assumptions section now states settled decisions rather than deferred defaults.

--- a/specs/025-re-home-lint/contracts/lint-gate.md
+++ b/specs/025-re-home-lint/contracts/lint-gate.md
@@ -1,0 +1,40 @@
+# Contract: The CI lint gate
+
+The interface this feature exposes is a CI gate plus a local command. This is its contract — what runs, what blocks, and what a contributor can rely on.
+
+## Command
+
+`pnpm lint` (root) → `turbo lint` → each package's `lint` script:
+
+- `@unbranded-ds/react` → `eslint src/`
+- `@unbranded-ds/tokens` → `eslint src/`
+- `@unbranded-ds/storybook` → `eslint .`
+
+The same command runs locally and in CI, against the same `eslint.config.ts`, so a local run reproduces the CI result (FR-009, SC-005).
+
+## CI surface
+
+- **Where**: a step named `Lint` in the `verify` job, after "Install dependencies" and before "Typecheck".
+- **Trigger**: pull requests and pushes to `main`, subject to the existing docs-only skip (a docs-only PR does not run lint).
+- **Blocking**: yes, from the first commit that lands the step. No advisory phase.
+
+## Pass / fail semantics
+
+| Condition | Result |
+|---|---|
+| Any ESLint **error** in a covered package | Step fails, `verify` fails, merge blocked |
+| ESLint **warnings** only (e.g. the 8 existing `react/*` warnings) | Step passes, warnings printed but non-blocking |
+| A literal color in `packages/react/src/components/**/*.tsx` | `no-hardcoded-colors` error → blocked |
+| Config fails to resolve (missing rule file, missing peer plugin) | Step fails loudly — never silently skipped |
+| Docs-only PR | Step does not run (existing skip) |
+
+Errors-only is ESLint's default exit behavior; the gate adds no `--max-warnings` flag.
+
+## What the gate covers and does not
+
+- **Covers**: `@unbranded-ds/react`, `@unbranded-ds/tokens`, `@unbranded-ds/storybook` source.
+- **Does not cover here**: the example app (`@unbranded-ds/example-nextjs`), which keeps linting itself in its own job (FR-006, unchanged). Generated files (`defaults.generated.ts`) and `dist/` are excluded via the existing config ignores.
+
+## Honesty guarantee (US3)
+
+After this change, every CI job name describes the checks it runs, and the README's CI section matches the workflow. No job or doc advertises a lint check it does not perform.

--- a/specs/025-re-home-lint/data-model.md
+++ b/specs/025-re-home-lint/data-model.md
@@ -1,0 +1,26 @@
+# Phase 1 Data Model: Re-home DS lint
+
+This feature has no domain data — no entities, no persisted state, no schema. It is CI and configuration. The closest analog worth recording is the set of configuration artifacts the change touches and the role each plays, so the implementer and a future reader know what owns what.
+
+## Configuration artifacts
+
+| Artifact | Role | Change |
+|---|---|---|
+| `eslint.config.ts` (root) | The single flat config for the whole monorepo. Sets antfu base (react, typescript, stylistic), the jsx-a11y rule block, and scopes `no-hardcoded-colors` to `packages/react/src/components/**/*.tsx` as an error. | Add `'style/quote-props': 'off'` to the antfu `rules` block. Nothing else. |
+| `.github/workflows/ci.yml` → `verify` job | The job named "Lint, typecheck, test, build" that today runs typecheck, sidecar validation, build, unit tests, and a Storybook build — but no lint. | Insert a `Lint` step running `pnpm lint`, after "Install dependencies", before "Typecheck". |
+| `turbo.json` → `lint` task | Fans `pnpm lint` out to each package's `lint` script. | Unchanged. |
+| `packages/react/package.json`, `packages/tokens/package.json` | Each defines `lint: eslint src/`. | Unchanged. |
+| `apps/storybook/package.json` | Defines `lint: eslint .`. | Unchanged. |
+| `packages/react/eslint/no-hardcoded-colors.js` | The custom rule the constitution (Section IV) mandates. | Unchanged. |
+| `packages/react/eslint/no-hardcoded-colors.test.ts` | (new) RuleTester proof the rule fires. | Created. |
+| `README.md` → CI section | Describes the gate for humans and agents. | Rewritten to match the real workflow; humanized. |
+
+## Rule states (the only "state" in play)
+
+The gate's behavior is defined by which rules fail the build:
+
+- `no-hardcoded-colors`: **error** (blocks) — scoped to component source. Unchanged; now actually runs.
+- `style/quote-props`: **error → off** — the 63 current failures; turned off as redundant style noise.
+- antfu's other stylistic rules (`indent`, `semi`, `quotes`, `arrow-parens`, ...): **error** (blocks) — unchanged; antfu remains the JS/TS formatter.
+- jsx-a11y rules: **error** (blocks) — unchanged.
+- antfu's React rules (`react/no-context-provider`, `react/no-use-context`, `react/set-state-in-effect`, ...): **warning** (does not block) — the 8 existing warnings stay non-blocking under the errors-only gate.

--- a/specs/025-re-home-lint/plan.md
+++ b/specs/025-re-home-lint/plan.md
@@ -1,0 +1,73 @@
+# Implementation Plan: Re-home DS lint so it actually runs
+
+**Branch**: `025-re-home-lint` | **Date**: 2026-06-19 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/025-re-home-lint/spec.md`
+
+## Summary
+
+Lint scripts already exist for every DS package (`turbo lint` runs `eslint` in `react`, `tokens`, and `storybook`), the antfu flat config resolves cleanly, and the in-house `no-hardcoded-colors` rule is wired as an error on `packages/react/src/components/**/*.tsx`. The only thing missing is that CI never calls lint: the `verify` job is named "Lint, typecheck, test, build" but has no lint step, and the README repeats the claim. This plan adds a blocking lint step to `verify` (in the constitution's `install → lint → typecheck` position), clears the one stylistic rule producing 63 redundant errors so the gate lands green, proves `no-hardcoded-colors` fires with a RuleTester unit test, and corrects the README so the advertised gate matches reality.
+
+The change is tooling and CI only. No component behavior, token value, or built artifact changes.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (strict, no `any`) for `eslint.config.ts` and the rule test; YAML for the workflow; Node 24 in CI.
+**Primary Dependencies**: ESLint 9 (flat config) via `@antfu/eslint-config` ^9 and its peer plugins (`@eslint-react/eslint-plugin`, `eslint-plugin-format`, `eslint-plugin-jsx-a11y`, `eslint-plugin-react-refresh`), the in-house `no-hardcoded-colors` rule (`packages/react/eslint/no-hardcoded-colors.js`), Prettier ^3 (delegated by antfu for CSS/HTML/Markdown only), Turborepo (`turbo lint`), Vitest 3 (the rule test), GitHub Actions.
+**Storage**: N/A — CI and config change, no runtime or persisted state.
+**Testing**: Vitest with ESLint's `RuleTester` to prove `no-hardcoded-colors` fires (durable replacement for a manual add-and-revert). Acceptance otherwise verified by the gate itself going red on an introduced error and green on the cleaned tree.
+**Target Platform**: GitHub Actions CI (ubuntu) and local developer machines.
+**Project Type**: pnpm + Turborepo monorepo; this feature touches root config, the CI workflow, the README, and one new test under `packages/react`.
+**Performance Goals**: Lint adds roughly one `turbo lint` run (~20s observed locally) to `verify`, reusing that job's existing install — no second environment setup, no extra free-tier minutes for a separate job.
+**Constraints**: No package version bump, no shipped-output change (FR-010). Reuse `verify`'s install; respect the existing docs-only skip. TypeScript strict, no `any`.
+**Scale/Scope**: Three linted packages (`react`, `tokens`, `storybook`); the diff is one workflow step, one eslint rule toggle, one README section, and one rule test.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+- [x] **Section VIII — Tooling baseline and CI job graph.** The constitution specifies the CI graph as `install → lint → typecheck → unit → build → storybook build → storybook test-runner → chromatic publish → MCP smoke test`. The current `verify` job skips lint, so CI is out of conformance today. This plan adds the lint step in exactly that position (after install, before typecheck), restoring compliance. ESLint flat config + Prettier are both retained as the constitution requires; antfu stays the JS/TS formatter, Prettier keeps the CSS/HTML/Markdown formats it already owns. No toolchain substitution.
+- [x] **Section IV — the lint rule that forbids hardcoded color.** `no-hardcoded-colors` is retained, now actually executes in CI, and gains a unit test proving it fires. This strengthens, never weakens, the rule the constitution mandates.
+- [x] **Section X — Compliance review.** This Constitution Check is the required gate. On changesets: the change is non-shipping (root `eslint.config.ts`, the workflow, the README, plus one test under `packages/react`). No package version bumps, and the only `packages/react` touch is a test, which the changeset gate exempts (per commit 4307f95). No changeset expected; if the gate flags it, the change still carries no version impact.
+- [x] **Section XI — agent and human legibility (REQUIRED gate).** No concessions.
+  - XI.1 Prose: the README CI section is read by both humans and agents, so it goes through the `humanizer` skill before merge.
+  - XI.4 Failure modes: lint output is already structured — each failure carries a rule ID, file, and line an agent can pattern-match. The gate surfaces machine-parseable codes, not just prose.
+  - XI.5 Story/contract coverage: unaffected; no component or story changes.
+
+No violations. Complexity Tracking is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/025-re-home-lint/
+├── plan.md              # This file
+├── spec.md              # Feature spec (with Clarifications)
+├── research.md          # Phase 0 output — decisions and rejected alternatives
+├── data-model.md        # Phase 1 output — configuration artifacts (no domain data)
+├── contracts/
+│   └── lint-gate.md     # Phase 1 output — the CI lint-gate contract
+├── quickstart.md        # Phase 1 output — run/verify the gate locally
+└── checklists/
+    └── requirements.md   # Spec quality checklist (from /speckit-specify)
+```
+
+### Source Code (repository root)
+
+```text
+eslint.config.ts                                  # disable style/quote-props (clears the 63 errors); no other change
+.github/workflows/ci.yml                          # add the Lint step to the verify job, after Install, before Typecheck
+README.md                                         # correct the CI section to match the real gate (humanized)
+packages/react/eslint/
+├── no-hardcoded-colors.js                        # unchanged (the rule)
+└── no-hardcoded-colors.test.ts                   # NEW — RuleTester unit test proving the rule fires
+turbo.json                                        # unchanged (the lint task already exists)
+packages/{react,tokens}/package.json              # unchanged (lint scripts already present)
+apps/storybook/package.json                       # unchanged (lint script already present)
+```
+
+**Structure Decision**: This is not an `src/` feature. The work is concentrated in four files: the root flat config (`eslint.config.ts`), the CI workflow (`.github/workflows/ci.yml`), the `README.md` CI section, and one new rule test co-located with the rule it covers (`packages/react/eslint/`). The existing `turbo lint` plumbing and per-package lint scripts are reused unchanged.
+
+## Complexity Tracking
+
+No constitution violations. No entries.

--- a/specs/025-re-home-lint/quickstart.md
+++ b/specs/025-re-home-lint/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart: Re-home DS lint
+
+How to make the change, verify it locally, and confirm the gate does what it claims.
+
+## Run lint the way CI will
+
+```bash
+pnpm lint
+```
+
+This runs `turbo lint` across `react`, `tokens`, and `storybook`. Before the fix it fails with 63 `style/quote-props` errors in `@unbranded-ds/tokens` and prints 8 `react/*` warnings (non-blocking). After the fix it should pass.
+
+## The change, in four edits
+
+1. **`eslint.config.ts`** — in the antfu `rules` block, add:
+   ```ts
+   'style/quote-props': 'off',
+   ```
+   That clears all 63 errors (they are all this one rule). Leave the rest of antfu's stylistic config alone — it is the JS/TS formatter.
+
+2. **`.github/workflows/ci.yml`** — in the `verify` job, add a step between "Install dependencies" and "Typecheck":
+   ```yaml
+   - name: Lint
+     run: pnpm lint
+   ```
+   The job is already named "Lint, typecheck, test, build," so no rename is needed.
+
+3. **`packages/react/eslint/no-hardcoded-colors.test.ts`** (new) — a `RuleTester` test: a token-backed color is valid, a literal hex/rgb/hsl in component source reports the rule's error. Run it with the package's Vitest.
+
+4. **`README.md`** — rewrite the CI section so it says `verify` lints, and so it stops claiming "two jobs" / folding the Storybook test-runner into `verify`. Run it through the `humanizer` skill before committing.
+
+## Verify the gate is real
+
+```bash
+# 1. Lint is green on the cleaned tree
+pnpm lint
+
+# 2. no-hardcoded-colors actually fires (durable proof)
+pnpm --filter @unbranded-ds/react test   # the RuleTester test passes
+
+# 3. Manual sanity: a literal color is caught
+#    Add `style={{ color: '#ff0000' }}` to any component in
+#    packages/react/src/components/**, then:
+pnpm lint                                  # fails with custom-rules/no-hardcoded-colors
+#    Revert the edit; lint goes green again.
+
+# 4. Errors-only: the 8 react warnings print but do NOT fail
+pnpm lint   # exit 0 despite the warnings
+```
+
+## Confirm CI honesty (US3)
+
+Read `.github/workflows/ci.yml` job names against their steps, and the README CI section against the workflow. No job or sentence should claim a lint check that is not run.

--- a/specs/025-re-home-lint/research.md
+++ b/specs/025-re-home-lint/research.md
@@ -1,0 +1,59 @@
+# Phase 0 Research: Re-home DS lint
+
+All clarify-cycle questions were answered before planning. Phase 0's job here was to confirm the mechanism each decision implies against the real config, and one decision needed refinement once the config was inspected.
+
+## D1 — How to clear the 63 `quote-props` errors
+
+**Decision**: Disable the single `style/quote-props` rule in `eslint.config.ts`. Do not disable antfu's whole stylistic set.
+
+**Rationale**: The clarify answer was "keep antfu, drop its style rules, because Prettier owns formatting." Inspecting the config showed that premise is only half true. antfu's stylistic set (configured with `indent: 'tab'`, `semi: true`, `quotes: 'single'`) is the active JS/TS formatter in this repo, not Prettier. There is no dedicated Prettier config (no `.prettierrc`, no `prettier` key), Prettier is not run in CI, and antfu's `formatters` option already delegates only CSS/HTML/Markdown to Prettier. So disabling the entire stylistic set would pull the JS/TS formatter out from under the codebase and leave a vacuum that Prettier's defaults (two-space, double-quote) would later fill as a tree-wide reformat — the opposite of the "no churn" intent.
+
+All 63 errors are the one rule `style/quote-props` (antfu default `consistent-as-needed`). Turning off that rule clears every one of them, churns no source, and leaves antfu's formatting otherwise intact. This honors the intent of the clarify answer (neutralize the redundant style noise) while staying surgical.
+
+**Alternatives considered**:
+- `stylistic: false` (the literal reading of the clarify answer). Rejected: removes the JS/TS formatter, invites a Prettier-default reformat of the whole tree, and conflicts with the tab/single-quote style the code already uses.
+- `eslint --fix` to make quote usage consistent (the clarify Q's option B). Rejected: the user chose disable over auto-fix; this would also edit `@unbranded-ds/tokens` source (~63 lines in `schema.ts` / `schema.test.ts`) for a cosmetic rule.
+
+**Surfaced to the user**: yes — this narrows the clarify decision from "all stylistic" to "the one noisy rule," for the reason above. Open to reverting to a wholesale `stylistic: false` if the intent really was to adopt Prettier as the JS/TS formatter, but that is a larger, separate change.
+
+## D2 — Errors-only gate
+
+**Decision**: Rely on ESLint's default exit behavior (non-zero on errors, zero on warnings). No `--max-warnings` flag.
+
+**Rationale**: FR-012 wants the gate to fail on errors only and leave the 8 existing `@unbranded-ds/react` warnings non-blocking. That is exactly ESLint's default, so the correct config is no extra flag. Adding `--max-warnings 0` would do the opposite — block on the 8 warnings — which the clarify cycle explicitly ruled out.
+
+**Alternatives considered**: `--max-warnings 0` with the 8 warnings fixed or baselined. Rejected per the clarify decision; the warnings move to a follow-up.
+
+## D3 — Where lint runs in CI
+
+**Decision**: A blocking step inside the existing `verify` job, placed after "Install dependencies" and before "Typecheck", running `pnpm lint`.
+
+**Rationale**: Lint is a single `turbo lint` command, so it reuses `verify`'s install with no second environment setup. The position matches the constitution's Section VIII job graph (`install → lint → typecheck → ...`). The job is already named "Lint, typecheck, test, build," so adding the step makes the name honest with no rename needed.
+
+**Alternatives considered**: a separate parallel `lint` job (rejected — re-installs deps, extra minutes, and Section VIII describes one job graph); a pre-commit `lint-staged` hook (rejected for this spec — the clarify cycle deferred it).
+
+## D4 — Coverage
+
+**Decision**: Run `pnpm lint` (`turbo lint`) unfiltered, covering `@unbranded-ds/react`, `@unbranded-ds/tokens`, and `@unbranded-ds/storybook`.
+
+**Rationale**: `turbo.json` defines a `lint` task and all three packages ship a `lint` script (`eslint src/` for react/tokens, `eslint .` for storybook). The example app lints itself in its own job and is untouched. No filtering is needed; the broadest coverage is also the simplest command.
+
+## D5 — Proving `no-hardcoded-colors` fires
+
+**Decision**: Add a Vitest test using ESLint's `RuleTester` against `no-hardcoded-colors`, co-located at `packages/react/eslint/no-hardcoded-colors.test.ts`.
+
+**Rationale**: US2/FR-003/SC-001 require proof the rule actually catches a literal color in component source. A RuleTester test is the durable, repeatable form of that proof: valid cases (token-backed color) pass, invalid cases (literal hex/rgb/hsl) report the expected error. It also fits the project's rule that custom logic gets tested. The rule has no test today.
+
+**Alternatives considered**: a manual add-color/run/revert check (rejected — not durable, not part of CI); a Storybook story (rejected — the rule is lint-time, not a render behavior).
+
+## D6 — README accuracy
+
+**Decision**: Rewrite the CI section so it matches the real workflow: `verify` does lint now, and the section stops mislabeling the job set (it currently says "two jobs" and folds the Storybook test-runner into `verify`, when there are more jobs and the test-runner is its own `storybook-test` job).
+
+**Rationale**: FR-005 requires the README to describe lint accurately, and US3's principle is that the repo stops advertising a gate it doesn't run. Correcting the lint claim while leaving the adjacent inaccuracies in the same paragraph would be a half-fix. The rewrite goes through the `humanizer` skill before merge (Section XI.1).
+
+## D7 — Prettier's role
+
+**Decision**: Leave Prettier as it is — a local `pnpm format` script with no dedicated config, plus antfu's `formatters` delegation for CSS/HTML/Markdown. Do not wire Prettier into CI in this spec.
+
+**Rationale**: Prettier is not the JS/TS formatter here (antfu stylistic is), it is not in the CI gate, and a sample of the files carrying `quote-props` errors already passes `prettier --check`. Pulling Prettier into the gate or making it the JS/TS formatter is a separate decision with tree-wide reach, out of scope for re-homing lint. Recorded so the next person knows the dual setup is intentional-for-now, not an oversight.

--- a/specs/025-re-home-lint/spec.md
+++ b/specs/025-re-home-lint/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: Re-home DS lint so it actually runs
+
+**Feature Branch**: `025-re-home-lint`
+**Created**: 2026-06-18
+**Status**: Draft
+**Input**: Workshop brief `docs/workshops/2026-06-18/spec-025-re-home-lint.md`. Surfaced triaging issue #98: lint was pulled from CI in Phase 7 for a crash that is now fixed, but lint never came back for the design system's own packages, while the CI job name and the README still claim it runs.
+
+## Clarifications
+
+### Session 2026-06-19
+
+- Q: Which ESLint stack should gate the DS packages, given Prettier already owns formatting and antfu's stylistic rules produce 63 redundant `quote-props` errors? → A: Keep antfu but disable its stylistic rule set; retain antfu's TypeScript-correctness, React, and jsx-a11y rules plus the in-house `no-hardcoded-colors`. (Plan Phase 0 refined the mechanism: antfu, not Prettier, is the JS/TS formatter here, so only the redundant `style/quote-props` rule is disabled rather than the whole stylistic set; Prettier keeps CSS, HTML, and Markdown. See FR-011.)
+- Q: Which packages should the CI lint step cover? → A: Every DS package with a `lint` script — `@unbranded-ds/react`, `@unbranded-ds/tokens`, and the `@unbranded-ds/storybook` app — through `pnpm lint` / `turbo lint`. The example app lints itself separately.
+- Q: Where should lint run in CI? → A: A blocking step inside the existing `verify` job, reusing its install. Not a separate job, and no pre-commit lint-staged hook in this spec.
+- Q: How do we reach a green tree and turn blocking on? → A: Fix to green and block from day one, with no advisory-first phase. The 63 `quote-props` errors clear by disabling antfu's style rules rather than hand-editing each one.
+- Q: Should the gate treat lint warnings as failures? → A: Errors-only gate. The 8 existing `@unbranded-ds/react` warnings stay non-blocking and are tracked for a separate follow-up.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - DS package changes are actually linted in CI (Priority: P1)
+
+A contributor or agent opens a pull request that touches a DS package (`@unbranded-ds/react`, `@unbranded-ds/tokens`, or the `@unbranded-ds/storybook` app). Lint runs against that package source as part of the gate, and an error is reported on the pull request before it can merge.
+
+**Why this priority**: This is the whole point. Today the DS packages are linted nowhere: not in CI, not on commit. The gate the repo advertises does not exist for the packages it most needs to cover. Everything else in this spec is in service of this.
+
+**Independent Test**: Introduce a deliberate lint error (for example, an unused import) in `packages/react` source, push it on a branch, and confirm the CI lint check reports the error and fails. Revert and confirm the check goes green.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pull request that modifies `@unbranded-ds/react` source containing a lint error, **When** CI runs, **Then** the lint step fails and names the error.
+2. **Given** a pull request that modifies `@unbranded-ds/tokens` source with no errors, **When** CI runs, **Then** the lint step passes.
+3. **Given** the current `main` tree, **When** lint runs across all linted DS packages, **Then** it completes without the Phase 7 configuration crash (no missing rule file, no missing peer plugin).
+
+---
+
+### User Story 2 - The token-discipline rule is proven to fire (Priority: P1)
+
+`no-hardcoded-colors` is the one DS-specific lint rule the project actually cares about: it enforces the constitution's rule that color comes from tokens, never literal hex/rgb in component source. It is wired into the config (scoped to `packages/react/src/components/**/*.tsx` as an error) but has never run end to end against real component source, so nobody can say whether it matches the right files or fires at all.
+
+**Why this priority**: A rule that is configured but never exercised is indistinguishable from no rule. Confirming it fires against component source is what makes the token guard real rather than nominal, and it is cheap to verify once User Story 1 lands.
+
+**Independent Test**: Add a hardcoded color (e.g. `color: '#ff0000'`) to a real component in `packages/react`, run lint, and confirm `no-hardcoded-colors` reports it as an error. Remove it and confirm the error clears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a component file in `@unbranded-ds/react` containing a literal color value, **When** lint runs, **Then** `no-hardcoded-colors` reports it as an error.
+2. **Given** the same component using a token-backed color instead, **When** lint runs, **Then** `no-hardcoded-colors` reports nothing for that line.
+
+---
+
+### User Story 3 - The repo stops advertising a gate it doesn't have (Priority: P2)
+
+A maintainer or prospective contributor reads the CI job names and the README's CI section to understand what the gate enforces. What they read matches what CI actually does.
+
+**Why this priority**: The gap is currently hidden twice over. The `verify` job is named "Lint, typecheck, test, build" but runs no lint, and the README's CI section says verify lints. A silent absence is worse than an honest gap, because a reader checking either source concludes the gate exists. This story corrects the advertising to match what ships; it depends on the outcome of User Story 1 but is independently verifiable.
+
+**Independent Test**: Read every CI job name and the README CI section against the actual workflow steps; confirm no job or doc claims a lint check that isn't run, and that lint coverage is described accurately.
+
+**Acceptance Scenarios**:
+
+1. **Given** the CI workflow after this change, **When** a reader compares each job's name to its steps, **Then** no job advertises "lint" unless it runs lint.
+2. **Given** the README's CI section after this change, **When** a reader compares it to the workflow, **Then** its description of lint coverage and whether lint blocks merge matches reality.
+
+---
+
+### Edge Cases
+
+- **Pre-existing violations in the current tree.** Lint today shows 63 errors in `@unbranded-ds/tokens` (61 `style/quote-props`, plus 2 `regexp/no-super-linear-backtracking` in test files) and 8 warnings in `@unbranded-ds/react`. The blocking gate cannot land green until the errors are gone: the 61 clear by disabling the `style/quote-props` rule (FR-011), and the 2 are narrowly suppressed with a rationale (test-time parsing of trusted repo files, not user input). The 8 warnings stay non-blocking (FR-012).
+- **Generated and built output.** Generated files (for example `defaults.generated.ts`) and build output (`dist/`) must be excluded from lint so generated code can't trip rules the authored source would never hit.
+- **A package with no lintable source.** Lint over such a package must no-op cleanly rather than error on an empty match.
+- **The config fails to resolve.** If lint ever cannot run to completion, that is a blocker to surface, not a check to silently skip. The whole point is to remove a silent absence, not relocate one.
+- **Docs-only changes.** A docs-only pull request need not run lint, consistent with the workflow's existing docs-only skip for the heavy jobs.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Lint MUST run in CI against every DS package that has a `lint` script — today `@unbranded-ds/react`, `@unbranded-ds/tokens`, and the `@unbranded-ds/storybook` app — through `pnpm lint` / `turbo lint`, on pull requests and pushes to `main`, subject to the existing docs-only skip.
+- **FR-002**: A lint error in DS package source MUST fail the CI run and block merge, starting with the commit that lands this gate. There is no advisory-first phase.
+- **FR-003**: The `no-hardcoded-colors` rule MUST be exercised against real component source such that a literal color value in a component is reported as an error.
+- **FR-004**: No CI job MAY advertise "lint" in its name unless it runs lint; job names MUST describe the checks they actually perform.
+- **FR-005**: The README's CI section MUST describe lint accurately: which packages are covered and that lint blocks merge.
+- **FR-006**: The existing example-app lint (`@unbranded-ds/example-nextjs`) MUST continue to run and MUST NOT be duplicated or regressed by this change.
+- **FR-007**: The lint configuration MUST resolve and run to completion without the Phase 7 failure modes (the missing `no-hardcoded-colors` rule file, the absent antfu peer plugins). This holds today: `turbo lint` runs, and the only failures are rule violations, not configuration errors.
+- **FR-008**: Any lint errors in the current DS package tree MUST be resolved so the blocking gate lands green. The pre-existing errors are 61 `style/quote-props` errors plus 2 `regexp/no-super-linear-backtracking` errors in `@unbranded-ds/tokens` test files. The 61 MUST be resolved by disabling the `style/quote-props` rule (see FR-011), not by hand-editing; the 2 are narrowly suppressed with a stated rationale (the regexes parse the repo's own source and generated CSS at test time, never user input, so the backtracking the rule guards against is not a DoS vector here).
+- **FR-009**: Lint MUST be runnable locally through a single documented command (`pnpm lint`) that produces the same result CI enforces, so a contributor can reproduce a CI lint failure before pushing.
+- **FR-010**: This change MUST be tooling and CI only: it MUST NOT alter any component behavior, token value, or built artifact, beyond the lint-config and CI changes themselves.
+- **FR-011**: The ESLint config MUST keep the antfu base, which remains the JS/TS formatter (tabs, single quotes, semi). It MUST disable only `style/quote-props` — the single stylistic rule producing 61 of the 63 pre-existing errors — rather than the whole stylistic set, because disabling the set wholesale would leave JS/TS formatting unenforced and invite a Prettier-default reformat of the tree. Prettier keeps the formats antfu already delegates to it (CSS, HTML, Markdown); it is not the JS/TS formatter and is not wired into this gate. The retained ESLint rules are antfu's TypeScript-correctness, React, stylistic (minus `quote-props`), and jsx-a11y rules plus the in-house `no-hardcoded-colors`.
+- **FR-012**: The CI gate MUST fail on lint errors only; warnings MUST NOT fail the build. The 8 existing `@unbranded-ds/react` warnings are accepted as non-blocking and tracked for a separate follow-up, not fixed here.
+- **FR-013**: Lint MUST run as a blocking step inside the existing `verify` CI job, reusing that job's dependency install, rather than as a separate job. This spec adds no `pre-commit` hook.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A hardcoded color introduced into any DS component is caught before merge 100% of the time (it cannot reach `main` undetected).
+- **SC-002**: A change to any linted DS package carrying a lint error cannot merge while the error is present.
+- **SC-003**: Every CI job's name matches the checks it runs; zero jobs claim a check they do not perform.
+- **SC-004**: The README's CI description and the actual CI gate agree when read side by side; a reader cannot be misled about whether lint runs or blocks.
+- **SC-005**: A contributor can reproduce the exact CI lint result locally with one command, with no separate setup beyond installing dependencies.
+- **SC-006**: Lint over the full set of linted DS packages passes on `main` at the moment the gate becomes blocking (the gate lands green).
+- **SC-007**: The gate fails on errors only. A new lint error blocks merge; the project's already-accepted warnings do not, and they remain visible in lint output.
+
+## Assumptions
+
+The brief left three decisions open; `/speckit-clarify` (session 2026-06-19) settled them, and they are reflected in the requirements above. Recorded here for context:
+
+- **ESLint stack: keep antfu, disable the one redundant style rule.** antfu remains the JS/TS formatter; only `style/quote-props` is disabled (FR-011) — the rule producing 61 of the 63 errors — which clears them without hand-editing and without pulling the formatter out from under the tree. The remaining 2 (`regexp/no-super-linear-backtracking` in tokens test files) are narrowly suppressed with a rationale. Prettier keeps the CSS, HTML, and Markdown formats antfu delegates to it. The retained rules are antfu's TypeScript-correctness, React, stylistic (minus `quote-props`), and jsx-a11y checks plus the in-house `no-hardcoded-colors`.
+- **Placement: a blocking step in `verify`.** Lint is one `pnpm lint` command, so it runs as a step inside the existing `verify` job and reuses its install (FR-013). No separate job, and no `pre-commit` `lint-staged` hook in this spec (a possible later add).
+- **Timing: blocks from day one.** Pre-existing errors are resolved within this spec so the gate lands green and blocking immediately, with no advisory-first phase (FR-002, FR-008).
+- **Warnings: errors-only gate.** The 8 `@unbranded-ds/react` warnings stay non-blocking and are tracked for a follow-up rather than fixed here (FR-012).
+- **The Phase 7 crash is resolved (confirmed).** `turbo lint` resolves and runs today; the only failures are rule violations, not config errors. No dependency installation work is expected (FR-007).
+- **Scope is the DS's own packages.** The example app lints itself and is out of scope except for the no-regression guarantee (FR-006). Per the project's constitution-scope rule, the example app's own toolchain is not governed here.

--- a/specs/025-re-home-lint/tasks.md
+++ b/specs/025-re-home-lint/tasks.md
@@ -1,0 +1,157 @@
+---
+description: "Task list for Re-home DS lint so it actually runs"
+---
+
+# Tasks: Re-home DS lint so it actually runs
+
+**Input**: Design documents from `/specs/025-re-home-lint/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/lint-gate.md, quickstart.md
+
+**Tests**: One test task is included (the RuleTester proof for `no-hardcoded-colors`), because User Story 2 and FR-003 explicitly require proving the rule fires. No other test tasks are generated.
+
+**Organization**: Tasks are grouped by user story. The three stories touch disjoint files (`eslint.config.ts` + `ci.yml` for US1, a new test under `packages/react/eslint/` for US2, `README.md` for US3), so US1 and US2 can run in parallel; US3's prose describes the gate US1 lands, so its content depends on US1.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Exact file paths are in each description
+
+## Path Conventions
+
+This is a pnpm + Turborepo monorepo. Relevant paths: repo-root `eslint.config.ts`, `.github/workflows/ci.yml`, `README.md`, and `packages/react/eslint/`. There is no `src/` work.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Establish what "green" means before changing anything.
+
+- [X] T001 Capture the current lint baseline: run `pnpm lint` from the repo root and record the result (expect 63 `style/quote-props` errors in `@unbranded-ds/tokens` and 8 non-blocking `react/*` warnings in `@unbranded-ds/react`). This confirms the antfu config resolves (no Phase 7 crash) and defines the target state.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Cross-story prerequisites.
+
+There are none. The three user stories touch disjoint files and are each independently testable, so no shared foundational work blocks them. Proceed directly to the stories.
+
+---
+
+## Phase 3: User Story 1 - DS package changes are actually linted in CI (Priority: P1) 🎯 MVP
+
+**Goal**: `pnpm lint` runs in CI against `react`, `tokens`, and `storybook`, and a lint error blocks merge. The tree is green so the gate is sane.
+
+**Independent Test**: Introduce a lint error (e.g. an unused import) in `packages/react/src`, push on a branch, confirm the `verify` job's lint step fails and names it; revert and confirm it passes.
+
+- [X] T002 [US1] In `eslint.config.ts`, add `'style/quote-props': 'off'` to the antfu `rules` block (alongside the existing `style/multiline-ternary` / `style/arrow-parens` entries). This clears all 63 errors as redundant style noise without churning source; leave the rest of antfu's stylistic config (the JS/TS formatter) untouched. Then run `pnpm lint` and confirm 0 errors remain (the 8 `react/*` warnings stay).
+- [X] T003 [US1] In `.github/workflows/ci.yml`, add a step named `Lint` running `pnpm lint` to the `verify` job, positioned after "Install dependencies" and before "Typecheck" (the constitution's `install → lint → typecheck` order). Do not add `--max-warnings`; errors-only is ESLint's default. The job is already named "Lint, typecheck, test, build", so no rename is needed.
+- [X] T004 [US1] Verify gate behavior locally per `quickstart.md`: on the clean tree `pnpm lint` exits 0; with a literal `style={{ color: '#ff0000' }}` added to a component in `packages/react/src/components/**` it exits non-zero with `custom-rules/no-hardcoded-colors`; reverting returns it to 0. Confirm the 8 `react/*` warnings print but do not fail.
+
+**Checkpoint**: Lint now runs and blocks in CI against all three DS packages, on a green tree. This is the MVP.
+
+---
+
+## Phase 4: User Story 2 - The token-discipline rule is proven to fire (Priority: P1)
+
+**Goal**: A durable, repeatable proof that `no-hardcoded-colors` catches literal colors in component source.
+
+**Independent Test**: Run `pnpm --filter @unbranded-ds/react test`; the RuleTester test passes, asserting the rule errors on literal colors and accepts token-backed ones.
+
+- [X] T005 [P] [US2] Create `packages/react/eslint/no-hardcoded-colors.test.ts`: a Vitest test using ESLint's `RuleTester` against the rule imported from `./no-hardcoded-colors.js`. Valid cases: a token-backed / CSS-variable color (e.g. `var(--color-primary)`). Invalid cases: literal `#ff0000`, `rgb(...)`, and `hsl(...)` in JSX/style, each expecting the rule's error. Use a parser config matching the rule's component-source target (TSX).
+- [X] T006 [US2] Ensure the new test is discovered and run by `@unbranded-ds/react`'s Vitest setup. If its test glob only covers `src/`, either extend the glob to include `eslint/**/*.test.ts` or relocate the test so it is picked up. Run `pnpm --filter @unbranded-ds/react test` and confirm the RuleTester test passes (depends on T005).
+
+**Checkpoint**: The constitution's token-discipline rule is no longer "configured but unproven" — it has a test that fails if the rule ever stops firing.
+
+---
+
+## Phase 5: User Story 3 - The repo stops advertising a gate it doesn't have (Priority: P2)
+
+**Goal**: CI job names and the README's CI section match what CI actually runs.
+
+**Independent Test**: Read each CI job name against its steps and the README CI section against the workflow; nothing claims a lint check it doesn't run.
+
+**Dependency note**: US3's content describes the gate US1 lands, so do it after US1 (T002–T003); otherwise the README would have to describe a gate that isn't wired yet.
+
+- [X] T007 [P] [US3] Rewrite the `## CI` section of `README.md` to match the real workflow: `verify` now lints (react/tokens/storybook) and that lint blocks merge; correct the stale "two jobs" claim and stop folding the Storybook test-runner into `verify` (it is the separate `storybook-test` job). Keep it accurate to the jobs that actually exist (`changes`, `verify`, `publish`, `example-e2e`, `storybook-test`).
+- [X] T008 [US3] Run the rewritten `README.md` CI section through the `humanizer` skill (formal invoke: draft → audit → revise) per the user's prose policy and constitution XI.1, and apply the revisions in place (depends on T007).
+- [X] T009 [US3] Audit every job `name:` in `.github/workflows/ci.yml` against its steps; confirm none advertises a check it doesn't run. After T003, "Lint, typecheck, test, build" on `verify` is accurate. Record (and fix) any remaining mismatch.
+
+**Checkpoint**: The gap is closed in both places a reader would check — the job names and the README.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Confirm the change is non-shipping and didn't break the rest of `verify`.
+
+- [X] T010 [P] Confirm the changeset gate (`changeset-check.yml`) passes for this branch. The change is non-shipping: root config, CI, README, and one test under `packages/react` (test-only `packages/react` changes are exempt; no package version bumps). No changeset is expected — only add one if the gate demands it.
+- [X] T011 Run the full `quickstart.md` validation end to end (lint green; RuleTester passes; manual hardcoded-color check red-then-green; errors-only confirmed). Also confirm the `example-e2e` job's own lint step in `.github/workflows/ci.yml` is unchanged and still runs (FR-006).
+- [X] T012 [P] Run `pnpm typecheck` and `pnpm test:unit` locally to confirm the `eslint.config.ts` and new-test changes didn't disturb the other `verify` steps.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: Empty; nothing to block on.
+- **User Stories (Phase 3–5)**: US1 and US2 are independent and can run in parallel. US3 depends on US1 for accurate content.
+- **Polish (Phase 6)**: After the stories you intend to ship.
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependencies. The MVP.
+- **US2 (P1)**: No dependencies on US1 — touches only the new test file. Can run alongside US1.
+- **US3 (P2)**: Content-dependent on US1 (it documents the landed gate). Start after T002–T003.
+
+### Within Each Story
+
+- US1: T002 (green) → T003 (add gate) → T004 (verify).
+- US2: T005 (write test) → T006 (ensure it runs).
+- US3: T007 (rewrite) → T008 (humanize); T009 (audit) after US1's T003.
+
+### Parallel Opportunities
+
+- US1 and US2 touch disjoint files, so they can proceed in parallel.
+- T005 [US2], T007 [US3], T010 and T012 [Polish] are each marked [P] (distinct files, no incomplete-task dependencies within their lane).
+
+---
+
+## Parallel Example: US1 + US2 together
+
+```bash
+# After Setup, one developer takes US1, another takes US2 — different files, no conflict:
+Dev A (US1): edit eslint.config.ts, then .github/workflows/ci.yml
+Dev B (US2): create packages/react/eslint/no-hardcoded-colors.test.ts
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1: capture the baseline.
+2. Phase 3 (US1): disable `quote-props`, add the `Lint` step, verify the gate.
+3. **STOP and VALIDATE**: lint runs and blocks in CI on a green tree. Ship this alone if needed — it closes the actual gap.
+
+### Incremental Delivery
+
+1. US1 → the gate is real (MVP).
+2. US2 → the token rule is proven, not just present.
+3. US3 → the docs and job names stop overstating.
+4. Polish → confirm non-shipping and green `verify`.
+
+Commit per task or logical group (matching the small-commit convention): the config change, the CI step, the rule test, and the README rewrite are natural separate commits.
+
+---
+
+## Notes
+
+- [P] = different files, no dependencies on incomplete tasks.
+- The README rewrite (T007) must pass through the `humanizer` skill (T008) before merge — it is human-facing prose.
+- The `style/quote-props` disable (T002) is the refinement Phase 0 surfaced: it clears the 63 errors without the tree-wide reformat that disabling all of antfu's stylistic set would invite. Confirm that call still holds before starting.
+- No component, token value, or built artifact changes (FR-010). If anything under `packages/react/src` or `packages/tokens/src` would change, stop — that is out of scope.


### PR DESCRIPTION
## Why

Lint was advertised but absent. Phase 7 pulled `pnpm lint` out of CI when the antfu config crashed, and it never went back. The crash is fixed now (#97 restored the `no-hardcoded-colors` rule file, and antfu's peer plugins are devDeps again), but lint still ran nowhere for the DS's own packages. The gap was hidden twice over: the `verify` job is literally named "Lint, typecheck, test, build," and the README's CI section said verify lints. Check either and you'd conclude the gate exists. It didn't, and a silent absence reads as covered, which is worse than an honest gap.

So `@unbranded-ds/react` and `@unbranded-ds/tokens` were linted nowhere, and `no-hardcoded-colors`, the rule the constitution requires, had never run end to end against real component source.

## What Changed

- Wired a `pnpm lint` step into the `verify` job, in the constitution's install → lint → typecheck order, so the gate the job name and README already advertise actually exists. errors-only is ESLint's default, so the eight React-19 idiom warnings stay advisory.
- Greened the tree by clearing two pre-existing error classes:
  - antfu's `style/quote-props` flagged 61 cosmetic errors for inconsistently quoted properties on the token maps, none with correctness value, so it's off. antfu still owns the rest of formatting, and Prettier keeps CSS/HTML/Markdown.
  - The two `regexp/no-super-linear-backtracking` errors in tokens tests are suppressed with a rationale: those regexes parse the repo's own source and generated CSS at test time, never user input, so the backtracking the rule guards against isn't a DoS vector here.
- Added a RuleTester suite next to `no-hardcoded-colors` so a regression that stops it firing can't slip by: token-backed values pass; literal hex/rgb/hsl/named colors and template literals error. Extended the react unit project's glob to pick it up.
- Rewrote the README's CI section to match the real job graph. It claimed two jobs and folded the Storybook test-runner into verify; there are five jobs, the test-runner is its own, and lint now lives in verify.
- Landed the spec-025 artifacts: the workshop brief (surfaced triaging #98), the spec, plan, tasks, and the research, data-model, contract, and quickstart docs.

## Scope

CI and tooling plumbing only. No component or token changes, no version bump.

## Test Plan

- The `verify` job runs `pnpm lint` green across the DS package tree.
- `pnpm --filter @unbranded-ds/react test:unit` exercises the new RuleTester suite.
